### PR TITLE
Refactor: use @abstractmethod in Diffractometer

### DIFF
--- a/bcdi/experiment/experiment_utils.py
+++ b/bcdi/experiment/experiment_utils.py
@@ -1018,7 +1018,6 @@ class Diffractometer(ABC):
         :param kwargs: beamline_specific parameters
         :return: a list of motor positions
         """
-        pass
 
     @abstractmethod
     def motor_positions(self, **kwargs):
@@ -1030,7 +1029,6 @@ class Diffractometer(ABC):
         :param kwargs: beamline_specific parameters
         :return: the diffractometer motors positions for the particular setup.
         """
-        pass
 
     def remove_circle(self, stage_name, index):
         """

--- a/bcdi/experiment/experiment_utils.py
+++ b/bcdi/experiment/experiment_utils.py
@@ -8,6 +8,7 @@
 #         Jerome Carnis, carnis_jerome@yahoo.fr
 """Classes related to the experimental setup."""
 
+from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from functools import reduce
 import gc
@@ -652,7 +653,7 @@ class Detector:
         return data, mask
 
 
-class Diffractometer:
+class Diffractometer(ABC):
     """
     Base class for defining diffractometers.
 
@@ -1007,6 +1008,7 @@ class Diffractometer:
                 )
         return index_circle
 
+    @abstractmethod
     def goniometer_values(self, **kwargs):
         """
         Define goniometer values.
@@ -1016,11 +1018,9 @@ class Diffractometer:
         :param kwargs: beamline_specific parameters
         :return: a list of motor positions
         """
-        raise NotImplementedError(
-            "This method is beamline specific and must be implemented"
-            " in the child class"
-        )
+        pass
 
+    @abstractmethod
     def motor_positions(self, **kwargs):
         """
         Define motor positions.
@@ -1030,10 +1030,7 @@ class Diffractometer:
         :param kwargs: beamline_specific parameters
         :return: the diffractometer motors positions for the particular setup.
         """
-        raise NotImplementedError(
-            "This method is beamline specific and must be implemented"
-            " in the child class"
-        )
+        pass
 
     def remove_circle(self, stage_name, index):
         """

--- a/tests/experiment/test_diffractometer.py
+++ b/tests/experiment/test_diffractometer.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+# BCDI: tools for pre(post)-processing Bragg coherent X-ray diffraction imaging data
+#   (c) 07/2017-06/2019 : CNRS UMR 7344 IM2NP
+#   (c) 07/2019-05/2021 : DESY PHOTON SCIENCE
+#   (c) 06/2021-present : DESY CFEL
+#       authors:
+#         Jerome Carnis, carnis_jerome@yahoo.fr
+
+import unittest
+import bcdi.experiment.experiment_utils as exp
+
+
+def run_tests(test_class):
+    suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
+    runner = unittest.TextTestRunner(verbosity=2)
+    return runner.run(suite)
+
+
+class Test(unittest.TestCase):
+    """
+    Tests
+    """
+
+    def test_create_diffractometer_from_parent(self):
+        with self.assertRaises(TypeError):
+            exp.Diffractometer(sample_offsets=[])
+
+
+if __name__ == "main":
+    run_tests(Test)

--- a/tests/experiment/test_diffractometer.py
+++ b/tests/experiment/test_diffractometer.py
@@ -18,9 +18,7 @@ def run_tests(test_class):
 
 
 class Test(unittest.TestCase):
-    """
-    Tests
-    """
+    """Tests related to diffractometer instantiation."""
 
     def test_create_diffractometer_from_abc(self):
         with self.assertRaises(TypeError):

--- a/tests/experiment/test_diffractometer.py
+++ b/tests/experiment/test_diffractometer.py
@@ -22,7 +22,7 @@ class Test(unittest.TestCase):
     Tests
     """
 
-    def test_create_diffractometer_from_parent(self):
+    def test_create_diffractometer_from_abc(self):
         with self.assertRaises(TypeError):
             exp.Diffractometer(sample_offsets=[])
 

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -18,9 +18,7 @@ def run_tests(test_class):
 
 
 class TestInRange(unittest.TestCase):
-    """
-    Tests on the function utilities.in_range
-    """
+    """Tests on the function utilities.in_range."""
 
     def setUp(self):
         # executed before each test


### PR DESCRIPTION
Use the abc module instead of throwing exceptions if the child class does not override the method