### PR TITLE
us explicit signature for methods 

### DIFF
--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -1527,7 +1527,6 @@ class BeamlineSIXS(Beamline):
         template_imagefile = template_imagefile
         return homedir, default_dirname, specfile, template_imagefile
 
-    @property
     def inplane_coeff(self, diffractometer):
         """
         Coefficient related to the detector inplane orientation at SIXS.

--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -205,29 +205,26 @@ class Beamline(ABC):
         """
 
     @abstractmethod
-    def transformation_matrix(self, params, verbose=True):
+    def transformation_matrix(self, wavelength, distance, pixel_x, pixel_y, inplane,
+                              outofplane, grazing_angle, tilt, rocking_angle,
+                              verbose=True):
         """
         Calculate the transformation matrix from detector frame to laboratory frame.
 
         For the transformation in direct space, the length scale is in nm,
         for the transformation in reciprocal space, it is in 1/nm.
 
-        :param params: dictionnary of the setup parameters including the following keys:
-
-         - 'wavelength': X-ray wasvelength in nm
-         - 'distance': detector distance in nm
-         - 'pixel_x': horizontal detector pixel size in nm
-         - 'pixel_y': vertical detector pixel size in nm
-         - 'inplane': horizontal detector angle in radians
-         - 'outofplane': vertical detector angle in radians
-         - 'grazing_angle': angle or list of angles of the sample circles which are
-           below the rotated circle
-         - 'tilt': angular step of the rocking curve in radians
-         - 'rocking_angle': "outofplane", "inplane" or "energy"
-         - 'array_shape': shape of the 3D array to orthogonalize
-
+        :param wavelength: X-ray wasvelength in nm
+        :param distance: detector distance in nm
+        :param pixel_x: horizontal detector pixel size in nm
+        :param pixel_y: vertical detector pixel size in nm
+        :param inplane: horizontal detector angle in radians
+        :param outofplane: vertical detector angle in radians
+        :param grazing_angle: angle or list of angles of the sample circles which are
+         below the rotated circle
+        :param tilt: angular step of the rocking curve in radians
+        :param rocking_angle: "outofplane", "inplane" or "energy"
         :param verbose: True to have printed comments
-
         :return: a tuple of two numpy arrays
 
          - the transformation matrix from the detector frame to the
@@ -374,17 +371,35 @@ class BeamlineCRISTAL(Beamline):
         return (self.detector_labframe[diffractometer.detector_circles[1]] *
                 self.detector_xrayutil[self.detector_ver])
 
-    def transformation_matrix(self, params, verbose=True):
-        wavelength = params["wavelength"]
-        distance = params["distance"]
+    def transformation_matrix(self, wavelength, distance, pixel_x, pixel_y, inplane,
+                              outofplane, grazing_angle, tilt, rocking_angle,
+                              verbose=True):
+        """
+        Calculate the transformation matrix from detector frame to laboratory frame.
+
+        For the transformation in direct space, the length scale is in nm,
+        for the transformation in reciprocal space, it is in 1/nm.
+
+        :param wavelength: X-ray wasvelength in nm
+        :param distance: detector distance in nm
+        :param pixel_x: horizontal detector pixel size in nm
+        :param pixel_y: vertical detector pixel size in nm
+        :param inplane: horizontal detector angle in radians
+        :param outofplane: vertical detector angle in radians
+        :param grazing_angle: angle or list of angles of the sample circles which are
+         below the rotated circle
+        :param tilt: angular step of the rocking curve in radians
+        :param rocking_angle: "outofplane", "inplane" or "energy"
+        :param verbose: True to have printed comments
+        :return: a tuple of two numpy arrays
+
+         - the transformation matrix from the detector frame to the
+           laboratory frame in reciprocal space (reciprocal length scale in  1/nm), as a
+           numpy array of shape (3,3)
+         - the q offset (3D vector)
+
+        """
         lambdaz = wavelength * distance
-        pixel_x = params["pixel_x"]
-        pixel_y = params["pixel_y"]
-        inplane = params["inplane"]
-        outofplane = params["outofplane"]
-        grazing_angle = params["grazing_angle"]
-        tilt = params["tilt"]
-        rocking_angle = params["rocking_angle"]
         mymatrix = np.zeros((3, 3))
         q_offset = np.zeros(3)
 
@@ -645,17 +660,35 @@ class BeamlineID01(Beamline):
         return (self.detector_labframe[diffractometer.detector_circles[1]] *
                 self.detector_xrayutil[self.detector_ver])
 
-    def transformation_matrix(self, params, verbose=True):
-        wavelength = params["wavelength"]
-        distance = params["distance"]
+    def transformation_matrix(self, wavelength, distance, pixel_x, pixel_y, inplane,
+                              outofplane, grazing_angle, tilt, rocking_angle,
+                              verbose=True):
+        """
+        Calculate the transformation matrix from detector frame to laboratory frame.
+
+        For the transformation in direct space, the length scale is in nm,
+        for the transformation in reciprocal space, it is in 1/nm.
+
+        :param wavelength: X-ray wasvelength in nm
+        :param distance: detector distance in nm
+        :param pixel_x: horizontal detector pixel size in nm
+        :param pixel_y: vertical detector pixel size in nm
+        :param inplane: horizontal detector angle in radians
+        :param outofplane: vertical detector angle in radians
+        :param grazing_angle: angle or list of angles of the sample circles which are
+         below the rotated circle
+        :param tilt: angular step of the rocking curve in radians
+        :param rocking_angle: "outofplane", "inplane" or "energy"
+        :param verbose: True to have printed comments
+        :return: a tuple of two numpy arrays
+
+         - the transformation matrix from the detector frame to the
+           laboratory frame in reciprocal space (reciprocal length scale in  1/nm), as a
+           numpy array of shape (3,3)
+         - the q offset (3D vector)
+
+        """
         lambdaz = wavelength * distance
-        pixel_x = params["pixel_x"]
-        pixel_y = params["pixel_y"]
-        inplane = params["inplane"]
-        outofplane = params["outofplane"]
-        grazing_angle = params["grazing_angle"]
-        tilt = params["tilt"]
-        rocking_angle = params["rocking_angle"]
         mymatrix = np.zeros((3, 3))
         q_offset = np.zeros(3)
 
@@ -915,17 +948,35 @@ class BeamlineNANOMAX(Beamline):
         return (self.detector_labframe[diffractometer.detector_circles[1]] *
                 self.detector_xrayutil[self.detector_ver])
 
-    def transformation_matrix(self, params, verbose=True):
-        wavelength = params["wavelength"]
-        distance = params["distance"]
+    def transformation_matrix(self, wavelength, distance, pixel_x, pixel_y, inplane,
+                              outofplane, grazing_angle, tilt, rocking_angle,
+                              verbose=True):
+        """
+        Calculate the transformation matrix from detector frame to laboratory frame.
+
+        For the transformation in direct space, the length scale is in nm,
+        for the transformation in reciprocal space, it is in 1/nm.
+
+        :param wavelength: X-ray wasvelength in nm
+        :param distance: detector distance in nm
+        :param pixel_x: horizontal detector pixel size in nm
+        :param pixel_y: vertical detector pixel size in nm
+        :param inplane: horizontal detector angle in radians
+        :param outofplane: vertical detector angle in radians
+        :param grazing_angle: angle or list of angles of the sample circles which are
+         below the rotated circle
+        :param tilt: angular step of the rocking curve in radians
+        :param rocking_angle: "outofplane", "inplane" or "energy"
+        :param verbose: True to have printed comments
+        :return: a tuple of two numpy arrays
+
+         - the transformation matrix from the detector frame to the
+           laboratory frame in reciprocal space (reciprocal length scale in  1/nm), as a
+           numpy array of shape (3,3)
+         - the q offset (3D vector)
+
+        """
         lambdaz = wavelength * distance
-        pixel_x = params["pixel_x"]
-        pixel_y = params["pixel_y"]
-        inplane = params["inplane"]
-        outofplane = params["outofplane"]
-        grazing_angle = params["grazing_angle"]
-        tilt = params["tilt"]
-        rocking_angle = params["rocking_angle"]
         mymatrix = np.zeros((3, 3))
         q_offset = np.zeros(3)
 
@@ -1187,17 +1238,35 @@ class BeamlineP10(Beamline):
         return (self.detector_labframe[diffractometer.detector_circles[1]] *
                 self.detector_xrayutil[self.detector_ver])
 
-    def transformation_matrix(self, params, verbose=True):
-        wavelength = params["wavelength"]
-        distance = params["distance"]
+    def transformation_matrix(self, wavelength, distance, pixel_x, pixel_y, inplane,
+                              outofplane, grazing_angle, tilt, rocking_angle,
+                              verbose=True):
+        """
+        Calculate the transformation matrix from detector frame to laboratory frame.
+
+        For the transformation in direct space, the length scale is in nm,
+        for the transformation in reciprocal space, it is in 1/nm.
+
+        :param wavelength: X-ray wasvelength in nm
+        :param distance: detector distance in nm
+        :param pixel_x: horizontal detector pixel size in nm
+        :param pixel_y: vertical detector pixel size in nm
+        :param inplane: horizontal detector angle in radians
+        :param outofplane: vertical detector angle in radians
+        :param grazing_angle: angle or list of angles of the sample circles which are
+         below the rotated circle
+        :param tilt: angular step of the rocking curve in radians
+        :param rocking_angle: "outofplane", "inplane" or "energy"
+        :param verbose: True to have printed comments
+        :return: a tuple of two numpy arrays
+
+         - the transformation matrix from the detector frame to the
+           laboratory frame in reciprocal space (reciprocal length scale in  1/nm), as a
+           numpy array of shape (3,3)
+         - the q offset (3D vector)
+
+        """
         lambdaz = wavelength * distance
-        pixel_x = params["pixel_x"]
-        pixel_y = params["pixel_y"]
-        inplane = params["inplane"]
-        outofplane = params["outofplane"]
-        grazing_angle = params["grazing_angle"]
-        tilt = params["tilt"]
-        rocking_angle = params["rocking_angle"]
         mymatrix = np.zeros((3, 3))
         q_offset = np.zeros(3)
 
@@ -1531,17 +1600,35 @@ class BeamlineSIXS(Beamline):
         return (self.detector_labframe[diffractometer.detector_circles[1]] *
                 self.detector_xrayutil[self.detector_ver])
 
-    def transformation_matrix(self, params, verbose=True):
-        wavelength = params["wavelength"]
-        distance = params["distance"]
+    def transformation_matrix(self, wavelength, distance, pixel_x, pixel_y, inplane,
+                              outofplane, grazing_angle, tilt, rocking_angle,
+                              verbose=True):
+        """
+        Calculate the transformation matrix from detector frame to laboratory frame.
+
+        For the transformation in direct space, the length scale is in nm,
+        for the transformation in reciprocal space, it is in 1/nm.
+
+        :param wavelength: X-ray wasvelength in nm
+        :param distance: detector distance in nm
+        :param pixel_x: horizontal detector pixel size in nm
+        :param pixel_y: vertical detector pixel size in nm
+        :param inplane: horizontal detector angle in radians
+        :param outofplane: vertical detector angle in radians
+        :param grazing_angle: angle or list of angles of the sample circles which are
+         below the rotated circle
+        :param tilt: angular step of the rocking curve in radians
+        :param rocking_angle: "outofplane", "inplane" or "energy"
+        :param verbose: True to have printed comments
+        :return: a tuple of two numpy arrays
+
+         - the transformation matrix from the detector frame to the
+           laboratory frame in reciprocal space (reciprocal length scale in  1/nm), as a
+           numpy array of shape (3,3)
+         - the q offset (3D vector)
+
+        """
         lambdaz = wavelength * distance
-        pixel_x = params["pixel_x"]
-        pixel_y = params["pixel_y"]
-        inplane = params["inplane"]
-        outofplane = params["outofplane"]
-        grazing_angle = params["grazing_angle"]
-        tilt = params["tilt"]
-        rocking_angle = params["rocking_angle"]
         mymatrix = np.zeros((3, 3))
         q_offset = np.zeros(3)
 
@@ -1764,17 +1851,35 @@ class Beamline34ID(Beamline):
         return (self.detector_labframe[diffractometer.detector_circles[1]] *
                 self.detector_xrayutil[self.detector_ver])
 
-    def transformation_matrix(self, params, verbose=True):
-        wavelength = params["wavelength"]
-        distance = params["distance"]
+    def transformation_matrix(self, wavelength, distance, pixel_x, pixel_y, inplane,
+                              outofplane, grazing_angle, tilt, rocking_angle,
+                              verbose=True):
+        """
+        Calculate the transformation matrix from detector frame to laboratory frame.
+
+        For the transformation in direct space, the length scale is in nm,
+        for the transformation in reciprocal space, it is in 1/nm.
+
+        :param wavelength: X-ray wasvelength in nm
+        :param distance: detector distance in nm
+        :param pixel_x: horizontal detector pixel size in nm
+        :param pixel_y: vertical detector pixel size in nm
+        :param inplane: horizontal detector angle in radians
+        :param outofplane: vertical detector angle in radians
+        :param grazing_angle: angle or list of angles of the sample circles which are
+         below the rotated circle
+        :param tilt: angular step of the rocking curve in radians
+        :param rocking_angle: "outofplane", "inplane" or "energy"
+        :param verbose: True to have printed comments
+        :return: a tuple of two numpy arrays
+
+         - the transformation matrix from the detector frame to the
+           laboratory frame in reciprocal space (reciprocal length scale in  1/nm), as a
+           numpy array of shape (3,3)
+         - the q offset (3D vector)
+
+        """
         lambdaz = wavelength * distance
-        pixel_x = params["pixel_x"]
-        pixel_y = params["pixel_y"]
-        inplane = params["inplane"]
-        outofplane = params["outofplane"]
-        grazing_angle = params["grazing_angle"]
-        tilt = params["tilt"]
-        rocking_angle = params["rocking_angle"]
         mymatrix = np.zeros((3, 3))
         q_offset = np.zeros(3)
 

--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -54,8 +54,9 @@ def create_beamline(name):
 
 class Beamline(ABC):
     """Base class for defining a beamline."""
+
     orientation_lookup = {"x-": 1, "x+": -1, "y-": 1, "y+": -1}  # lookup table for the
-    # detector orientation and rotation direction, where axes are expressed in the 
+    # detector orientation and rotation direction, where axes are expressed in the
     # laboratory frame (z downstream, y vertical up, x outboard).
     # Expected detector orientation:
     # "x-" detector horizontal axis inboard, as it should be in the CXI convention
@@ -172,7 +173,7 @@ class Beamline(ABC):
         Define a coefficient +/- 1 depending on the detector inplane rotation direction
         (1 for clockwise, -1 for anti-clockwise) and the detector inplane orientation
         (1 for inboard, -1 for outboard).
-        
+
         See scripts/postprocessing/correct_angles_detector.py for a use case.
 
         :param diffractometer: Diffractometer instance of the beamline.
@@ -192,7 +193,7 @@ class Beamline(ABC):
         Define a coefficient +/- 1 depending on the detector out of plane rotation
         direction (1 for clockwise, -1 for anti-clockwise) and the detector out of
         plane orientation (1 for downward, -1 for upward).
-        
+
         See scripts/postprocessing/correct_angles_detector.py for a use case.
 
         :param diffractometer: Diffractometer instance of the beamline.
@@ -200,9 +201,19 @@ class Beamline(ABC):
         """
 
     @abstractmethod
-    def transformation_matrix(self, wavelength, distance, pixel_x, pixel_y, inplane,
-                              outofplane, grazing_angle, tilt, rocking_angle,
-                              verbose=True):
+    def transformation_matrix(
+        self,
+        wavelength,
+        distance,
+        pixel_x,
+        pixel_y,
+        inplane,
+        outofplane,
+        grazing_angle,
+        tilt,
+        rocking_angle,
+        verbose=True,
+    ):
         """
         Calculate the transformation matrix from detector frame to laboratory frame.
 
@@ -249,8 +260,9 @@ class BeamlineCRISTAL(Beamline):
         if not all(isinstance(val, str) for val in {datadir, template_imagefile}):
             raise TypeError("datadir and template_imagefile should be strings")
         if not isinstance(scan_number, int):
-            raise TypeError("scan_number should be an integer, "
-                            f"got {type(scan_number)}")
+            raise TypeError(
+                "scan_number should be an integer, " f"got {type(scan_number)}"
+            )
         # no specfile, load directly the dataset
         ccdfiletmp = os.path.join(datadir + template_imagefile % scan_number)
         return h5py.File(ccdfiletmp, "r")
@@ -323,7 +335,7 @@ class BeamlineCRISTAL(Beamline):
          - template_imagefile: the template for data/image file names
 
         """
-        homedir = (root_folder + sample_name + str(scan_number) + "/")
+        homedir = root_folder + sample_name + str(scan_number) + "/"
         default_dirname = "data/"
         return homedir, default_dirname, "", template_imagefile
 
@@ -340,8 +352,10 @@ class BeamlineCRISTAL(Beamline):
         :param diffractometer: Diffractometer instance of the beamline.
         :return: +1 or -1
         """
-        return (self.orientation_lookup[diffractometer.detector_circles[0]] *
-                self.orientation_lookup[self.detector_hor])
+        return (
+            self.orientation_lookup[diffractometer.detector_circles[0]]
+            * self.orientation_lookup[self.detector_hor]
+        )
 
     def outofplane_coeff(self, diffractometer):
         """
@@ -356,12 +370,24 @@ class BeamlineCRISTAL(Beamline):
         :param diffractometer: Diffractometer instance of the beamline.
         :return: +1 or -1
         """
-        return (self.orientation_lookup[diffractometer.detector_circles[1]] *
-                self.orientation_lookup[self.detector_ver])
+        return (
+            self.orientation_lookup[diffractometer.detector_circles[1]]
+            * self.orientation_lookup[self.detector_ver]
+        )
 
-    def transformation_matrix(self, wavelength, distance, pixel_x, pixel_y, inplane,
-                              outofplane, grazing_angle, tilt, rocking_angle,
-                              verbose=True):
+    def transformation_matrix(
+        self,
+        wavelength,
+        distance,
+        pixel_x,
+        pixel_y,
+        inplane,
+        outofplane,
+        grazing_angle,
+        tilt,
+        rocking_angle,
+        verbose=True,
+    ):
         """
         Calculate the transformation matrix from detector frame to laboratory frame.
 
@@ -585,8 +611,14 @@ class BeamlineID01(Beamline):
         return kout
 
     @staticmethod
-    def init_paths(root_folder, sample_name, scan_number, specfile_name,
-                   template_imagefile, **kwargs):
+    def init_paths(
+        root_folder,
+        sample_name,
+        scan_number,
+        specfile_name,
+        template_imagefile,
+        **kwargs,
+    ):
         """
         Initialize paths used for data processing and logging at ID01.
 
@@ -605,7 +637,7 @@ class BeamlineID01(Beamline):
          - template_imagefile: the template for data/image file names
 
         """
-        homedir = (root_folder + sample_name + str(scan_number) + "/")
+        homedir = root_folder + sample_name + str(scan_number) + "/"
         default_dirname = "data/"
         return homedir, default_dirname, specfile_name, template_imagefile
 
@@ -622,8 +654,10 @@ class BeamlineID01(Beamline):
         :param diffractometer: Diffractometer instance of the beamline.
         :return: +1 or -1
         """
-        return (self.orientation_lookup[diffractometer.detector_circles[0]] *
-                self.orientation_lookup[self.detector_hor])
+        return (
+            self.orientation_lookup[diffractometer.detector_circles[0]]
+            * self.orientation_lookup[self.detector_hor]
+        )
 
     def outofplane_coeff(self, diffractometer):
         """
@@ -638,12 +672,24 @@ class BeamlineID01(Beamline):
         :param diffractometer: Diffractometer instance of the beamline.
         :return: +1 or -1
         """
-        return (self.orientation_lookup[diffractometer.detector_circles[1]] *
-                self.orientation_lookup[self.detector_ver])
+        return (
+            self.orientation_lookup[diffractometer.detector_circles[1]]
+            * self.orientation_lookup[self.detector_ver]
+        )
 
-    def transformation_matrix(self, wavelength, distance, pixel_x, pixel_y, inplane,
-                              outofplane, grazing_angle, tilt, rocking_angle,
-                              verbose=True):
+    def transformation_matrix(
+        self,
+        wavelength,
+        distance,
+        pixel_x,
+        pixel_y,
+        inplane,
+        outofplane,
+        grazing_angle,
+        tilt,
+        rocking_angle,
+        verbose=True,
+    ):
         """
         Calculate the transformation matrix from detector frame to laboratory frame.
 
@@ -813,8 +859,9 @@ class BeamlineNANOMAX(Beamline):
         if not all(isinstance(val, str) for val in {datadir, template_imagefile}):
             raise TypeError("datadir and template_imagefile should be strings")
         if not isinstance(scan_number, int):
-            raise TypeError("scan_number should be an integer, "
-                            f"got {type(scan_number)}")
+            raise TypeError(
+                "scan_number should be an integer, " f"got {type(scan_number)}"
+            )
         ccdfiletmp = os.path.join(datadir + template_imagefile % scan_number)
         return h5py.File(ccdfiletmp, "r")
 
@@ -886,7 +933,7 @@ class BeamlineNANOMAX(Beamline):
          - template_imagefile: the template for data/image file names
 
         """
-        homedir = (root_folder + sample_name + "{:06d}".format(scan_number) + "/")
+        homedir = root_folder + sample_name + "{:06d}".format(scan_number) + "/"
         default_dirname = "data/"
         return homedir, default_dirname, "", template_imagefile
 
@@ -903,8 +950,10 @@ class BeamlineNANOMAX(Beamline):
         :param diffractometer: Diffractometer instance of the beamline.
         :return: +1 or -1
         """
-        return (self.orientation_lookup[diffractometer.detector_circles[0]] *
-                self.orientation_lookup[self.detector_hor])
+        return (
+            self.orientation_lookup[diffractometer.detector_circles[0]]
+            * self.orientation_lookup[self.detector_hor]
+        )
 
     def outofplane_coeff(self, diffractometer):
         """
@@ -919,12 +968,24 @@ class BeamlineNANOMAX(Beamline):
         :param diffractometer: Diffractometer instance of the beamline.
         :return: +1 or -1
         """
-        return (self.orientation_lookup[diffractometer.detector_circles[1]] *
-                self.orientation_lookup[self.detector_ver])
+        return (
+            self.orientation_lookup[diffractometer.detector_circles[1]]
+            * self.orientation_lookup[self.detector_ver]
+        )
 
-    def transformation_matrix(self, wavelength, distance, pixel_x, pixel_y, inplane,
-                              outofplane, grazing_angle, tilt, rocking_angle,
-                              verbose=True):
+    def transformation_matrix(
+        self,
+        wavelength,
+        distance,
+        pixel_x,
+        pixel_y,
+        inplane,
+        outofplane,
+        grazing_angle,
+        tilt,
+        rocking_angle,
+        verbose=True,
+    ):
         """
         Calculate the transformation matrix from detector frame to laboratory frame.
 
@@ -1166,7 +1227,6 @@ class BeamlineP10(Beamline):
          - template_imagefile: the template for data/image file names
 
         """
-
         specfile = sample_name + "_{:05d}".format(scan_number)
         homedir = root_folder + specfile + "/"
         default_dirname = "e4m/"
@@ -1186,8 +1246,10 @@ class BeamlineP10(Beamline):
         :param diffractometer: Diffractometer instance of the beamline.
         :return: +1 or -1
         """
-        return (self.orientation_lookup[diffractometer.detector_circles[0]] *
-                self.orientation_lookup[self.detector_hor])
+        return (
+            self.orientation_lookup[diffractometer.detector_circles[0]]
+            * self.orientation_lookup[self.detector_hor]
+        )
 
     def outofplane_coeff(self, diffractometer):
         """
@@ -1202,12 +1264,24 @@ class BeamlineP10(Beamline):
         :param diffractometer: Diffractometer instance of the beamline.
         :return: +1 or -1
         """
-        return (self.orientation_lookup[diffractometer.detector_circles[1]] *
-                self.orientation_lookup[self.detector_ver])
+        return (
+            self.orientation_lookup[diffractometer.detector_circles[1]]
+            * self.orientation_lookup[self.detector_ver]
+        )
 
-    def transformation_matrix(self, wavelength, distance, pixel_x, pixel_y, inplane,
-                              outofplane, grazing_angle, tilt, rocking_angle,
-                              verbose=True):
+    def transformation_matrix(
+        self,
+        wavelength,
+        distance,
+        pixel_x,
+        pixel_y,
+        inplane,
+        outofplane,
+        grazing_angle,
+        tilt,
+        rocking_angle,
+        verbose=True,
+    ):
         """
         Calculate the transformation matrix from detector frame to laboratory frame.
 
@@ -1392,8 +1466,9 @@ class BeamlineSIXS(Beamline):
     def __init__(self, name):
         super().__init__(name=name)
 
-    def create_logfile(self, datadir, template_imagefile, scan_number,
-                       filename, **kwargs):
+    def create_logfile(
+        self, datadir, template_imagefile, scan_number, filename, **kwargs
+    ):
         """
         Create the logfile, which is the data itself for SIXS.
 
@@ -1407,12 +1482,14 @@ class BeamlineSIXS(Beamline):
         :param filename: str, name of the alias dictionary
         :return: logfile
         """
-        if not all(isinstance(val, str) for val in
-                   {datadir, template_imagefile, filename}):
+        if not all(
+            isinstance(val, str) for val in {datadir, template_imagefile, filename}
+        ):
             raise TypeError("datadir and template_imagefile should be strings")
         if not isinstance(scan_number, int):
-            raise TypeError("scan_number should be an integer, "
-                            f"got {type(scan_number)}")
+            raise TypeError(
+                "scan_number should be an integer, " f"got {type(scan_number)}"
+            )
 
         shortname = template_imagefile % scan_number
         if self.name == "SIXS_2018":
@@ -1487,8 +1564,14 @@ class BeamlineSIXS(Beamline):
         return kout
 
     @staticmethod
-    def init_paths(root_folder, sample_name, scan_number, specfile_name,
-                   template_imagefile, **kwargs):
+    def init_paths(
+        root_folder,
+        sample_name,
+        scan_number,
+        specfile_name,
+        template_imagefile,
+        **kwargs,
+    ):
         """
         Initialize paths used for data processing and logging at SIXS.
 
@@ -1509,7 +1592,7 @@ class BeamlineSIXS(Beamline):
          - template_imagefile: the template for data/image file names
 
         """
-        homedir = (root_folder + sample_name + str(scan_number) + "/")
+        homedir = root_folder + sample_name + str(scan_number) + "/"
         default_dirname = "data/"
 
         if specfile_name is None:
@@ -1540,8 +1623,10 @@ class BeamlineSIXS(Beamline):
         :param diffractometer: Diffractometer instance of the beamline.
         :return: +1 or -1
         """
-        return (self.orientation_lookup[diffractometer.detector_circles[0]] *
-                self.orientation_lookup[self.detector_hor])
+        return (
+            self.orientation_lookup[diffractometer.detector_circles[0]]
+            * self.orientation_lookup[self.detector_hor]
+        )
 
     def outofplane_coeff(self, diffractometer):
         """
@@ -1556,12 +1641,24 @@ class BeamlineSIXS(Beamline):
         :param diffractometer: Diffractometer instance of the beamline.
         :return: +1 or -1
         """
-        return (self.orientation_lookup[diffractometer.detector_circles[1]] *
-                self.orientation_lookup[self.detector_ver])
+        return (
+            self.orientation_lookup[diffractometer.detector_circles[1]]
+            * self.orientation_lookup[self.detector_ver]
+        )
 
-    def transformation_matrix(self, wavelength, distance, pixel_x, pixel_y, inplane,
-                              outofplane, grazing_angle, tilt, rocking_angle,
-                              verbose=True):
+    def transformation_matrix(
+        self,
+        wavelength,
+        distance,
+        pixel_x,
+        pixel_y,
+        inplane,
+        outofplane,
+        grazing_angle,
+        tilt,
+        rocking_angle,
+        verbose=True,
+    ):
         """
         Calculate the transformation matrix from detector frame to laboratory frame.
 
@@ -1694,7 +1791,7 @@ class Beamline34ID(Beamline):
 
     @staticmethod
     def create_logfile(**kwargs):
-        """Method not implemented."""
+        """Create logfile for 34ID-C."""
         raise NotImplementedError("create_logfile method not implemented for 34ID")
 
     @property
@@ -1766,12 +1863,12 @@ class Beamline34ID(Beamline):
          - template_imagefile: the template for data/image file names
 
         """
-        homedir = (root_folder + sample_name + str(scan_number) + "/")
+        homedir = root_folder + sample_name + str(scan_number) + "/"
         default_dirname = "data/"
         return homedir, default_dirname, "", template_imagefile
 
     def inplane_coeff(self, diffractometer):
-        # 
+        #
         """
         Coefficient related to the detector inplane orientation at SIXS.
 
@@ -1784,8 +1881,10 @@ class Beamline34ID(Beamline):
         :param diffractometer: Diffractometer instance of the beamline.
         :return: +1 or -1
         """
-        return (self.orientation_lookup[diffractometer.detector_circles[0]] *
-                self.orientation_lookup[self.detector_hor])
+        return (
+            self.orientation_lookup[diffractometer.detector_circles[0]]
+            * self.orientation_lookup[self.detector_hor]
+        )
 
     def outofplane_coeff(self, diffractometer):
         """
@@ -1800,12 +1899,24 @@ class Beamline34ID(Beamline):
         :param diffractometer: Diffractometer instance of the beamline.
         :return: +1 or -1
         """
-        return (self.orientation_lookup[diffractometer.detector_circles[1]] *
-                self.orientation_lookup[self.detector_ver])
+        return (
+            self.orientation_lookup[diffractometer.detector_circles[1]]
+            * self.orientation_lookup[self.detector_ver]
+        )
 
-    def transformation_matrix(self, wavelength, distance, pixel_x, pixel_y, inplane,
-                              outofplane, grazing_angle, tilt, rocking_angle,
-                              verbose=True):
+    def transformation_matrix(
+        self,
+        wavelength,
+        distance,
+        pixel_x,
+        pixel_y,
+        inplane,
+        outofplane,
+        grazing_angle,
+        tilt,
+        rocking_angle,
+        verbose=True,
+    ):
         """
         Calculate the transformation matrix from detector frame to laboratory frame.
 

--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -256,13 +256,28 @@ class BeamlineCRISTAL(Beamline):
 
     @property
     def detector_hor(self):
-        # we look at the detector from downstream, detector X is along the outboard
-        # direction
+        """
+        Horizontal detector orientation expressed in the frame of xrayutilities.
+
+        We look at the detector from downstream, detector X is along the outboard
+        direction. The frame convention of xrayutilities is the following: x downstream,
+        y outboard, z vertical up.
+
+        :return: "y+"
+        """
         return "y+"
 
     @property
     def detector_ver(self):
-        # origin is at the top, detector Y along vertical down
+        """
+        Vertical detector orientation expressed in the frame of xrayutilities.
+
+        The origin is at the top, detector Y along vertical down. The frame
+        convention of xrayutilities is the following: x downstream, y outboard,
+        z vertical up.
+
+        :return: "z-"
+        """
         return "z-"
 
     @staticmethod
@@ -476,13 +491,28 @@ class BeamlineID01(Beamline):
 
     @property
     def detector_hor(self):
-        # we look at the detector from downstream, detector X is along the outboard
-        # direction
+        """
+        Horizontal detector orientation expressed in the frame of xrayutilities.
+
+        We look at the detector from downstream, detector X is along the outboard
+        direction. The frame convention of xrayutilities is the following: x downstream,
+        y outboard, z vertical up.
+
+        :return: "y+"
+        """
         return "y+"
 
     @property
     def detector_ver(self):
-        # origin is at the top, detector Y along vertical down
+        """
+        Vertical detector orientation expressed in the frame of xrayutilities.
+
+        The origin is at the top, detector Y along vertical down. The frame
+        convention of xrayutilities is the following: x downstream, y outboard,
+        z vertical up.
+
+        :return: "z-"
+        """
         return "z-"
 
     @staticmethod
@@ -698,13 +728,28 @@ class BeamlineNANOMAX(Beamline):
 
     @property
     def detector_hor(self):
-        # we look at the detector from downstream, detector X is along the outboard
-        # direction
+        """
+        Horizontal detector orientation expressed in the frame of xrayutilities.
+
+        We look at the detector from downstream, detector X is along the outboard
+        direction. The frame convention of xrayutilities is the following: x downstream,
+        y outboard, z vertical up.
+
+        :return: "y+"
+        """
         return "y+"
 
     @property
     def detector_ver(self):
-        # origin is at the top, detector Y along vertical down
+        """
+        Vertical detector orientation expressed in the frame of xrayutilities.
+
+        The origin is at the top, detector Y along vertical down. The frame
+        convention of xrayutilities is the following: x downstream, y outboard,
+        z vertical up.
+
+        :return: "z-"
+        """
         return "z-"
 
     @staticmethod
@@ -919,13 +964,28 @@ class BeamlineP10(Beamline):
 
     @property
     def detector_hor(self):
-        # we look at the detector from upstream, detector X is opposite to the outboard
-        # direction
+        """
+        Horizontal detector orientation expressed in the frame of xrayutilities.
+
+        We look at the detector from upstream, detector X is opposite to the outboard
+        direction. The frame convention of xrayutilities is the following: x downstream,
+        y outboard, z vertical up.
+
+        :return: "y-"
+        """
         return "y-"
 
     @property
     def detector_ver(self):
-        # origin is at the top, detector Y along vertical down
+        """
+        Vertical detector orientation expressed in the frame of xrayutilities.
+
+        The origin is at the top, detector Y along vertical down. The frame
+        convention of xrayutilities is the following: x downstream, y outboard,
+        z vertical up.
+
+        :return: "z-"
+        """
         return "z-"
 
     @staticmethod
@@ -1190,13 +1250,28 @@ class BeamlineSIXS(Beamline):
 
     @property
     def detector_hor(self):
-        # we look at the detector from downstream, detector X is along the outboard
-        # direction
+        """
+        Horizontal detector orientation expressed in the frame of xrayutilities.
+
+        We look at the detector from downstream, detector X is along the outboard
+        direction. The frame convention of xrayutilities is the following: x downstream,
+        y outboard, z vertical up.
+
+        :return: "y+"
+        """
         return "y+"
 
     @property
     def detector_ver(self):
-        # origin is at the top, detector Y along vertical down
+        """
+        Vertical detector orientation expressed in the frame of xrayutilities.
+
+        The origin is at the top, detector Y along vertical down. The frame
+        convention of xrayutilities is the following: x downstream, y outboard,
+        z vertical up.
+
+        :return: "z-"
+        """
         return "z-"
 
     @staticmethod
@@ -1385,13 +1460,28 @@ class Beamline34ID(Beamline):
 
     @property
     def detector_hor(self):
-        # we look at the detector from upstream, detector X is opposite to the outboard
-        # direction
+        """
+        Horizontal detector orientation expressed in the frame of xrayutilities.
+
+        We look at the detector from upstream, detector X is opposite to the outboard
+        direction. The frame convention of xrayutilities is the following: x downstream,
+        y outboard, z vertical up.
+
+        :return: "y-"
+        """
         return "y-"
 
     @property
     def detector_ver(self):
-        # origin is at the top, detector Y along vertical down
+        """
+        Vertical detector orientation expressed in the frame of xrayutilities.
+
+        The origin is at the top, detector Y along vertical down. The frame
+        convention of xrayutilities is the following: x downstream, y outboard,
+        z vertical up.
+
+        :return: "z-"
+        """
         return "z-"
 
     @staticmethod

--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -1607,7 +1607,6 @@ class BeamlineSIXS(Beamline):
         else:
             specfile = specfile_name
 
-        template_imagefile = template_imagefile
         return homedir, default_dirname, specfile, template_imagefile
 
     def inplane_coeff(self, diffractometer):

--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -109,19 +109,16 @@ class Beamline(ABC):
 
     @staticmethod
     @abstractmethod
-    def exit_wavevector(params):
+    def exit_wavevector(wavelength, inplane_angle, outofplane_angle):
         """
         Calculate the exit wavevector kout.
 
         It uses the setup parameters. kout is expressed in 1/m in the
         laboratory frame (z downstream, y vertical, x outboard).
 
-        :param params: dictionnary of the setup parameters including the following keys:
-
-          - 'wavelength_m': X-ray wavelength in meters.
-          - 'inplane_angle': horizontal detector angle, in degrees.
-          - 'outofplane_angle': vertical detector angle, in degrees.
-
+        :param wavelength: float, X-ray wavelength in meters.
+        :param inplane_angle: float, horizontal detector angle, in degrees.
+        :param outofplane_angle: float, vertical detector angle, in degrees.
         :return: kout vector as a numpy array of shape (3)
         """
 
@@ -269,19 +266,29 @@ class BeamlineCRISTAL(Beamline):
         return "z-"
 
     @staticmethod
-    def exit_wavevector(params):
-        # gamma is anti-clockwise
+    def exit_wavevector(wavelength, inplane_angle, outofplane_angle):
+        """
+        Calculate the exit wavevector kout at CRISTAL.
+
+        gamma is anti-clockwise. kout is expressed in 1/m in the
+        laboratory frame (z downstream, y vertical, x outboard).
+
+        :param wavelength: float, X-ray wavelength in meters.
+        :param inplane_angle: float, horizontal detector angle, in degrees.
+        :param outofplane_angle: float, vertical detector angle, in degrees.
+        :return: kout vector as a numpy array of shape (3)
+        """
         kout = (
             2
             * np.pi
-            / params["wavelength_m"]
+            / wavelength
             * np.array(
                 [
-                    np.cos(np.pi * params["inplane_angle"] / 180)
-                    * np.cos(np.pi * params["outofplane_angle"] / 180),  # z
-                    np.sin(np.pi * params["outofplane_angle"] / 180),  # y
-                    np.sin(np.pi * params["inplane_angle"] / 180)
-                    * np.cos(np.pi * params["outofplane_angle"] / 180),  # x
+                    np.cos(np.pi * inplane_angle / 180)
+                    * np.cos(np.pi * outofplane_angle / 180),  # z
+                    np.sin(np.pi * outofplane_angle / 180),  # y
+                    np.sin(np.pi * inplane_angle / 180)
+                    * np.cos(np.pi * outofplane_angle / 180),  # x
                 ]
             )
         )
@@ -479,19 +486,29 @@ class BeamlineID01(Beamline):
         return "z-"
 
     @staticmethod
-    def exit_wavevector(params):
-        # nu is clockwise
+    def exit_wavevector(wavelength, inplane_angle, outofplane_angle):
+        """
+        Calculate the exit wavevector kout at ID01.
+
+        nu is clockwise. kout is expressed in 1/m in the
+        laboratory frame (z downstream, y vertical, x outboard).
+
+        :param wavelength: float, X-ray wavelength in meters.
+        :param inplane_angle: float, horizontal detector angle, in degrees.
+        :param outofplane_angle: float, vertical detector angle, in degrees.
+        :return: kout vector as a numpy array of shape (3)
+        """
         kout = (
             2
             * np.pi
-            / params["wavelength_m"]
+            / wavelength
             * np.array(
                 [
-                    np.cos(np.pi * params["inplane_angle"] / 180)
-                    * np.cos(np.pi * params["outofplane_angle"] / 180),  # z
-                    np.sin(np.pi * params["outofplane_angle"] / 180),  # y
-                    -np.sin(np.pi * params["inplane_angle"] / 180)
-                    * np.cos(np.pi * params["outofplane_angle"] / 180),  # x
+                    np.cos(np.pi * inplane_angle / 180)
+                    * np.cos(np.pi * outofplane_angle / 180),  # z
+                    np.sin(np.pi * outofplane_angle / 180),  # y
+                    -np.sin(np.pi * inplane_angle / 180)
+                    * np.cos(np.pi * outofplane_angle / 180),  # x
                 ]
             )
         )
@@ -691,19 +708,29 @@ class BeamlineNANOMAX(Beamline):
         return "z-"
 
     @staticmethod
-    def exit_wavevector(params):
-        # gamma is clockwise
+    def exit_wavevector(wavelength, inplane_angle, outofplane_angle):
+        """
+        Calculate the exit wavevector kout at Nanomax.
+
+        gamma is clockwise. kout is expressed in 1/m in the
+        laboratory frame (z downstream, y vertical, x outboard).
+
+        :param wavelength: float, X-ray wavelength in meters.
+        :param inplane_angle: float, horizontal detector angle, in degrees.
+        :param outofplane_angle: float, vertical detector angle, in degrees.
+        :return: kout vector as a numpy array of shape (3)
+        """
         kout = (
             2
             * np.pi
-            / params["wavelength_m"]
+            / wavelength
             * np.array(
                 [
-                    np.cos(np.pi * params["inplane_angle"] / 180)
-                    * np.cos(np.pi * params["outofplane_angle"] / 180),  # z
-                    np.sin(np.pi * params["outofplane_angle"] / 180),  # y
-                    -np.sin(np.pi * params["inplane_angle"] / 180)
-                    * np.cos(np.pi * params["outofplane_angle"] / 180),  # x
+                    np.cos(np.pi * inplane_angle / 180)
+                    * np.cos(np.pi * outofplane_angle / 180),  # z
+                    np.sin(np.pi * outofplane_angle / 180),  # y
+                    -np.sin(np.pi * inplane_angle / 180)
+                    * np.cos(np.pi * outofplane_angle / 180),  # x
                 ]
             )
         )
@@ -902,19 +929,29 @@ class BeamlineP10(Beamline):
         return "z-"
 
     @staticmethod
-    def exit_wavevector(params):
-        # gamma is anti-clockwise
+    def exit_wavevector(wavelength, inplane_angle, outofplane_angle):
+        """
+        Calculate the exit wavevector kout at P10.
+
+        gamma is anti-clockwise. kout is expressed in 1/m in the
+        laboratory frame (z downstream, y vertical, x outboard).
+
+        :param wavelength: float, X-ray wavelength in meters.
+        :param inplane_angle: float, horizontal detector angle, in degrees.
+        :param outofplane_angle: float, vertical detector angle, in degrees.
+        :return: kout vector as a numpy array of shape (3)
+        """
         kout = (
             2
             * np.pi
-            / params["wavelength_m"]
+            / wavelength
             * np.array(
                 [
-                    np.cos(np.pi * params["inplane_angle"] / 180)
-                    * np.cos(np.pi * params["outofplane_angle"] / 180),  # z
-                    np.sin(np.pi * params["outofplane_angle"] / 180),  # y
-                    np.sin(np.pi * params["inplane_angle"] / 180)
-                    * np.cos(np.pi * params["outofplane_angle"] / 180),  # x
+                    np.cos(np.pi * inplane_angle / 180)
+                    * np.cos(np.pi * outofplane_angle / 180),  # z
+                    np.sin(np.pi * outofplane_angle / 180),  # y
+                    np.sin(np.pi * inplane_angle / 180)
+                    * np.cos(np.pi * outofplane_angle / 180),  # x
                 ]
             )
         )
@@ -1163,19 +1200,29 @@ class BeamlineSIXS(Beamline):
         return "z-"
 
     @staticmethod
-    def exit_wavevector(params):
-        # gamma is anti-clockwise
+    def exit_wavevector(wavelength, inplane_angle, outofplane_angle):
+        """
+        Calculate the exit wavevector kout at SIXS.
+
+        gamma is anti-clockwise. kout is expressed in 1/m in the
+        laboratory frame (z downstream, y vertical, x outboard).
+
+        :param wavelength: float, X-ray wavelength in meters.
+        :param inplane_angle: float, horizontal detector angle, in degrees.
+        :param outofplane_angle: float, vertical detector angle, in degrees.
+        :return: kout vector as a numpy array of shape (3)
+        """
         kout = (
             2
             * np.pi
-            / params["wavelength_m"]
+            / wavelength
             * np.array(
                 [
-                    np.cos(np.pi * params["inplane_angle"] / 180)
-                    * np.cos(np.pi * params["outofplane_angle"] / 180),  # z
-                    np.sin(np.pi * params["outofplane_angle"] / 180),  # y
-                    np.sin(np.pi * params["inplane_angle"] / 180)
-                    * np.cos(np.pi * params["outofplane_angle"] / 180),  # x
+                    np.cos(np.pi * inplane_angle / 180)
+                    * np.cos(np.pi * outofplane_angle / 180),  # z
+                    np.sin(np.pi * outofplane_angle / 180),  # y
+                    np.sin(np.pi * inplane_angle / 180)
+                    * np.cos(np.pi * outofplane_angle / 180),  # x
                 ]
             )
         )
@@ -1348,19 +1395,29 @@ class Beamline34ID(Beamline):
         return "z-"
 
     @staticmethod
-    def exit_wavevector(params):
-        # gamma is anti-clockwise
+    def exit_wavevector(wavelength, inplane_angle, outofplane_angle):
+        """
+        Calculate the exit wavevector kout at 34ID-C.
+
+        gamma is anti-clockwise. kout is expressed in 1/m in the
+        laboratory frame (z downstream, y vertical, x outboard).
+
+        :param wavelength: float, X-ray wavelength in meters.
+        :param inplane_angle: float, horizontal detector angle, in degrees.
+        :param outofplane_angle: float, vertical detector angle, in degrees.
+        :return: kout vector as a numpy array of shape (3)
+        """
         kout = (
             2
             * np.pi
-            / params["wavelength_m"]
+            / wavelength
             * np.array(
                 [
-                    np.cos(np.pi * params["inplane_angle"] / 180)
-                    * np.cos(np.pi * params["outofplane_angle"] / 180),  # z
-                    np.sin(np.pi * params["outofplane_angle"] / 180),  # y
-                    np.sin(np.pi * params["inplane_angle"] / 180)
-                    * np.cos(np.pi * params["outofplane_angle"] / 180),  # x
+                    np.cos(np.pi * inplane_angle / 180)
+                    * np.cos(np.pi * outofplane_angle / 180),  # z
+                    np.sin(np.pi * outofplane_angle / 180),  # y
+                    np.sin(np.pi * inplane_angle / 180)
+                    * np.cos(np.pi * outofplane_angle / 180),  # x
                 ]
             )
         )

--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -1332,7 +1332,8 @@ class Beamline34ID(Beamline):
         super().__init__(name=name)
 
     @staticmethod
-    def create_logfile(params):
+    def create_logfile(**kwargs):
+        """Method not implemented."""
         raise NotImplementedError("create_logfile method not implemented for 34ID")
 
     @property

--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -10,7 +10,8 @@
 """
 Beamline-related classes.
 
-The methods in child classes have the same signature as in the base class. The available
+These classes are not meant to be instantiated directly but via a Setup instance. The
+methods in child classes have the same signature as in the base class. The available
 beamlines are:
 
 - BeamlineID01

--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -129,11 +129,11 @@ class Beamline(ABC):
 
     @staticmethod
     @abstractmethod
-    def init_paths(params):
+    def init_paths(**kwargs):
         """
         Initialize paths used for data processing and logging.
 
-        :param params: dictionnary of the setup parameters including the following keys:
+        :param kwargs: dictionnary of the setup parameters including the following keys:
 
          - 'sample_name': string in front of the scan number in the data folder
            name.
@@ -319,17 +319,26 @@ class BeamlineCRISTAL(Beamline):
         return kout
 
     @staticmethod
-    def init_paths(params):
-        homedir = (
-            params["root_folder"]
-            + params["sample_name"]
-            + str(params["scan_number"])
-            + "/"
-        )
+    def init_paths(root_folder, sample_name, scan_number, template_imagefile, **kwargs):
+        """
+        Initialize paths used for data processing and logging at CRISTAL.
+
+        :param root_folder: folder of the experiment, where all scans are stored
+        :param sample_name: string in front of the scan number in the data folder
+         name.
+        :param scan_number: int, the scan number
+        :param template_imagefile: template for the data files, e.g. 'S%d.nxs'
+        :return: a tuple of strings:
+
+         - homedir: the path of the scan folder
+         - default_dirname: the name of the folder containing images / raw data
+         - specfile: the name of the specfile if it exists
+         - template_imagefile: the template for data/image file names
+
+        """
+        homedir = (root_folder + sample_name + str(scan_number) + "/")
         default_dirname = "data/"
-        specfile = params["specfile_name"]
-        template_imagefile = params["template_imagefile"]
-        return homedir, default_dirname, specfile, template_imagefile
+        return homedir, default_dirname, "", template_imagefile
 
     def inplane_coeff(self, diffractometer):
         """
@@ -578,17 +587,29 @@ class BeamlineID01(Beamline):
         return kout
 
     @staticmethod
-    def init_paths(params):
-        homedir = (
-            params["root_folder"]
-            + params["sample_name"]
-            + str(params["scan_number"])
-            + "/"
-        )
+    def init_paths(root_folder, sample_name, scan_number, specfile_name,
+                   template_imagefile, **kwargs):
+        """
+        Initialize paths used for data processing and logging at ID01.
+
+        :param root_folder: folder of the experiment, where all scans are stored
+        :param sample_name: string in front of the scan number in the data folder
+         name.
+        :param scan_number: int, the scan number
+        :param specfile_name: name of the spec file without '.spec'
+        :param template_imagefile: template for the data files, e.g.
+         'data_mpx4_%05d.edf.gz' or 'align_eiger2M_%05d.edf.gz'
+        :return: a tuple of strings:
+
+         - homedir: the path of the scan folder
+         - default_dirname: the name of the folder containing images / raw data
+         - specfile: the name of the specfile if it exists
+         - template_imagefile: the template for data/image file names
+
+        """
+        homedir = (root_folder + sample_name + str(scan_number) + "/")
         default_dirname = "data/"
-        specfile = params["specfile_name"]
-        template_imagefile = params["template_imagefile"]
-        return homedir, default_dirname, specfile, template_imagefile
+        return homedir, default_dirname, specfile_name, template_imagefile
 
     def inplane_coeff(self, diffractometer):
         """
@@ -839,17 +860,26 @@ class BeamlineNANOMAX(Beamline):
         return kout
 
     @staticmethod
-    def init_paths(params):
-        homedir = (
-            params["root_folder"]
-            + params["sample_name"]
-            + "{:06d}".format(params["scan_number"])
-            + "/"
-        )
+    def init_paths(root_folder, sample_name, scan_number, template_imagefile, **kwargs):
+        """
+        Initialize paths used for data processing and logging at Nanomax.
+
+        :param root_folder: folder of the experiment, where all scans are stored
+        :param sample_name: string in front of the scan number in the data folder
+         name.
+        :param scan_number: int, the scan number
+        :param template_imagefile: template for the data files, e.g. '%06d.h5'
+        :return: a tuple of strings:
+
+         - homedir: the path of the scan folder
+         - default_dirname: the name of the folder containing images / raw data
+         - specfile: the name of the specfile if it exists
+         - template_imagefile: the template for data/image file names
+
+        """
+        homedir = (root_folder + sample_name + "{:06d}".format(scan_number) + "/")
         default_dirname = "data/"
-        specfile = params["specfile_name"]
-        template_imagefile = params["template_imagefile"]
-        return homedir, default_dirname, specfile, template_imagefile
+        return homedir, default_dirname, "", template_imagefile
 
     def inplane_coeff(self, diffractometer):
         """
@@ -1099,11 +1129,28 @@ class BeamlineP10(Beamline):
         return kout
 
     @staticmethod
-    def init_paths(params):
-        specfile = params["sample_name"] + "_{:05d}".format(params["scan_number"])
-        homedir = params["root_folder"] + specfile + "/"
+    def init_paths(root_folder, sample_name, scan_number, template_imagefile, **kwargs):
+        """
+        Initialize paths used for data processing and logging at P10.
+
+        :param root_folder: folder of the experiment, where all scans are stored
+        :param sample_name: string in front of the scan number in the data folder
+         name.
+        :param scan_number: int, the scan number
+        :param template_imagefile: template for the data files, e.g. '_master.h5'
+        :return: a tuple of strings:
+
+         - homedir: the path of the scan folder
+         - default_dirname: the name of the folder containing images / raw data
+         - specfile: the name of the specfile if it exists
+         - template_imagefile: the template for data/image file names
+
+        """
+
+        specfile = sample_name + "_{:05d}".format(scan_number)
+        homedir = root_folder + specfile + "/"
         default_dirname = "e4m/"
-        template_imagefile = specfile + params["template_imagefile"]
+        template_imagefile = specfile + template_imagefile
         return homedir, default_dirname, specfile, template_imagefile
 
     def inplane_coeff(self, diffractometer):
@@ -1409,16 +1456,32 @@ class BeamlineSIXS(Beamline):
         return kout
 
     @staticmethod
-    def init_paths(params):
-        homedir = (
-            params["root_folder"]
-            + params["sample_name"]
-            + str(params["scan_number"])
-            + "/"
-        )
+    def init_paths(root_folder, sample_name, scan_number, specfile_name,
+                   template_imagefile, **kwargs):
+        """
+        Initialize paths used for data processing and logging at SIXS.
+
+        :param root_folder: folder of the experiment, where all scans are stored
+        :param sample_name: string in front of the scan number in the data folder
+         name.
+        :param scan_number: int, the scan number
+        :param specfile_name: None or full path of the alias dictionnary (e.g.
+         root_folder+'alias_dict_2019.txt')
+        :param template_imagefile: template for the data files, e.g.
+         'align.spec_ascan_mu_%05d.nxs' (SIXS_2018), 'spare_ascan_mu_%05d.nxs'
+         (SIXS_2019).
+        :return: a tuple of strings:
+
+         - homedir: the path of the scan folder
+         - default_dirname: the name of the folder containing images / raw data
+         - specfile: the name of the specfile if it exists
+         - template_imagefile: the template for data/image file names
+
+        """
+        homedir = (root_folder + sample_name + str(scan_number) + "/")
         default_dirname = "data/"
 
-        if params["specfile_name"] is None:
+        if specfile_name is None:
             # default to the alias dictionnary located within the package
             specfile = os.path.abspath(
                 os.path.join(
@@ -1428,9 +1491,9 @@ class BeamlineSIXS(Beamline):
                 )
             )
         else:
-            specfile = params["specfile_name"]
+            specfile = specfile_name
 
-        template_imagefile = params["template_imagefile"]
+        template_imagefile = template_imagefile
         return homedir, default_dirname, specfile, template_imagefile
 
     @property
@@ -1644,17 +1707,27 @@ class Beamline34ID(Beamline):
         return kout
 
     @staticmethod
-    def init_paths(params):
-        homedir = (
-            params["root_folder"]
-            + params["sample_name"]
-            + str(params["scan_number"])
-            + "/"
-        )
+    def init_paths(root_folder, sample_name, scan_number, template_imagefile, **kwargs):
+        """
+        Initialize paths used for data processing and logging at SIXS.
+
+        :param root_folder: folder of the experiment, where all scans are stored
+        :param sample_name: string in front of the scan number in the data folder
+         name.
+        :param scan_number: int, the scan number
+        :param template_imagefile: template for the data files, e.g.
+         'Sample%dC_ES_data_51_256_256.npz'.
+        :return: a tuple of strings:
+
+         - homedir: the path of the scan folder
+         - default_dirname: the name of the folder containing images / raw data
+         - specfile: the name of the specfile if it exists
+         - template_imagefile: the template for data/image file names
+
+        """
+        homedir = (root_folder + sample_name + str(scan_number) + "/")
         default_dirname = "data/"
-        specfile = params["specfile_name"]
-        template_imagefile = params["template_imagefile"]
-        return homedir, default_dirname, specfile, template_imagefile
+        return homedir, default_dirname, "", template_imagefile
 
     def inplane_coeff(self, diffractometer):
         # 

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -7,7 +7,22 @@
 #       authors:
 #         Jerome Carnis, carnis_jerome@yahoo.fr
 
-"""Diffractometer class."""
+"""
+Beamline-related diffractometer classes.
+
+These classes are not meant to be instantiated directly but via a Setup instance. The
+methods in child classes have the same signature as in the base class. The available
+beamlines are:
+
+- DiffractometerID01
+- DiffractometerSIXS
+- Diffractometer34ID
+- DiffractometerP10
+- DiffractometerCRISTAL
+- DiffractometerNANOMAX
+
+"""
+
 from abc import ABC, abstractmethod
 from functools import reduce
 from numbers import Number, Real

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -12,7 +12,7 @@ Beamline-related diffractometer classes.
 
 These classes are not meant to be instantiated directly but via a Setup instance. The
 methods in child classes have the same signature as in the base class. The available
-beamlines are:
+diffractometers are:
 
 - DiffractometerID01
 - DiffractometerSIXS

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -42,7 +42,7 @@ def create_diffractometer(beamline, sample_offsets):
     if beamline == "NANOMAX":
         return DiffractometerNANOMAX(sample_offsets)
     raise NotImplementedError(
-        "No diffractometer implemented for the " f"beamline {sample_offsets}"
+        f"No diffractometer implemented for the beamline {beamline}"
     )
 
 

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -502,7 +502,7 @@ class Setup:
 
         :return: +1 or -1
         """
-        return self._beamline.inplane_coeff
+        return self._beamline.inplane_coeff(self.diffractometer)
 
     @property
     def outofplane_angle(self):

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -525,7 +525,7 @@ class Setup:
 
         :return: +1 or -1
         """
-        return self._beamline.outofplane_coeff
+        return self._beamline.outofplane_coeff(self.diffractometer)
 
     @property
     def params(self):

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -850,24 +850,22 @@ class Setup:
             self.detector.template_file,
         ) = (root_folder, sample_name, template_imagefile)
 
-        params = {
-            "sample_name": sample_name,
-            "scan_number": scan_number,
-            "root_folder": root_folder,
-            "save_dir": save_dir,
-            "specfile_name": specfile_name,
-            "template_imagefile": template_imagefile,
-            "data_dirname": data_dirname,
-            "save_dirname": save_dirname,
-        }
-
         # create beamline-dependent path parameters
         (
             homedir,
             default_dirname,
             specfile,
             template_imagefile,
-        ) = self._beamline.init_paths(params)
+        ) = self._beamline.init_paths(
+            sample_name=sample_name,
+            scan_number=scan_number,
+            root_folder=root_folder,
+            save_dir=save_dir,
+            specfile_name=specfile_name,
+            template_imagefile=template_imagefile,
+            data_dirname=data_dirname,
+            save_dirname=save_dirname,
+        )
 
         # define the data directory
         if data_dirname is not None:

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -73,6 +73,16 @@ class Setup:
        of data keeps changing)
 
     """
+    labframe_to_xrayutil = {
+        "x+": "y+",
+        "x-": "y-",
+        "y+": "z+",
+        "y-": "z-",
+        "z+": "x+",
+        "z-": "x-",
+    }  # conversion table from the laboratory frame (CXI convention)
+    # (z downstream, y vertical up, x outboard) to the frame of xrayutilities
+    # (x downstream, y outboard, z vertical up)
 
     def __init__(
         self,
@@ -186,7 +196,7 @@ class Setup:
     @property
     def beam_direction_xrutils(self):
         """
-        Direction of the incident X-ray beam.
+        Direction of the incident X-ray beam in xrayutilities frame.
 
         xrayutilities frame convention: (x downstream, y outboard, z vertical up).
         """
@@ -304,28 +314,31 @@ class Setup:
         self._detector = value
 
     @property
-    def detector_hor(self):
+    def detector_hor_xrutil(self):
         """
-        Expose the detector_hor beamline property to the outer world.
+        Convert the detector horizontal orientation to xrayutilities frame.
 
-        This is beamline-dependent. The frame convention of xrayutilities is the
-        following: x downstream, y outboard, z vertical up.
+        The laboratory frame convention is (z downstream, y vertical, x outboard).
+        The frame convention of xrayutilities is (x downstream, y outboard,
+        z vertical up).
 
-        :return: "y+" or "y-" depending on the detector horizontal orientation
+        :return: "x+" or "x-" depending on the detector horizontal orientation
         """
-        return self._beamline.detector_hor
+        return self.labframe_to_xrayutil[self._beamline.detector_hor]
 
     @property
-    def detector_ver(self):
+    def detector_ver_xrutil(self):
         """
-        Expose the detector_ver beamline property to the outer world.
+        Convert the detector vertical orientation to xrayutilities frame.
 
-        This is beamline-dependent. The frame convention of xrayutilities is the
-        following: x downstream, y outboard, z vertical up.
+        The laboratory frame convention is (z downstream, y vertical, x outboard).
+        The frame convention of xrayutilities is (x downstream, y outboard,
+        z vertical up).
 
         :return: "z+" or "z-" depending on the detector vertical orientation
         """
-        return self._beamline.detector_ver
+
+        return self.labframe_to_xrayutil[self._beamline.detector_ver]
 
     @property
     def diffractometer(self):

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -404,12 +404,11 @@ class Setup:
 
         :return: kout vector
         """
-        params = {
-            "inplane_angle": self.inplane_angle,
-            "outofplane_angle": self.outofplane_angle,
-            "wavelength_m": self.wavelength,
-        }
-        return self._beamline.exit_wavevector(params=params)
+        return self._beamline.exit_wavevector(
+            inplane_angle=self.inplane_angle,
+            outofplane_angle=self.outofplane_angle,
+            wavelength=self.wavelength,
+        )
 
     @property
     def filtered_data(self):

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -644,14 +644,13 @@ class Setup:
         :param filename: the file name to load, or the path of 'alias_dict.txt' for SIXS
         :return: logfile
         """
-        params = {
-            "scan_number": scan_number,
-            "root_folder": root_folder,
-            "filename": filename,
-            "datadir": self.detector.datadir,
-            "template_imagefile": self.detector.template_imagefile,
-        }
-        return self._beamline.create_logfile(params=params)
+        return self._beamline.create_logfile(
+            scan_number=scan_number,
+            root_folder=root_folder,
+            filename=filename,
+            datadir=self.detector.datadir,
+            template_imagefile=self.detector.template_imagefile,
+            )
 
     def detector_frame(
         self,

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -1858,20 +1858,17 @@ class Setup:
         ###########################################################
         # calculate the transformation matrix in reciprocal space #
         ###########################################################
-        params = {
-            "wavelength": wavelength,
-            "distance": distance,
-            "pixel_x": pixel_x,
-            "pixel_y": pixel_y,
-            "inplane": inplane,
-            "outofplane": outofplane,
-            "grazing_angle": grazing_angle,
-            "rocking_angle": self.rocking_angle,
-            "tilt": tilt,
-        }
-
         mymatrix, q_offset = self._beamline.transformation_matrix(
-            params, verbose=verbose
+            wavelength=wavelength,
+            distance=distance,
+            pixel_x=pixel_x,
+            pixel_y=pixel_y,
+            inplane=inplane,
+            outofplane=outofplane,
+            grazing_angle=grazing_angle,
+            rocking_angle=self.rocking_angle,
+            tilt=tilt,
+            verbose=verbose
         )
 
         ###############################################################

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -73,6 +73,7 @@ class Setup:
        of data keeps changing)
 
     """
+
     labframe_to_xrayutil = {
         "x+": "y+",
         "x-": "y-",
@@ -337,7 +338,6 @@ class Setup:
 
         :return: "z+" or "z-" depending on the detector vertical orientation
         """
-
         return self.labframe_to_xrayutil[self._beamline.detector_ver]
 
     @property
@@ -662,7 +662,7 @@ class Setup:
             filename=filename,
             datadir=self.detector.datadir,
             template_imagefile=self.detector.template_imagefile,
-            )
+        )
 
     def detector_frame(
         self,
@@ -1881,7 +1881,7 @@ class Setup:
             grazing_angle=grazing_angle,
             rocking_angle=self.rocking_angle,
             tilt=tilt,
-            verbose=verbose
+            verbose=verbose,
         )
 
         ###############################################################

--- a/bcdi/preprocessing/preprocessing_utils.py
+++ b/bcdi/preprocessing/preprocessing_utils.py
@@ -1562,61 +1562,6 @@ def check_pixels(data, mask, debugging=False):
     return data, mask
 
 
-def create_logfile(setup, detector, scan_number, root_folder, filename):
-    """
-    Create the logfile used in gridmap().
-
-    :param setup: the experimental setup: Class SetupPreprocessing()
-    :param detector: the detector object: Class experiment_utils.Detector()
-    :param scan_number: the scan number to load
-    :param root_folder: the root directory of the experiment,
-     where is the specfile/.fio file
-    :param filename: the file name to load, or the path of 'alias_dict.txt' for SIXS
-    :return: logfile
-    """
-    logfile = ""
-
-    if setup.beamline == "CRISTAL":  # no specfile, load directly the dataset
-        ccdfiletmp = os.path.join(
-            detector.datadir + detector.template_imagefile % scan_number
-        )
-        logfile = h5py.File(ccdfiletmp, "r")
-
-    elif setup.beamline == "P10":  # load .fio file
-        logfile = root_folder + filename + "/" + filename + ".fio"
-
-    elif setup.beamline == "SIXS_2018":  # no specfile, load directly the dataset
-        import bcdi.preprocessing.nxsReady as nxsReady
-
-        logfile = nxsReady.DataSet(
-            longname=detector.datadir + detector.template_imagefile % scan_number,
-            shortname=detector.template_imagefile % scan_number,
-            alias_dict=filename,
-            scan="SBS",
-        )
-    elif setup.beamline == "SIXS_2019":  # no specfile, load directly the dataset
-        import bcdi.preprocessing.ReadNxs3 as ReadNxs3
-
-        logfile = ReadNxs3.DataSet(
-            directory=detector.datadir,
-            filename=detector.template_imagefile % scan_number,
-            alias_dict=filename,
-        )
-
-    elif setup.beamline == "ID01":  # load spec file
-        from silx.io.specfile import SpecFile
-
-        logfile = SpecFile(root_folder + filename + ".spec")
-
-    elif setup.beamline == "NANOMAX":
-        ccdfiletmp = os.path.join(
-            detector.datadir + detector.template_imagefile % scan_number
-        )
-        logfile = h5py.File(ccdfiletmp, "r")
-
-    return logfile
-
-
 def cristal_find_detector(
     datafile,
     setup,
@@ -1893,6 +1838,7 @@ def find_bragg(data, peak_method):
 
 
 def get_motor_pos(logfile, scan_number, setup, motor_name):
+    # TODO: this one should go to diffractometer child classes
     """
     Load the scan data and extract motor positions.
 

--- a/doc/modules/experiment/index.rst
+++ b/doc/modules/experiment/index.rst
@@ -17,7 +17,7 @@ beamline
 ^^^^^^^^
 
 .. automodule:: bcdi.experiment.beamline
-   :members: create_beamline, Beamline
+   :members:
 
 detector
 ^^^^^^^^

--- a/scripts/preprocessing/bcdi_preprocess_BCDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_BCDI.py
@@ -867,8 +867,8 @@ for scan_idx, scan_nb in enumerate(scans, start=1):
                 )
                 # detector init_area method, pixel sizes are the binned ones
                 hxrd.Ang2Q.init_area(
-                    setup.detector_ver,
-                    setup.detector_hor,
+                    setup.detector_ver_xrutil,
+                    setup.detector_hor_xrutil,
                     cch1=cch1,
                     cch2=cch2,
                     Nch1=nch1,

--- a/tests/experiment/test_beamline.py
+++ b/tests/experiment/test_beamline.py
@@ -45,10 +45,10 @@ class TestBeamlineCRISTAL(fake_filesystem_unittest.TestCase):
         self.diffractometer = DiffractometerCRISTAL(sample_offsets=(0, 0))
 
     def test_detector_hor(self):
-        self.assertTrue(self.beamline.detector_hor == "y+")
+        self.assertTrue(self.beamline.detector_hor == "x+")
 
     def test_detector_ver(self):
-        self.assertTrue(self.beamline.detector_ver == "z-")
+        self.assertTrue(self.beamline.detector_ver == "y-")
 
     def test_exit_wavevector(self):
         params = {

--- a/tests/experiment/test_beamline.py
+++ b/tests/experiment/test_beamline.py
@@ -53,12 +53,11 @@ class TestBeamlineCRISTAL(fake_filesystem_unittest.TestCase):
         params = {
             "inplane_angle": 0.0,
             "outofplane_angle": 90.0,
-            "wavelength_m": 2 * np.pi,
+            "wavelength": 2 * np.pi,
         }
-        print(self.beamline.exit_wavevector(params))
         self.assertTrue(
             np.allclose(
-                self.beamline.exit_wavevector(params),
+                self.beamline.exit_wavevector(**params),
                 np.array([0.0, 1.0, 0.0]),
                 rtol=1e-09,
                 atol=1e-09,

--- a/tests/experiment/test_beamline.py
+++ b/tests/experiment/test_beamline.py
@@ -12,7 +12,7 @@ import os
 from pyfakefs import fake_filesystem_unittest
 import unittest
 from bcdi.experiment.beamline import create_beamline, Beamline
-
+from bcdi.experiment.diffractometer import DiffractometerCRISTAL
 
 def run_tests(test_class):
     suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
@@ -42,6 +42,7 @@ class TestBeamlineCRISTAL(fake_filesystem_unittest.TestCase):
         with open(datadir + "test.nxs", "w") as f:
             f.write("dummy")
         self.beamline = create_beamline("CRISTAL")
+        self.diffractometer = DiffractometerCRISTAL(sample_offsets=(0, 0))
 
     def test_detector_hor(self):
         self.assertTrue(self.beamline.detector_hor == "y+")
@@ -86,10 +87,10 @@ class TestBeamlineCRISTAL(fake_filesystem_unittest.TestCase):
         self.assertEqual(template_imagefile, self.sample_name + "%d.nxs")
 
     def test_inplane_coeff(self):
-        self.assertEqual(self.beamline.inplane_coeff, 1)
+        self.assertEqual(self.beamline.inplane_coeff(self.diffractometer), 1)
 
     def test_outofplane_coeff(self):
-        self.assertEqual(self.beamline.inplane_coeff, 1)
+        self.assertEqual(self.beamline.inplane_coeff(self.diffractometer), 1)
 
 
 if __name__ == "__main__":

--- a/tests/experiment/test_beamline.py
+++ b/tests/experiment/test_beamline.py
@@ -14,6 +14,7 @@ import unittest
 from bcdi.experiment.beamline import create_beamline, Beamline
 from bcdi.experiment.diffractometer import DiffractometerCRISTAL
 
+
 def run_tests(test_class):
     suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
     runner = unittest.TextTestRunner(verbosity=2)

--- a/tests/experiment/test_beamline.py
+++ b/tests/experiment/test_beamline.py
@@ -90,7 +90,7 @@ class TestBeamlineCRISTAL(fake_filesystem_unittest.TestCase):
         self.assertEqual(self.beamline.inplane_coeff(self.diffractometer), 1)
 
     def test_outofplane_coeff(self):
-        self.assertEqual(self.beamline.inplane_coeff(self.diffractometer), 1)
+        self.assertEqual(self.beamline.outofplane_coeff(self.diffractometer), 1)
 
 
 if __name__ == "__main__":

--- a/tests/experiment/test_beamline.py
+++ b/tests/experiment/test_beamline.py
@@ -78,7 +78,7 @@ class TestBeamlineCRISTAL(fake_filesystem_unittest.TestCase):
             default_dirname,
             specfile,
             template_imagefile,
-        ) = self.beamline.init_paths(params)
+        ) = self.beamline.init_paths(**params)
         self.assertEqual(
             homedir, self.root_dir + self.sample_name + str(self.scan_number) + "/"
         )


### PR DESCRIPTION
Instead of a single dictionary of parameters, use the explicit signature.

Remove all references to xrayutilities frame, use only the laboratory frame.

Use lookup dictionaries instead of hardcoding values in methods.

Update the doc