### PR TITLE
Allow the user to not provide a mask in the prtf calculation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,6 @@
+* Refactor: allow the user to not provide a mask in the BCDI PRTF calculations (3D and
+  2D)
+
 * Refractor: split bcdi.experiment.experiment_utils module into smaller modules
 
 Version 0.1.2
@@ -5,24 +8,28 @@ Version 0.1.2
 
 * Refactor: remove circular imports from modules
 
-* Refactor: ``move crop_pad``, ``bin_data`` and ``gaussian_window functions`` from ``postprocessing_utils.py`` to another module
-  in order to avoid circular imports
+* Refactor: ``move crop_pad``, ``bin_data`` and ``gaussian_window functions`` from
+  ``postprocessing_utils.py`` to another module in order to avoid circular imports
 
-* Feature: create a Diffractometer class with one child class for each beamline, move all functions related to
-  the goniometer positions in the class
+* Feature: create a Diffractometer class with one child class for each beamline, move
+  all functions related to the goniometer positions in the class
 
-* Feature: add an option in ``strain.py`` to put back the sample in the laboratory frame with all sample circles
-  rotated back to 0 deg
+* Feature: add an option in ``strain.py`` to put back the sample in the laboratory
+  frame with all sample circles rotated back to 0 deg
 
 * Refactor: show only necessary plots and console output in ``strain.py``
 
-* Refactor: create Setup calculated properties and transfer calculations in scripts to these properties
+* Refactor: create Setup calculated properties and transfer calculations in scripts to
+  these properties
 
-* Refactor: perform the geometrical transformation and rotation of the reconstructed crystal in a single step
+* Refactor: perform the geometrical transformation and rotation of the reconstructed
+  crystal in a single step
 
-* Refactor: perform the geometrical transformation and rotation of the diffraction pattern in a single step
+* Refactor: perform the geometrical transformation and rotation of the diffraction
+  pattern in a single step
 
-* Bug: provide voxel sizes in the correct order when rotating the diffraction pattern in ``preprocess_bcdi.py``
+* Bug: provide voxel sizes in the correct order when rotating the diffraction pattern
+  in ``preprocess_bcdi.py``
 
 Version 0.1.1
 -------------
@@ -32,95 +39,129 @@ Version 0.1.1
 Version 0.1.0
 -------------
 
-* Feature: implement ``publication/bcdi_diffpattern_from_reconstruction.py``, to compare with the experimental measurement in the crystal frame
+* Feature: implement ``publication/bcdi_diffpattern_from_reconstruction.py``, to
+  compare with the experimental measurement in the crystal frame
 
 * Refactor: simplify PRTF calculations
 
 * Feature: implement the inplane rocking curve at CRISTAL
 
-* Feature: implement ``graph_utils.savefig`` to save figures for publication with and without labels
+* Feature: implement ``graph_utils.savefig`` to save figures for publication with and
+  without labels
 
-* Feature: implement ``angular_profile.py`` to calculate the width of linecuts through the center of mass of a 2D object at different angles
+* Feature: implement ``angular_profile.py`` to calculate the width of linecuts through
+  the center of mass of a 2D object at different angles
 
-* Feature: implement ``line_profile.py`` to calculate line profiles along particular directions in 2D or 3D objects
+* Feature: implement ``line_profile.py`` to calculate line profiles along particular
+  directions in 2D or 3D objects
 
 Version 0.0.10a2
 ----------------
 
-* Feature: implement ``interpolate_cdi.py``, to interpolate the intensity of masked voxels using the centrosymmetry property
+* Feature: implement ``interpolate_cdi.py``, to interpolate the intensity of masked
+  voxels using the centrosymmetry property
 
-* Feature: implement the interpolation of the reciprocal space data in the laboratory frame using the linearized transformation matrix
+* Feature: implement the interpolation of the reciprocal space data in the laboratory
+  frame using the linearized transformation matrix
 
 * Refactor: update the calculation of the transformation matrices when chi is non-zero
 
-* Feature: allow different voxel sizes in each dimension in ``strain.py`` (NOT BACK COMPATIBLE)
+* Feature: allow different voxel sizes in each dimension in ``strain.py``
+  (NOT BACK COMPATIBLE)
 
-* Feature: implement validation functions in ``utils.validation.py`` for commonly used parameters, implement related unit tests
+* Feature: implement validation functions in ``utils.validation.py`` for commonly used
+  parameters, implement related unit tests
 
-* Refactor: merge the class SetupPostprocessing and SetupPreprocessing in a single class Setup due to code redundances
+* Refactor: merge the class SetupPostprocessing and SetupPreprocessing in a single
+  class Setup due to code redundances
 
-* Feature: implement ``linecut_diffpattern.py``, a GUI to get a linecut of a 3D diffraction pattern along a desired direction
+* Feature: implement ``linecut_diffpattern.py``, a GUI to get a linecut of a 3D
+  diffraction pattern along a desired direction
 
-* Feature: add a GUI to ``prtf_bcdi.py``, to get a linecut of the 3D PRTF along a desired direction
+* Feature: add a GUI to ``prtf_bcdi.py``, to get a linecut of the 3D PRTF along a
+  desired direction
 
-* Feature: implement ``center_of_rotation.py``, to calculate the distance of the crystal to the center of rotation
+* Feature: implement ``center_of_rotation.py``, to calculate the distance of the
+  crystal to the center of rotation
 
-* Bug: in ``facet_strain.py``, solve bugs in plane fitting when the facet is parallel to an axis
+* Bug: in ``facet_strain.py``, solve bugs in plane fitting when the facet is parallel
+  to an axis
 
-* Feature: implement ``rotate_scan.py``, to rotate a 3D reciprocal space map around a vector
+* Feature: implement ``rotate_scan.py``, to rotate a 3D reciprocal space map around a
+  vector
 
-* Refactor: in ``modes_decomposition.py``, implement skipping alignment between datasets or aligning based on a support
+* Refactor: in ``modes_decomposition.py``, implement skipping alignment between datasets
+  or aligning based on a support
 
 Version 0.0.9
 -------------
 
 * Feature: implement support for MAXIV NANOMAX beamline
 
-* Feature: implement ``rocking_curves.py`` to follow the evolution of the Bragg peak between several rocking curves
+* Feature: implement ``rocking_curves.py`` to follow the evolution of the Bragg peak
+  between several rocking curves
 
-* Feature: implement ``flatten_modulus.py`` to remove low frequency artefacts in the modulus reconstructed by phase retrieval
+* Feature: implement ``flatten_modulus.py`` to remove low frequency artefacts in the
+  modulus reconstructed by phase retrieval
 
-* Feature: implement ``xcca_3D_map.py`` to calculate the angular cross-correlation CCF(q,q) over a range in q
+* Feature: implement ``xcca_3D_map.py`` to calculate the angular cross-correlation
+  CCF(q,q) over a range in q
 
-* Feature: implement ``view_ccf.py`` and ``view_ccf_map.py`` to plot the cross-correlation function output
+* Feature: implement ``view_ccf.py`` and ``view_ccf_map.py`` to plot the
+  cross-correlation function output
 
 * Feature: implement the 3D angular X-ray cross-correlation analysis
 
-* Refactor: allow the reloading of binned data and its orthogonalization in ``preprocess_cdi.py`` and ``preprocess_bcdi.py``
+* Refactor: allow the reloading of binned data and its orthogonalization in
+  ``preprocess_cdi.py`` and ``preprocess_bcdi.py``
 
 * Feature: implement ``crop_npz.py`` to crop combined stacked data to the desired size
 
-* Feature: implement ``scan_analysis.py`` to plot interactively the integrated intensity in a region of interest for a 1D scan
+* Feature: implement ``scan_analysis.py`` to plot interactively the integrated
+  intensity in a region of interest for a 1D scan
 
-* Feature: implement ``view_mesh.py`` to plot interactively the integrated intensity in a region of interest for a 2D mesh
+* Feature: implement ``view_mesh.py`` to plot interactively the integrated intensity
+  in a region of interest for a 2D mesh
 
-* Refactor: when gridding forward CDI data, reverse the rotation direction to compensate the rotation of Ewald sphere
+* Refactor: when gridding forward CDI data, reverse the rotation direction to
+  compensate the rotation of Ewald sphere
 
 * Refactor: updated ``extract_bulk_surface.py`` to use module functions
 
-* Bug: treat correctly the case angle=pi/2 during the interpolation of CDI data onto the laboratory frame
+* Bug: treat correctly the case angle=pi/2 during the interpolation of CDI data onto
+  the laboratory frame
 
-* Refactor: solve instabilities resulting from duplicate vertices after smoothing in ``facet_strain.py``
+* Refactor: solve instabilities resulting from duplicate vertices after smoothing in
+  ``facet_strain.py``
 
 * Refactor: modify ``polarplot.py`` to use module functions instead of inline script
 
-* Feature: implement ``coefficient_variation.py`` to compare several reconstructed modulus of a BCDI dataset
+* Feature: implement ``coefficient_variation.py`` to compare several reconstructed
+  modulus of a BCDI dataset
 
-* Feature: implement diffraction_angles.py`` to find Bragg reflections for a particular goniometer setup, based on xrayutilities
+* Feature: implement diffraction_angles.py`` to find Bragg reflections for a particular
+  goniometer setup, based on xrayutilities
 
-* Feature: add the option of restarting masking the aliens during preprocessing, not back compatible with previous versions
+* Feature: add the option of restarting masking the aliens during preprocessing,
+  not back compatible with previous versions
 
-* Feature: implement simultaneous masking over the 3 axes in two new preprocessing scripts ``preprocess_bcdi.py`` and ``preprocess_cdi.py``
+* Feature: implement simultaneous masking over the 3 axes in two new preprocessing
+  scripts ``preprocess_bcdi.py`` and ``preprocess_cdi.py``
 
-* Feature: implement ``domain_orientation.py`` to find the orientation of domains in a 3D forward CDI dataset of mesocrystal
+* Feature: implement ``domain_orientation.py`` to find the orientation of domains in a
+  3D forward CDI dataset of mesocrystal
 
-* Feature: implement ``simu_diffpattern_CDI.py`` to find in 3D the Bragg peaks positions of a mesocrystal (supported unit cells: FCC, simple cubic, BCC and BCT)
+* Feature: implement ``simu_diffpattern_CDI.py`` to find in 3D the Bragg peaks positions
+  of a mesocrystal (supported unit cells: FCC, simple cubic, BCC and BCT)
 
-* Feature: implement ``fit_1D curve.py`` to fit simultaneously ranges of a 1D curve with gaussian lineshapes
+* Feature: implement ``fit_1D curve.py`` to fit simultaneously ranges of a 1D curve with
+  gaussian lineshapes
 
-* Feature: implement ``fit_background.py`` to interactively determine the background in 1D reciprocal space curves
+* Feature: implement ``fit_background.py`` to interactively determine the background in
+  1D reciprocal space curves
 
-* Refactor: in ``multislices_plot()`` and ``contour_slices()``, allow to plot the data at user-defined slices positions.
+* Refactor: in ``multislices_plot()`` and ``contour_slices()``, allow to plot the data
+  at user-defined slices positions.
 
 * Feature: implement ``prtf_bcdi_2D.py`` to calculate the PRTF also for 2D cases.
 
@@ -129,19 +170,25 @@ Version 0.0.8
 
 * Feature: implement ``3Dobject_movie.py``, creating movies of a real-space 3D object.
 
-* Feature: implement ``modes_decomposition.py``, decomposition of a set of reconstructed object in orthogonal modes (adapted from PyNX)
+* Feature: implement ``modes_decomposition.py``, decomposition of a set of reconstructed
+  object in orthogonal modes (adapted from PyNX)
 
 * Bug: correct the calculation of q when data is binned
 
-* implement scripts to visualize isosurfaces of reciprocal/real space including publication options (in /publication/)
+* implement scripts to visualize isosurfaces of reciprocal/real space including
+  publication options (in /publication/)
 
-* implement ``algorithms_utils.py``, featuring psf and image deconvolution using Richardson-Lucy algorithm
+* implement ``algorithms_utils.py``, featuring psf and image deconvolution using
+  Richardson-Lucy algorithm
 
-* implement separate PRTF resolution estimation for CDI (``prtf_cdi.py``) and BCDI (``bcdi_prtf.py``) datasets
+* implement separate PRTF resolution estimation for CDI (``prtf_cdi.py``) and BCDI
+  (``bcdi_prtf.py``) datasets
 
-* Feature: implement ``angular_average.py`` to average 3D CDI reciprocal space data in 1D curve
+* Feature: implement ``angular_average.py`` to average 3D CDI reciprocal space data in
+  1D curve
 
-* Feature: implement view_psf to plot the psf output of a phase retrieval with partial coherence
+* Feature: implement view_psf to plot the psf output of a phase retrieval with partial
+  coherence
 
 * Refactor: change name of ``make_support.py`` to ``rescale_support.py``
 
@@ -149,98 +196,127 @@ Version 0.0.7
 -------------
 * Feature: implement ``supportMaker()`` class to define a support from a set of planes
 
-* Feature: implement ``maskMaker()`` class for easier implementation of new masking features
+* Feature: implement ``maskMaker()`` class for easier implementation of new masking
+  features
 
 * Debug ``prepare_bcdi_mask.py`` for energy scans at ID01
 
-* Feature: implement ``utils/scripts/make_support.py``, to rescale a support for phasing with a larger FFT window
+* Feature: implement ``utils/scripts/make_support.py``, to rescale a support for phasing
+  with a larger FFT window
 
-* Feature/refactor: implement ``prepare_cdi_mask.py`` for forward CDI, rename existing as ``prepare_bcdi_mask.py`` for Bragg CDI
+* Feature/refactor: implement ``prepare_cdi_mask.py`` for forward CDI, rename existing
+  as ``prepare_bcdi_mask.py`` for Bragg CDI
 
 * Feature: add the possibility to change the detector distance in ``simu_noise.py``
 
-* Feature: add the possibility to pre-process data acquired without scans, e.g. in a macro (no spec file)
+* Feature: add the possibility to pre-process data acquired without scans, e.g. in a
+  macro (no spec file)
 
-* Feature: in ``strain.py``, implement phase unwrapping so that the phase range can be larger than 2*pi
+* Feature: in ``strain.py``, implement phase unwrapping so that the phase range can be
+  larger than 2*pi
 
-* Feature: in ``facet_strain.py``, implement edge removal for more precise statistics on facet strain
+* Feature: in ``facet_strain.py``, implement edge removal for more precise statistics
+  on facet strain
 
-* Feature: in ``facet_strain.py``, allow anisotropic voxel size and user-defined reference axis in the stereographic projection
+* Feature: in ``facet_strain.py``, allow anisotropic voxel size and user-defined
+  reference axis in the stereographic projection
 
 Version 0.0.6
 -------------
 
-* Feature: implement facet detection using a stereographic projection in ``facet_recognition/scripts/facet_strain.py``
+* Feature: implement facet detection using a stereographic projection in
+  ``facet_recognition/scripts/facet_strain.py``
 
 * Feature: Converted ``bcdi/facet_recognition/scripts/facet_strain.py``
 
 * Feature: implement ``bcdi/facet_recognition/facets_utils.py``
 
-* Refactor: exclude voxels left over by coordination number selection in ``postprocessing/postprocessing_utils.find_bulk()``
+* Refactor: exclude voxels left over by coordination number selection in
+  ``postprocessing/postprocessing_utils.find_bulk()``
 
-* Refactor: use the mean amplitude of the surface layer to define the bulk in ``postprocessing/postprocessing_utils.find_bulk()``
+* Refactor: use the mean amplitude of the surface layer to define the bulk in
+  ``postprocessing/postprocessing_utils.find_bulk()``
 
 * Feature: enable PRTF resolution calculation for simulated data
 
 * Feature: create ``preprocessing/scripts/apodize.py`` to apodize reciprocal space data
 
-* Feature: implement 3d Tukey and 3d Blackman windows for apodization in ``postprocessing_utils()``
+* Feature: implement 3d Tukey and 3d Blackman windows for apodization in
+  ``postprocessing_utils()``
 
-* Feature: in ``postprocessing/scripts/resolution_prtf.py``, allow for binning the detector plane
+* Feature: in ``postprocessing/scripts/resolution_prtf.py``, allow for binning the
+  detector plane
 
-* Bug: in ``postprocessing/scripts/strain.py``, correct the original array size taking into account the binning factor
+* Bug: in ``postprocessing/scripts/strain.py``, correct the original array size taking
+  into account the binning factor
 
 * Feature: implement ``postprocessing_utils.bin_data()``
 
 Version 0.0.5
 -------------
 
-* Feature: implement support for SIXS data measured after the 11/03/2019 with the new data recorder.
+* Feature: implement support for SIXS data measured after the 11/03/2019 with the new
+  data recorder.
 
-* Refactor: ``modify preprocessing/scripts/readdata_P10.py`` to support several beamlines and rename it ``read_data.py``
+* Refactor: ``modify preprocessing/scripts/readdata_P10.py`` to support several
+  beamlines and rename it ``read_data.py``
 
-* Feature: implement support for multiple beamlines in postprocessing/script/resolution_prtf.py
+* Feature: implement support for multiple beamlines in
+  ``postprocessing/script/resolution_prtf.py``
 
-* Refactor: merge all ``preprocessing/preprocessing_utils.regrid_*.py`` in ``preprocessing/preprocessing_utils.regrid()``
+* Refactor: merge all ``preprocessing/preprocessing_utils.regrid_*.py`` in
+  ``preprocessing/preprocessing_utils.regrid()``
 
 * Converted ``postprocessing/scripts/resolution_prtf.py``
 
-* Refactor: add the possibility of giving a single element instead of the full tuple in ``graph/graph_utils.combined_plots()``
+* Refactor: add the possibility of giving a single element instead of the full tuple
+  in ``graph/graph_utils.combined_plots()``
 
 * Converted ``postprocessing/scripts/resolution_prtf.py``
 
 * Feature: create a ``Colormap()`` class in ``graph/graph_utils.py``
 
-* Refactor: merge all ``postprocessing/scripts/calc_angles_beam_*.py`` in ``postprocessing/scripts/correct_angles_detector.py``
+* Refactor: merge all ``postprocessing/scripts/calc_angles_beam_*.py`` in
+  ``postprocessing/scripts/correct_angles_detector.py``
 
-* Feature: Implement ``motor_values()`` and ``load_data()`` in ``preprocessing/preprocessing_utils.py``
+* Feature: Implement ``motor_values()`` and ``load_data()`` in
+  ``preprocessing/preprocessing_utils.py``
 
-* Feature: Implement ``SetupPostprocessing.rotation_direction()`` in ``experiment/experiment_utils.py``
+* Feature: Implement ``SetupPostprocessing.rotation_direction()`` in
+  ``experiment/experiment_utils.py``
 
 * Feature: add other counter name 'curpetra' for beam intensity monitor at P10
 
-* Bug: ``postprocessing/scripts/calc_angles_beam_*.py``: correct bug when roi_detector is not defined, and round the Bragg peak COM to integer pixels
+* Bug: ``postprocessing/scripts/calc_angles_beam_*.py``: correct bug when roi_detector
+  is not defined, and round the Bragg peak COM to integer pixels
 
 Version 0.0.4
 -------------
 
-* Implement ``motor_positions_p10()``, ``motor_positions_cristal()`` in ``preprocessing/preprocessing_utils.py``
+* Implement ``motor_positions_p10()``, ``motor_positions_cristal()`` in
+  ``preprocessing/preprocessing_utils.py``
 
-* Implement ``motor_positions_sixs()`` and ``motor_positions_id01()`` in ``preprocessing/preprocessing_utils.py``
+* Implement ``motor_positions_sixs()`` and ``motor_positions_id01()`` in
+  ``preprocessing/preprocessing_utils.py``
 
 * Implement ``find_bragg()`` in ``preprocessing/preprocessing_utils.py``
 
-* New parameter 'binning' in ``postprocessing/strain.py`` to account for binning during phasing.
+* New parameter 'binning' in ``postprocessing/strain.py`` to account for binning during
+  phasing.
 
-* Converted ``postprocessing/scripts/calc_angles_beam_P10.py`` and ``postprocessing/scripts/calc_angles_beam_CRISTAL.py``
+* Converted ``postprocessing/scripts/calc_angles_beam_P10.py`` and
+  ``postprocessing/scripts/calc_angles_beam_CRISTAL.py``
 
-* Converted ``postprocessing/scripts/calc_angles_beam_SIXS.py`` and ``postprocessing/scripts/calc_angles_beam_ID01.py``
+* Converted ``postprocessing/scripts/calc_angles_beam_SIXS.py`` and
+  ``postprocessing/scripts/calc_angles_beam_ID01.py``
 
 * Converted ``publication/scripts/paper_figure_strain.py``
 
-* Feat: implement ``postprocessing_utils.flip_reconstruction()`` to calculate the conjugate object giving the same diffracted intensity.
+* Feat: implement ``postprocessing_utils.flip_reconstruction()`` to calculate the
+  conjugate object giving the same diffracted intensity.
 
-* Switch the backend to Qt4Agg or Qt5Agg in ``prepare_cdi_mask.py`` to avoid Tk bug with interactive interface.
+* Switch the backend to Qt4Agg or Qt5Agg in ``prepare_cdi_mask.py`` to avoid Tk bug
+  with interactive interface.
 
 * Correct bug in ``preprocessing_utils.center_fft()`` when 'fix_size' is not empty.
 
@@ -272,12 +348,15 @@ Version 0.0.2
 
 * Created ``sort_reconstruction()`` in ``bcdi/postprocessing/postprocessing_utils.py``
 
-* Implemented regridding on the orthogonal frame of the diffraction pattern for P10 dataset.
+* Implemented regridding on the orthogonal frame of the diffraction pattern for P10
+  dataset.
 
-* Removed cumbersome argument headerlines_P10 in prepare_mask_cdi.py, use string parsing instead.
+* Removed cumbersome argument headerlines_P10 in prepare_mask_cdi.py, use string parsing
+  instead.
 
 Version 0.0.1
 -------------
-* Initial add, for the moment only the main scripts have been converted and checked: ``strain.py`` and ``prepare_cdi_mask.py``
+* Initial add, for the moment only the main scripts have been converted and checked:
+  ``strain.py`` and ``prepare_cdi_mask.py``
 
 EOF

--- a/scripts/postprocessing/bcdi_prtf_BCDI.py
+++ b/scripts/postprocessing/bcdi_prtf_BCDI.py
@@ -31,7 +31,8 @@ import bcdi.utils.validation as valid
 helptext = """
 Calculate the resolution of a BCDI reconstruction using the phase retrieval transfer
 function (PRTF). The measured diffraction pattern and reconstructions should be in
-the detector frame, before phase ramp removal and centering.
+the detector frame, before phase ramp removal and centering. An optional mask can be
+provided.
 
 For the laboratory frame, the CXI convention is used: z downstream, y vertical,
 x outboard. For q, the usual convention is used: qx downstream, qz vertical, qy outboard

--- a/scripts/postprocessing/bcdi_prtf_BCDI.py
+++ b/scripts/postprocessing/bcdi_prtf_BCDI.py
@@ -45,9 +45,8 @@ Path structure:
 
 scan = 74
 sample_name = "S"  # "SN"  #
-root_folder = (
-    "D:/data/CRISTAL_March2021/"  # folder of the experiment, where all scans are stored
-)
+root_folder = "D:/data/CRISTAL_March2021/"
+# folder of the experiment, where all scans are stored
 save_dir = None  # PRTF will be saved here, leave None otherwise
 comment = ""  # should start with _
 crop_roi = None
@@ -122,9 +121,8 @@ sample_offsets = (
     0,
     0,
     0,
-)  # tuple of offsets in degrees of the sample around
-# (downstream, vertical up, outboard)
-# convention: the sample offsets will be subtracted to the motor values
+)  # tuple of offsets in degrees of the sample for each sample circle (outer first).
+# the sample offsets will be subtracted to the motor values. Leave None if no offset.
 ###############################
 # only needed for simulations #
 ###############################
@@ -332,7 +330,10 @@ file_path = filedialog.askopenfilename(
     title="Select mask",
     filetypes=[("NPZ", "*.npz"), ("NPY", "*.npy")],
 )
-mask, _ = util.load_file(file_path)
+try:
+    mask, _ = util.load_file(file_path)
+except ValueError:
+    mask = np.zeros(diff_pattern.shape, dtype=int)
 
 ###########################################################
 # crop the diffraction pattern and the mask to compensate #

--- a/scripts/postprocessing/bcdi_prtf_BCDI_2D.py
+++ b/scripts/postprocessing/bcdi_prtf_BCDI_2D.py
@@ -43,9 +43,8 @@ Path structure:
 """
 
 scan = 279
-root_folder = (
-    "D:/data/DATA_exp/"  # folder of the experiment, where all scans are stored
-)
+root_folder = "D:/data/DATA_exp/"
+# folder of the experiment, where all scans are stored
 save_dir = None  # PRTF will be saved here, leave None otherwise
 sample_name = "S"  # "SN"  #
 comment = ""  # should start with _
@@ -127,9 +126,8 @@ sample_offsets = (
     0,
     0,
     0,
-)  # tuple of offsets in degrees of the sample around
-# (downstream, vertical up, outboard)
-# convention: the sample offsets will be subtracted to the motor values
+)  # tuple of offsets in degrees of the sample for each sample circle (outer first).
+# the sample offsets will be subtracted to the motor values. Leave None if no offset.
 ###############################
 # only needed for simulations #
 ###############################
@@ -239,7 +237,10 @@ file_path = filedialog.askopenfilename(
     title="Select 2D mask",
     filetypes=[("NPZ", "*.npz"), ("NPY", "*.npy")],
 )
-mask_2D, _ = util.load_file(file_path)
+try:
+    mask_2D, _ = util.load_file(file_path)
+except ValueError:
+    mask_2D = np.zeros(slice_2D.shape, dtype=int)
 
 ###########################################################
 # crop the diffraction pattern and the mask to compensate #

--- a/scripts/postprocessing/bcdi_prtf_BCDI_2D.py
+++ b/scripts/postprocessing/bcdi_prtf_BCDI_2D.py
@@ -30,7 +30,8 @@ import bcdi.utils.utilities as util
 helptext = """
 Calculate the resolution of a 2D BCDI reconstruction using the phase retrieval
 transfer function (PRTF). The measured diffraction pattern and reconstructions should
-be in the detector frame, before phase ramp removal and centering.
+be in the detector frame, before phase ramp removal and centering. An optional mask
+can be provided.
 
 For the laboratory frame, the CXI convention is used: z downstream, y vertical,
 x outboard. For q, the usual convention is used: qx downstream, qz vertical, qy outboard


### PR DESCRIPTION
If the user do not provide a mask (by closing the pop-up window), an empty mask is automatically generated.

- [X] New feature (non-breaking change which adds functionality)

* OS: Windows
* Python version: 3.8.8

## Checklist:

- [X] My code follows the style guidelines of this project
- [X ] I have reviewed my code and checked for misspellings
- [X] I have made corresponding changes to the documentation
- [X] I have run ``doit`` and all tasks have passed
