### PR TITLE
allow gridding d2scan in preprocessing

### DIFF
--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -359,9 +359,7 @@ class Beamline(ABC):
 
     @staticmethod
     @abstractmethod
-    def process_positions(
-        setup, logfile, nb_frames, scan_number, frames_logical=None, follow_bragg=False
-    ):
+    def process_positions(setup, logfile, nb_frames, scan_number, frames_logical=None):
         """
         Load and crop/pad motor positions depending on the current number of frames.
 
@@ -376,9 +374,6 @@ class Beamline(ABC):
          In case of cropping/padding the number of frames changes. A frame whose
          index is set to 1 means that it is used, 0 means not used, -1 means padded
          (added) frame
-        :param follow_bragg: True when in energy scans the detector was also scanned
-         to follow the Bragg peak
-
         :return: a tuple of 1D arrays (sample circles, detector circles, energy)
         """
 
@@ -543,7 +538,6 @@ class BeamlineCRISTAL(Beamline):
         nb_frames,
         scan_number,
         frames_logical=None,
-        follow_bragg=False,
     ):
         """
         Load and crop/pad motor positions depending on the number of frames at CRISTAL.
@@ -559,15 +553,12 @@ class BeamlineCRISTAL(Beamline):
          In case of cropping/padding the number of frames changes. A frame whose
          index is set to 1 means that it is used, 0 means not used, -1 means padded
          (added) frame
-        :param follow_bragg: True when in energy scans the detector was also scanned
-         to follow the Bragg peak
         :return: a tuple of 1D arrays (sample circles, detector circles, energy)
         """
         mgomega, mgphi, gamma, delta, energy = setup.diffractometer.motor_positions(
             setup=setup,
             logfile=logfile,
             scan_number=scan_number,
-            follow_bragg=follow_bragg,
         )
         # first, remove the motor positions corresponding to deleted frames during data
         # loading (frames_logical = 0)
@@ -860,7 +851,6 @@ class BeamlineID01(Beamline):
         nb_frames,
         scan_number,
         frames_logical=None,
-        follow_bragg=False,
     ):
         """
         Load and crop/pad motor positions depending on the number of frames at ID01.
@@ -876,15 +866,12 @@ class BeamlineID01(Beamline):
          In case of cropping/padding the number of frames changes. A frame whose
          index is set to 1 means that it is used, 0 means not used, -1 means padded
          (added) frame
-        :param follow_bragg: True when in energy scans the detector was also scanned
-         to follow the Bragg peak
         :return: a tuple of 1D arrays (sample circles, detector circles, energy)
         """
         mu, eta, phi, nu, delta, energy = setup.diffractometer.motor_positions(
             setup=setup,
             logfile=logfile,
             scan_number=scan_number,
-            follow_bragg=follow_bragg,
         )
         # first, remove the motor positions corresponding to deleted frames during data
         # loading (frames_logical = 0)
@@ -1176,7 +1163,6 @@ class BeamlineNANOMAX(Beamline):
         nb_frames,
         scan_number,
         frames_logical=None,
-        follow_bragg=False,
     ):
         """
         Load and crop/pad motor positions depending on the number of frames at NANOMAX.
@@ -1192,15 +1178,12 @@ class BeamlineNANOMAX(Beamline):
          In case of cropping/padding the number of frames changes. A frame whose
          index is set to 1 means that it is used, 0 means not used, -1 means padded
          (added) frame
-        :param follow_bragg: True when in energy scans the detector was also scanned
-         to follow the Bragg peak
         :return: a tuple of 1D arrays (sample circles, detector circles, energy)
         """
         theta, phi, gamma, delta, energy = setup.diffractometer.motor_positions(
             setup=setup,
             logfile=logfile,
             scan_number=scan_number,
-            follow_bragg=follow_bragg,
         )
         # first, remove the motor positions corresponding to deleted frames during data
         # loading (frames_logical = 0)
@@ -1488,7 +1471,6 @@ class BeamlineP10(Beamline):
         nb_frames,
         scan_number,
         frames_logical=None,
-        follow_bragg=False,
     ):
         """
         Load and crop/pad motor positions depending on the number of frames at P10.
@@ -1504,15 +1486,12 @@ class BeamlineP10(Beamline):
          In case of cropping/padding the number of frames changes. A frame whose
          index is set to 1 means that it is used, 0 means not used, -1 means padded
          (added) frame
-        :param follow_bragg: True when in energy scans the detector was also scanned
-         to follow the Bragg peak
         :return: a tuple of 1D arrays (sample circles, detector circles, energy)
         """
         mu, om, chi, phi, gamma, delta, energy = setup.diffractometer.motor_positions(
             setup=setup,
             logfile=logfile,
             scan_number=scan_number,
-            follow_bragg=follow_bragg,
         )
         # first, remove the motor positions corresponding to deleted frames during data
         # loading (frames_logical = 0)
@@ -2100,7 +2079,6 @@ class BeamlineSIXS(Beamline):
         nb_frames,
         scan_number,
         frames_logical=None,
-        follow_bragg=False,
     ):
         """
         Load and crop/pad motor positions depending on the number of frames at SIXS.
@@ -2116,15 +2094,12 @@ class BeamlineSIXS(Beamline):
          In case of cropping/padding the number of frames changes. A frame whose
          index is set to 1 means that it is used, 0 means not used, -1 means padded
          (added) frame
-        :param follow_bragg: True when in energy scans the detector was also scanned
-         to follow the Bragg peak
         :return: a tuple of 1D arrays (sample circles, detector circles, energy)
         """
         beta, mu, gamma, delta, energy = setup.diffractometer.motor_positions(
             setup=setup,
             logfile=logfile,
             scan_number=scan_number,
-            follow_bragg=follow_bragg,
         )
         # first, remove the motor positions corresponding to deleted frames during data
         # loading (frames_logical = 0)
@@ -2363,7 +2338,6 @@ class Beamline34ID(Beamline):
         nb_frames,
         scan_number,
         frames_logical=None,
-        follow_bragg=False,
     ):
         """
         Load and crop/pad motor positions depending on the number of frames at 34ID-C.
@@ -2379,15 +2353,12 @@ class Beamline34ID(Beamline):
          In case of cropping/padding the number of frames changes. A frame whose
          index is set to 1 means that it is used, 0 means not used, -1 means padded
          (added) frame
-        :param follow_bragg: True when in energy scans the detector was also scanned
-         to follow the Bragg peak
         :return: a tuple of 1D arrays (sample circles, detector circles, energy)
         """
         theta, phi, delta, gamma, energy = setup.diffractometer.motor_positions(
             setup=setup,
             logfile=logfile,
             scan_number=scan_number,
-            follow_bragg=follow_bragg,
         )
         # first, remove the motor positions corresponding to deleted frames during data
         # loading (frames_logical = 0)

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -1987,22 +1987,24 @@ class DiffractometerID01(Diffractometer):
             device_values = []
         return np.asarray(device_values)
 
-    def read_monitor(self, logfile, scan_number, **kwargs):
+    def read_monitor(self, logfile, scan_number, actuators, **kwargs):
         """
         Load the default monitor for a dataset measured at ID01.
 
         :param logfile: the logfile created in Setup.create_logfile()
         :param scan_number: int, the scan number to load
+        :param actuators: dictionary defining the entries corresponding to actuators
+         in the spec file
         :return: the default monitor values
         """
-        monitor = self.read_device(
-            logfile=logfile, scan_number=scan_number, device_name="mon2"
-        )
-        if len(monitor) == 0:
+        monitor_name = actuators.get("monitor")
+        if monitor_name is None:
             monitor = self.read_device(
-                logfile=logfile,
-                scan_number=scan_number,
-                device_name="exp1",  # exp1 for old data at ID01
+                logfile=logfile, scan_number=scan_number, device_name="exp1"
+            )
+        else:
+            monitor = self.read_device(
+                logfile=logfile, scan_number=scan_number, device_name=monitor_name
             )
         return monitor
 

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -1727,8 +1727,6 @@ class DiffractometerID01(Diffractometer):
         :param kwargs:
          - 'logfile': the logfile created in Setup.create_logfile()
          - 'scan_number': the scan number to load
-         - 'follow_bragg': boolean, True for energy scans where the detector position
-           is changed during the scan to follow the Bragg peak.
 
         :return: a tuple of angular values in degrees, depending on stage_name:
 
@@ -1744,8 +1742,6 @@ class DiffractometerID01(Diffractometer):
         # load kwargs
         logfile = kwargs["logfile"]
         scan_number = kwargs["scan_number"]
-        follow_bragg = kwargs.get("follow_bragg", False)
-        valid.valid_item(follow_bragg, allowed_types=bool, name="follow_bragg")
 
         # check some parameter
         valid.valid_item(
@@ -1759,7 +1755,6 @@ class DiffractometerID01(Diffractometer):
             setup=setup,
             logfile=logfile,
             scan_number=scan_number,
-            follow_bragg=follow_bragg,
         )
 
         # define the circles of interest for BCDI

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -1936,12 +1936,12 @@ class DiffractometerID01(Diffractometer):
                                "delta": "Delta"}
             else:
                 names_table = {"mu": "mu", "eta": "eta", "phi": "phi", "nu": "nu",
-                               "delta": "delta"}
+                               "delta": "del"}
 
             if "del" in labels:
-                delta = labels_data[labels.index(names_table["del"]), :]  # scanned
+                delta = labels_data[labels.index(names_table["delta"]), :]  # scanned
             else:  # positioner
-                delta = motor_values[motor_names.index(names_table["del"])]
+                delta = motor_values[motor_names.index(names_table["delta"])]
 
             mu = motor_values[motor_names.index(names_table["mu"])]  # positioner
 

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -1923,11 +1923,23 @@ class DiffractometerID01(Diffractometer):
                 old_names = True
 
             if old_names:
-                names_table = {"mu": "Mu", "eta": "Eta", "phi": "Phi", "nu": "Nu",
-                               "delta": "Delta", "energy": "Energy"}
+                names_table = {
+                    "mu": "Mu",
+                    "eta": "Eta",
+                    "phi": "Phi",
+                    "nu": "Nu",
+                    "delta": "Delta",
+                    "energy": "Energy",
+                }
             else:
-                names_table = {"mu": "mu", "eta": "eta", "phi": "phi", "nu": "nu",
-                               "delta": "del", "energy": "energy"}
+                names_table = {
+                    "mu": "mu",
+                    "eta": "eta",
+                    "phi": "phi",
+                    "nu": "nu",
+                    "delta": "del",
+                    "energy": "energy",
+                }
 
             if names_table["mu"] in labels:
                 mu = labels_data[labels.index(names_table["mu"]), :]  # scanned

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -1915,42 +1915,49 @@ class DiffractometerID01(Diffractometer):
             labels_data = logfile[str(scan_number) + ".1"].data  # motor scanned
 
             try:
-                nu = motor_values[motor_names.index("nu")]  # positioner
+                _ = motor_values[motor_names.index("nu")]  # positioner
             except ValueError:
                 print("'nu' not in the list, trying 'Nu'")
-                nu = motor_values[motor_names.index("Nu")]  # positioner
+                _ = motor_values[motor_names.index("Nu")]  # positioner
                 print("Defaulting to old ID01 motor names")
                 old_names = True
 
             if old_names:
                 names_table = {"mu": "Mu", "eta": "Eta", "phi": "Phi", "nu": "Nu",
-                               "delta": "Delta"}
+                               "delta": "Delta", "energy": "Energy"}
             else:
                 names_table = {"mu": "mu", "eta": "eta", "phi": "phi", "nu": "nu",
-                               "delta": "del"}
+                               "delta": "del", "energy": "energy"}
 
-            if "del" in labels:
+            if names_table["mu"] in labels:
+                mu = labels_data[labels.index(names_table["mu"]), :]  # scanned
+            else:
+                mu = motor_values[motor_names.index(names_table["mu"])]  # positioner
+
+            if names_table["eta"] in labels:
+                eta = labels_data[labels.index(names_table["eta"]), :]  # scanned
+            else:
+                eta = motor_values[motor_names.index(names_table["eta"])]  # positioner
+
+            if names_table["phi"] in labels:
+                phi = labels_data[labels.index(names_table["phi"]), :]  # scanned
+            else:
+                phi = motor_values[motor_names.index(names_table["phi"])]  # positioner
+
+            if names_table["delta"] in labels:
                 delta = labels_data[labels.index(names_table["delta"]), :]  # scanned
             else:  # positioner
                 delta = motor_values[motor_names.index(names_table["delta"])]
 
-            mu = motor_values[motor_names.index(names_table["mu"])]  # positioner
+            if names_table["nu"] in labels:
+                nu = labels_data[labels.index(names_table["nu"]), :]  # scanned
+            else:  # positioner
+                nu = motor_values[motor_names.index(names_table["nu"])]
 
-            if setup.rocking_angle == "outofplane":
-                eta = labels_data[labels.index(names_table["eta"]), :]
-                phi = motor_values[motor_names.index(names_table["phi"])]
-            elif setup.rocking_angle == "inplane":
-                phi = labels_data[labels.index(names_table["phi"]), :]
-                eta = motor_values[motor_names.index(names_table["eta"])]
-            elif setup.rocking_angle == "energy":
-                raw_energy = labels_data[labels.index("energy"), :]  # in kev, scanned
-                phi = motor_values[motor_names.index(names_table["phi"])]  # positioner
-                eta = motor_values[motor_names.index(names_table["eta"])]  # positioner
+            if names_table["energy"] in labels:
+                raw_energy = labels_data[labels.index(names_table["energy"]), :]
+                # energy scanned, override the user-defined energy
                 energy = raw_energy * 1000.0  # switch to eV
-            else:
-                raise ValueError(
-                    "Invalid rocking angle ", setup.rocking_angle, "for ID01"
-                )
 
             # remove user-defined sample offsets (sample: mu, eta, phi)
             mu = mu - self.sample_offsets[0]

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -1903,16 +1903,12 @@ class DiffractometerID01(Diffractometer):
         :param kwargs:
          - 'logfile': the logfile created in Setup.create_logfile()
          - 'scan_number': the scan number to load
-         - 'follow_bragg': boolean, True for energy scans where the detector position
-           is changed during the scan to follow the Bragg peak.
 
         :return: (mu, eta, phi, nu, delta, energy) values
         """
         # load and check kwargs
         logfile = kwargs["logfile"]
         scan_number = kwargs["scan_number"]
-        follow_bragg = kwargs.get("follow_bragg", False)
-        valid.valid_item(follow_bragg, allowed_types=bool, name="follow_bragg")
 
         energy = setup.energy  # will be overridden if setup.rocking_angle is 'energy'
         old_names = False

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -1897,6 +1897,8 @@ class DiffractometerID01(Diffractometer):
         """
         Load the scan data and extract motor positions.
 
+        Stages names for data previous to ?2017? start with a capital letter.
+
         :param setup: an instance of the class Setup
         :param kwargs:
          - 'logfile': the logfile created in Setup.create_logfile()
@@ -1929,46 +1931,31 @@ class DiffractometerID01(Diffractometer):
                 print("Defaulting to old ID01 motor names")
                 old_names = True
 
-            if not old_names:
-                mu = motor_values[motor_names.index("mu")]  # positioner
+            if old_names:
+                names_table = {"mu": "Mu", "eta": "Eta", "phi": "Phi", "nu": "Nu",
+                               "delta": "Delta"}
             else:
-                mu = motor_values[motor_names.index("Mu")]  # positioner
+                names_table = {"mu": "mu", "eta": "eta", "phi": "phi", "nu": "nu",
+                               "delta": "delta"}
 
-            if follow_bragg:
-                if not old_names:
-                    delta = labels_data[labels.index("del"), :]  # scanned
-                else:
-                    delta = labels_data[labels.index("Delta"), :]  # scanned
-            else:
-                if not old_names:
-                    delta = motor_values[motor_names.index("del")]  # positioner
-                else:
-                    delta = motor_values[motor_names.index("Delta")]  # positioner
+            if "del" in labels:
+                delta = labels_data[labels.index(names_table["del"]), :]  # scanned
+            else:  # positioner
+                delta = motor_values[motor_names.index(names_table["del"])]
+
+            mu = motor_values[motor_names.index(names_table["mu"])]  # positioner
 
             if setup.rocking_angle == "outofplane":
-                if not old_names:
-                    eta = labels_data[labels.index("eta"), :]
-                    phi = motor_values[motor_names.index("phi")]
-                else:
-                    eta = labels_data[labels.index("Eta"), :]
-                    phi = motor_values[motor_names.index("Phi")]
+                eta = labels_data[labels.index(names_table["eta"]), :]
+                phi = motor_values[motor_names.index(names_table["phi"])]
             elif setup.rocking_angle == "inplane":
-                if not old_names:
-                    phi = labels_data[labels.index("phi"), :]
-                    eta = motor_values[motor_names.index("eta")]
-                else:
-                    phi = labels_data[labels.index("Phi"), :]
-                    eta = motor_values[motor_names.index("Eta")]
+                phi = labels_data[labels.index(names_table["phi"]), :]
+                eta = motor_values[motor_names.index(names_table["eta"])]
             elif setup.rocking_angle == "energy":
                 raw_energy = labels_data[labels.index("energy"), :]  # in kev, scanned
-                if not old_names:
-                    phi = motor_values[motor_names.index("phi")]  # positioner
-                    eta = motor_values[motor_names.index("eta")]  # positioner
-                else:
-                    phi = motor_values[motor_names.index("Phi")]  # positioner
-                    eta = motor_values[motor_names.index("Eta")]  # positioner
+                phi = motor_values[motor_names.index(names_table["phi"])]  # positioner
+                eta = motor_values[motor_names.index(names_table["eta"])]  # positioner
                 energy = raw_energy * 1000.0  # switch to eV
-
             else:
                 raise ValueError(
                     "Invalid rocking angle ", setup.rocking_angle, "for ID01"

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -65,8 +65,6 @@ class Setup:
        to the number of elements in custom_images.
      - 'custom_motors': list of motor values when the scan does no follow
        the beamline's usual directory format.
-     - 'follow_bragg':bool, True when the detector is also scanned during energy scans
-       to follow the Bragg peak
      - 'sample_inplane': sample inplane reference direction along the beam at
        0 angles in xrayutilities frame (x is downstream, y outboard, and z vertical
        up at zero incident angle).
@@ -125,7 +123,6 @@ class Setup:
                 "offset_inplane",
                 "actuators",
                 "is_series",
-                "follow_bragg",
             },
             name="Setup.__init__",
         )
@@ -140,7 +137,6 @@ class Setup:
         self.custom_monitor = kwargs.get("custom_monitor")  # list or tuple
         self.custom_motors = kwargs.get("custom_motors")  # dictionnary
         self.actuators = kwargs.get("actuators", {})  # list or tuple
-        self.follow_bragg = kwargs.get("follow_bragg", False)  # boolean
         # kwargs for xrayutilities, delegate the test on their values to xrayutilities
         self.sample_inplane = kwargs.get("sample_inplane", (1, 0, 0))
         self.sample_outofplane = kwargs.get("sample_outofplane", (0, 0, 1))
@@ -588,7 +584,6 @@ class Setup:
             "sample_offsets_deg": self.diffractometer.sample_offsets,
             "direct_beam_pixel": self.direct_beam,
             "filtered_data": self.filtered_data,
-            "follow_bragg": self.follow_bragg,
             "custom_scan": self.custom_scan,
             "custom_images": self.custom_images,
             "actuators": self.actuators,
@@ -670,7 +665,6 @@ class Setup:
             f"direct_beam={self.direct_beam}, "
             f"sample_offsets={self.diffractometer.sample_offsets}, "
             f"filtered_data={self.filtered_data},\n"
-            f"follow_bragg={self.follow_bragg}, "
             f"custom_scan={self.custom_scan}, "
             f"custom_images={self.custom_images},\n"
             f"custom_monitor={self.custom_monitor},\n"
@@ -697,8 +691,6 @@ class Setup:
            In case of cropping/padding the number of frames changes. A frame whose
            index is set to 1 means that it is used, 0 means not used, -1 means padded
            (added) frame
-         - 'follow_bragg': True when in energy scans the detector was also
-           scanned to follow the Bragg peak
 
         :return:
          - qx, qz, qy components for the dataset. xrayutilities uses the xyz crystal
@@ -710,11 +702,6 @@ class Setup:
 
         """
         # check some parameters
-        follow_bragg = kwargs.get("follow_bragg", False)
-        if not isinstance(follow_bragg, bool):
-            raise TypeError(
-                "follow_bragg should be a boolean, got " f"{type(follow_bragg)}"
-            )
         frames_logical = kwargs.get("frames_logical")
         valid.valid_1d_array(
             frames_logical,
@@ -736,7 +723,6 @@ class Setup:
             nb_frames=nb_frames,
             scan_number=scan_number,
             frames_logical=frames_logical,
-            follow_bragg=follow_bragg,
         )
 
         # calculate q values

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -872,8 +872,6 @@ def grid_bcdi_labframe(
      orthonormal frame x y z
     :param debugging: set to True to see plots
     :param kwargs:
-     - 'follow_bragg': bool, True when for energy scans the detector was also scanned
-       to follow the Bragg peak
      - 'fill_value': tuple of two real numbers, fill values to use for pixels outside
        of the interpolation range. The first value is for the data, the second for the
        mask. Default is (0, 0)
@@ -885,11 +883,9 @@ def grid_bcdi_labframe(
     # check and load kwargs
     valid.valid_kwargs(
         kwargs=kwargs,
-        allowed_kwargs={"follow_bragg", "fill_value", "reference_axis"},
+        allowed_kwargs={"fill_value", "reference_axis"},
         name="kwargs",
     )
-    follow_bragg = kwargs.get("follow_bragg", False)
-    valid.valid_item(follow_bragg, allowed_types=bool, name="follow_bragg")
     fill_value = kwargs.get("fill_value", (0, 0))
     valid.valid_container(
         fill_value,
@@ -1035,7 +1031,6 @@ def grid_bcdi_xrayutil(
     frames_logical,
     hxrd,
     debugging=False,
-    **kwargs,
 ):
     """
     Interpolate BCDI reciprocal space data using xrayutilities package.
@@ -1055,22 +1050,10 @@ def grid_bcdi_xrayutil(
     :param hxrd: an initialized xrayutilities HXRD object used for the orthogonalization
      of the dataset
     :param debugging: set to True to see plots
-    :param kwargs:
-     - follow_bragg (bool): True when for energy scans the detector was also scanned to
-       follow the Bragg peak
-
     :return: the data and mask interpolated in the crystal frame, q values
      (downstream, vertical up, outboard). q values are in inverse angstroms.
     """
     valid.valid_ndarray(arrays=(data, mask), ndim=3)
-    # check and load kwargs
-    valid.valid_kwargs(
-        kwargs=kwargs,
-        allowed_kwargs={"follow_bragg"},
-        name="kwargs",
-    )
-    follow_bragg = kwargs.get("follow_bragg", False)
-    valid.valid_item(follow_bragg, allowed_types=bool, name="follow_bragg")
 
     numz, numy, numx = data.shape
     print(
@@ -1090,7 +1073,6 @@ def grid_bcdi_xrayutil(
         nb_frames=numz,
         scan_number=scan_number,
         frames_logical=frames_logical,
-        follow_bragg=follow_bragg,
     )
 
     maxbins = []

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -1093,25 +1093,6 @@ def grid_bcdi_xrayutil(
         follow_bragg=follow_bragg,
     )
 
-    # below is specific to ID01 energy scans
-    # where frames are duplicated for undulator gap change
-    if setup.beamline == "ID01" and setup.rocking_angle == "energy":
-        # frames need to be removed
-        tempdata = np.zeros(((frames_logical != 0).sum(), numy, numx))
-        offset_frame = 0
-        for idx in range(numz):
-            if frames_logical[idx] != 0:  # use frame
-                tempdata[idx - offset_frame, :, :] = data[idx, :, :]
-            else:  # average with the precedent frame
-                offset_frame = offset_frame + 1
-                tempdata[idx - offset_frame, :, :] = (
-                    tempdata[idx - offset_frame, :, :] + data[idx, :, :]
-                ) / 2
-        data = tempdata
-        mask = mask[
-            0 : data.shape[0], :, :
-        ]  # truncate the mask to have the correct size
-
     maxbins = []
     for dim in (qx, qy, qz):
         maxstep = max((abs(np.diff(dim, axis=j)).max() for j in range(3)))

--- a/scripts/facet_recognition/bcdi_polarplot.py
+++ b/scripts/facet_recognition/bcdi_polarplot.py
@@ -187,8 +187,6 @@ custom_motors = None
 # P10: om, phi, chi, mu, gamma, delta
 # SIXS: beta, mu, gamma, delta
 rocking_angle = "outofplane"  # "outofplane" or "inplane" or "energy"
-follow_bragg = False  # only for energy scans, set to True if the detector was
-# also scanned to follow the Bragg peak
 specfile_name = "psic_nano_20141204"
 # .spec for ID01, .fio for P10, alias_dict.txt for SIXS_2018,
 # not used for CRISTAL and SIXS_2019
@@ -368,7 +366,6 @@ if not reconstructed_data:  # load reciprocal space data
         frames_logical=frames_logical,
         hxrd=hxrd,
         debugging=debug,
-        follow_bragg=follow_bragg,
     )
 
     nz, ny, nx = data.shape  # CXI convention: z downstream, y vertical up, x outboard

--- a/scripts/postprocessing/bcdi_prtf_BCDI.py
+++ b/scripts/postprocessing/bcdi_prtf_BCDI.py
@@ -71,8 +71,6 @@ actuators = {"rocking_angle": "actuator_1_1"}
 # e.g.  {'rocking_angle': 'actuator_1_3', 'detector': 'data_04', 'monitor': 'data_05'}
 is_series = True  # specific to series measurement at P10
 rocking_angle = "inplane"  # "outofplane" or "inplane"
-follow_bragg = False  # only for energy scans, set to True if the detector
-# was also scanned to follow the Bragg peak
 specfile_name = ""
 # template for ID01: name of the spec file without '.spec'
 # template for SIXS_2018: full path of the alias dictionnary 'alias_dict.txt',
@@ -451,7 +449,6 @@ else:
         hxrd=hxrd,
         nb_frames=numz,
         scan_number=scan,
-        follow_bragg=follow_bragg,
     )
 
 if debug:

--- a/scripts/postprocessing/bcdi_prtf_BCDI_2D.py
+++ b/scripts/postprocessing/bcdi_prtf_BCDI_2D.py
@@ -74,8 +74,6 @@ actuators = {}
 # e.g.  {'rocking_angle': 'actuator_1_3', 'detector': 'data_04', 'monitor': 'data_05'}
 is_series = False  # specific to series measurement at P10
 rocking_angle = "outofplane"  # "outofplane" or "inplane"
-follow_bragg = False  # only for energy scans, set to True if the detector
-# was also scanned to follow the Bragg peak
 specfile_name = "alignment"
 # .spec for ID01, .fio for P10, alias_dict.txt for SIXS_2018,
 # not used for CRISTAL and SIXS_2019
@@ -369,7 +367,6 @@ else:
         hxrd=hxrd,
         nb_frames=numz,
         scan_number=scan,
-        follow_bragg=follow_bragg,
     )
 
 if debug:

--- a/scripts/preprocessing/bcdi_preprocess_BCDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_BCDI.py
@@ -179,7 +179,7 @@ x_bragg = 1577  # horizontal pixel number of the Bragg peak,
 # can be used for the definition of the ROI
 y_bragg = 833  # vertical pixel number of the Bragg peak,
 # can be used for the definition of the ROI
-roi_detector = None # [y_bragg - 216, y_bragg + 216, x_bragg - 200, x_bragg + 200]  #
+roi_detector = None  # [y_bragg - 216, y_bragg + 216, x_bragg - 200, x_bragg + 200]  #
 # [Vstart, Vstop, Hstart, Hstop]
 # leave None to use the full detector.
 # Use with center_fft='skip' if you want this exact size.
@@ -218,7 +218,7 @@ fill_value_mask = 0  # 0 (not masked) or 1 (masked).
 # imposed). The data is by default set to 0 outside of the defined range.
 beam_direction = (1, 0, 0)
 # beam direction in the laboratory frame (downstream, vertical up, outboard)
-sample_offsets = (0, 0, 0,)
+sample_offsets = None
 # tuple of offsets in degrees of the sample for each sample circle (outer first).
 # convention: the sample offsets will be subtracted to the motor values.
 # Leave None if no offset.

--- a/scripts/preprocessing/bcdi_preprocess_BCDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_BCDI.py
@@ -77,9 +77,8 @@ frames_pattern = None
 # parameters used in masking #
 ##############################
 flag_interact = True  # True to interact with plots, False to close it automatically
-background_plot = (
-    "0.5"  # in level of grey in [0,1], 0 being dark. For visual comfort during masking
-)
+background_plot = "0.5"
+# in level of grey in [0,1], 0 being dark. For visual comfort during masking
 #########################################################
 # parameters related to data cropping/padding/centering #
 #########################################################
@@ -218,7 +217,7 @@ fill_value_mask = 0  # 0 (not masked) or 1 (masked).
 # imposed). The data is by default set to 0 outside of the defined range.
 beam_direction = (1, 0, 0)
 # beam direction in the laboratory frame (downstream, vertical up, outboard)
-sample_offsets = (0, 0, 90, 0,)
+sample_offsets = (0, 0, 0,)
 # tuple of offsets in degrees of the sample for each sample circle (outer first).
 # convention: the sample offsets will be subtracted to the motor values.
 # Leave None if no offset.

--- a/scripts/preprocessing/bcdi_preprocess_BCDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_BCDI.py
@@ -155,8 +155,6 @@ custom_monitor = np.ones(51)
 rocking_angle = "outofplane"  # "outofplane" for a sample rotation around x outboard,
 # "inplane" for a sample rotation around y vertical up, "energy"
 
-follow_bragg = False  # only for energy scans, set to True if the detector
-# was also scanned to follow the Bragg peak
 specfile_name = "2021_04_10_093013_pt"
 # template for ID01: name of the spec file without '.spec'
 # template for SIXS: full path of the alias dictionnary or
@@ -621,7 +619,6 @@ for scan_idx, scan_nb in enumerate(scans, start=1):
                 logfile=logfile,
                 scan_number=scan_nb,
                 setup=setup,
-                follow_bragg=follow_bragg,
             )
             setup.tilt_angle = (tilt_angle[1:] - tilt_angle[0:-1]).mean()
             # override detector motor positions if the corrected values
@@ -867,7 +864,6 @@ for scan_idx, scan_nb in enumerate(scans, start=1):
                     setup=setup,
                     frames_logical=frames_logical,
                     hxrd=hxrd,
-                    follow_bragg=follow_bragg,
                     debugging=debug,
                 )
             else:  # 'linearization'
@@ -883,7 +879,6 @@ for scan_idx, scan_nb in enumerate(scans, start=1):
                     align_q=align_q,
                     reference_axis=axis_to_array_xyz[ref_axis_q],
                     debugging=debug,
-                    follow_bragg=follow_bragg,
                     fill_value=(0, fill_value_mask),
                 )
             nz, ny, nx = data.shape

--- a/scripts/preprocessing/bcdi_preprocess_BCDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_BCDI.py
@@ -118,14 +118,10 @@ medfilt_order = 7  # for custom median filter,
 # parameters used when reloading processed data #
 #################################################
 reload_previous = False  # True to resume a previous masking (load data and mask)
-reload_orthogonal = (
-    False  # True if the reloaded data is already intepolated in an orthonormal frame
-)
-preprocessing_binning = (
-    1,
-    1,
-    1,
-)  # binning factors in each dimension of the binned data to be reloaded
+reload_orthogonal = False
+# True if the reloaded data is already intepolated in an orthonormal frame
+preprocessing_binning = (1, 1, 1)
+# binning factors in each dimension of the binned data to be reloaded
 ##################
 # saving options #
 ##################
@@ -133,9 +129,8 @@ save_rawdata = False  # save also the raw data when use_rawdata is False
 save_to_npz = True  # True to save the processed data in npz format
 save_to_mat = False  # True to save also in .mat format
 save_to_vti = False  # save the orthogonalized diffraction pattern to VTK file
-save_asint = (
-    False  # if True, the result will be saved as an array of integers (save space)
-)
+save_asint = False
+# if True, the result will be saved as an array of integers (save space)
 ######################################
 # define beamline related parameters #
 ######################################
@@ -184,7 +179,7 @@ x_bragg = 1577  # horizontal pixel number of the Bragg peak,
 # can be used for the definition of the ROI
 y_bragg = 833  # vertical pixel number of the Bragg peak,
 # can be used for the definition of the ROI
-roi_detector = [y_bragg - 216, y_bragg + 216, x_bragg - 200, x_bragg + 200]  #
+roi_detector = None # [y_bragg - 216, y_bragg + 216, x_bragg - 200, x_bragg + 200]  #
 # [Vstart, Vstop, Hstart, Hstop]
 # leave None to use the full detector.
 # Use with center_fft='skip' if you want this exact size.

--- a/scripts/preprocessing/bcdi_preprocess_BCDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_BCDI.py
@@ -30,9 +30,6 @@ import bcdi.preprocessing.bcdi_utils as bu
 import bcdi.utils.utilities as util
 import bcdi.utils.validation as valid
 
-plt.switch_backend("Qt5Agg")
-# "Qt5Agg" or "Qt4Agg" depending on the version of Qt installer, bug with Tk
-
 helptext = """
 Prepare experimental data for Bragg CDI phasing: crop/pad, center, mask, normalize and
 filter the data.
@@ -50,12 +47,12 @@ output files saved in:   /rootdir/S1/pynxraw/ or /rootdir/S1/pynx/ depending on 
 'use_rawdata' option
 """
 
-scans = 76  # np.arange(1401, 1419+1, 3)  # scan number or list of scan numbers
+scans = 33  # np.arange(1401, 1419+1, 3)  # scan number or list of scan numbers
 # scans = np.concatenate((scans, np.arange(1147, 1195+1, 3)))
 # bad_indices = np.argwhere(scans == 738)
 # scans = np.delete(scans, bad_indices)
 
-root_folder = "C:/Users/carnisj/Documents/data/P10_Longfei_Nov2020/data/"
+root_folder = "C:/Users/Jerome/Documents/data/MIR_radial_scan/"
 # folder of the experiment, where all scans are stored
 save_dir = root_folder + "test/"  # images will be saved here, leave it to None
 # otherwise
@@ -64,12 +61,12 @@ data_dirname = None  # leave None to use the beamline default,
 # (data directly in the scan folder), or a non-empty string for the subfolder name
 # (default to scan_folder/pynx/ or scan_folder/pynxraw/
 # depending on the setting of use_rawdata)
-sample_name = "B15_syn_S1_2"  # str or list of str of sample names
+sample_name = "S"  # str or list of str of sample names
 # (string in front of the scan number in the folder name).
 # If only one name is indicated, it will be repeated to match the number of scans.
 user_comment = ""  # string, should start with "_"
 debug = False  # set to True to see plots
-binning = (1, 2, 2)  # binning to apply to the data
+binning = (1, 3, 3)  # binning to apply to the data
 # (stacking dimension, detector vertical axis, detector horizontal axis)
 bin_during_loading = False  # True to bin during loading, require less memory
 frames_pattern = None
@@ -79,7 +76,7 @@ frames_pattern = None
 ##############################
 # parameters used in masking #
 ##############################
-flag_interact = False  # True to interact with plots, False to close it automatically
+flag_interact = True  # True to interact with plots, False to close it automatically
 background_plot = (
     "0.5"  # in level of grey in [0,1], 0 being dark. For visual comfort during masking
 )
@@ -142,9 +139,8 @@ save_asint = (
 ######################################
 # define beamline related parameters #
 ######################################
-beamline = (
-    "P10"  # name of the beamline, used for data loading and normalization by monitor
-)
+beamline = "ID01"
+# name of the beamline, used for data loading and normalization by monitor
 # supported beamlines: 'ID01', 'SIXS_2018', 'SIXS_2019', 'CRISTAL', 'P10',
 # 'NANOMAX', '34ID'
 actuators = None  # {'rocking_angle': 'actuator_1_1'}
@@ -158,16 +154,15 @@ custom_scan = False  # set it to True for a stack of images acquired without sca
 # there is no spec/log file available
 custom_images = [3]  # np.arange(11353, 11453, 1)
 # list of image numbers for the custom_scan, None otherwise
-custom_monitor = np.ones(
-    51
-)  # monitor values for normalization for the custom_scan, None otherwise
+custom_monitor = np.ones(51)
+# monitor values for normalization for the custom_scan, None otherwise
 
 rocking_angle = "outofplane"  # "outofplane" for a sample rotation around x outboard,
 # "inplane" for a sample rotation around y vertical up, "energy"
 
 follow_bragg = False  # only for energy scans, set to True if the detector
 # was also scanned to follow the Bragg peak
-specfile_name = ""
+specfile_name = "BCDI_2021_03_11_205927"
 # template for ID01: name of the spec file without '.spec'
 # template for SIXS: full path of the alias dictionnary or
 # None to use the one in the package folder
@@ -176,9 +171,8 @@ specfile_name = ""
 # detector related parameters #
 ###############################
 detector = "Eiger4M"  # "Eiger2M", "Maxipix", "Eiger4M", "Merlin" or "Timepix"
-linearity_func = (
-    None  # lambda array_1d: (array_1d*(7.484e-22*array_1d**4 - 3.447e-16*array_1d**3 +
-)
+linearity_func = None
+# lambda array_1d: (array_1d*(7.484e-22*array_1d**4 - 3.447e-16*array_1d**3 +
 # 5.067e-11*array_1d**2 - 6.022e-07*array_1d + 0.889)) # MIR
 # np.divide(array_1d, (1-array_1d*1.3e-6))  # Sarah_1
 # (array_1d*(7.484e-22*array_1d**4 - 3.447e-16*array_1d**3 +
@@ -202,10 +196,9 @@ photon_filter = "loading"  # 'loading' or 'postprocessing',
 background_file = None  # root_folder + 'background.npz'  # non empty file path or None
 hotpixels_file = None  # root_folder + 'hotpixels_cristal.npz'
 # root_folder + 'mask_merlin.npy'  # non empty file path or None
-flatfield_file = (
-    None  # root_folder + "flatfield_maxipix_8kev.npz"  # non empty file path or None
-)
-template_imagefile = "_master.h5"
+flatfield_file = None
+# root_folder + "flatfield_maxipix_8kev.npz"  # non empty file path or None
+template_imagefile = "data_mpx4_%05d.edf.gz"
 # template for ID01: 'data_mpx4_%05d.edf.gz' or 'align_eiger2M_%05d.edf.gz'
 # template for SIXS_2018: 'align.spec_ascan_mu_%05d.nxs'
 # template for SIXS_2019: 'spare_ascan_mu_%05d.nxs'
@@ -222,27 +215,20 @@ nb_pixel_y = None  # fix to declare a known detector but with less pixels
 ################################################################################
 use_rawdata = False  # False for using data gridded in laboratory frame
 # True for using data in detector frame
-interp_method = "linearization"  # 'xrayutilities' or 'linearization'
+interp_method = "xrayutilities"  # 'xrayutilities' or 'linearization'
 fill_value_mask = 0  # 0 (not masked) or 1 (masked).
 # It will define how the pixels outside of the data range are
 # processed during the interpolation. Because of the large number of masked pixels,
 # phase retrieval converges better if the pixels are not masked (0 intensity
 # imposed). The data is by default set to 0 outside of the defined range.
-beam_direction = (
-    1,
-    0,
-    0,
-)  # beam direction in the laboratory frame (downstream, vertical up, outboard)
-sample_offsets = (
-    0,
-    0,
-    90,
-    0,
-)  # tuple of offsets in degrees of the sample for each sample circle (outer first).
+beam_direction = (1, 0, 0)
+# beam direction in the laboratory frame (downstream, vertical up, outboard)
+sample_offsets = (0, 0, 90, 0,)
+# tuple of offsets in degrees of the sample for each sample circle (outer first).
 # convention: the sample offsets will be subtracted to the motor values.
 # Leave None if no offset.
-sdd = 1.84  # in m, sample to detector distance in m
-energy = 8170  # np.linspace(11100, 10900, num=51)  # x-ray energy in eV
+sdd = 1.434  # in m, sample to detector distance in m
+energy = 9000  # np.linspace(11100, 10900, num=51)  # x-ray energy in eV
 custom_motors = None
 # {"mu": 0, "phi": -15.98, "chi": 90, "theta": 0, "delta": -0.5685, "gamma": 33.3147}
 # use this to declare motor positions if there is not log file, None otherwise
@@ -259,34 +245,26 @@ custom_motors = None
 # parameters when orthogonalizing the data before     #
 # phasing  using the linearized transformation matrix #
 ######################################################
-align_q = True  # used only when interp_method is 'linearization',
+align_q = False  # used only when interp_method is 'linearization',
 # if True it rotates the crystal to align q
 # along one axis of the array
 ref_axis_q = "y"  # q will be aligned along that axis
-outofplane_angle = (
-    42.6093  # detector angle in deg (rotation around x outboard, typically delta),
-)
+outofplane_angle = 42.6093
+# detector angle in deg (rotation around x outboard, typically delta),
+
 # corrected for the direct beam position. Leave None to use the uncorrected position.
-inplane_angle = (
-    -0.5783
-)  # detector angle in deg(rotation around y vertical up, typically gamma),
+inplane_angle = -0.5783
+# detector angle in deg(rotation around y vertical up, typically gamma),
 # corrected for the direct beam position. Leave None to use the uncorrected position.
 ################################################################################
 # parameters when orthogonalizing the data before phasing  using xrayutilities #
 ################################################################################
 # xrayutilities uses the xyz crystal frame: for incident angle = 0,
 # x is downstream, y outboard, and z vertical up
-sample_inplane = (
-    1,
-    0,
-    0,
-)
+sample_inplane = (1, 0, 0)
 # sample inplane reference direction along the beam at 0 angles in xrayutilities frame
-sample_outofplane = (
-    0,
-    0,
-    1,
-)  # surface normal of the sample at 0 angles in xrayutilities frame
+sample_outofplane = (0, 0, 1)
+# surface normal of the sample at 0 angles in xrayutilities frame
 offset_inplane = 0  # outer detector angle offset as determined by
 # xrayutilities area detector initialization
 cch1 = 208  # direct beam vertical position in the full unbinned detector for

--- a/scripts/preprocessing/bcdi_preprocess_BCDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_BCDI.py
@@ -47,7 +47,7 @@ output files saved in:   /rootdir/S1/pynxraw/ or /rootdir/S1/pynx/ depending on 
 'use_rawdata' option
 """
 
-scans = 33  # np.arange(1401, 1419+1, 3)  # scan number or list of scan numbers
+scans = 86  # np.arange(1401, 1419+1, 3)  # scan number or list of scan numbers
 # scans = np.concatenate((scans, np.arange(1147, 1195+1, 3)))
 # bad_indices = np.argwhere(scans == 738)
 # scans = np.delete(scans, bad_indices)
@@ -140,6 +140,7 @@ beamline = "ID01"
 actuators = None  # {'rocking_angle': 'actuator_1_1'}
 # Optional dictionary that can be used to define the entries corresponding to
 # actuators in data files (useful at CRISTAL where the location of data keeps changing)
+# or to define a monitor different from "exp1" at ID01
 # e.g.  {'rocking_angle': 'actuator_1_3', 'detector': 'data_04', 'monitor': 'data_05'}
 is_series = True  # specific to series measurement at P10
 
@@ -156,7 +157,7 @@ rocking_angle = "outofplane"  # "outofplane" for a sample rotation around x outb
 
 follow_bragg = False  # only for energy scans, set to True if the detector
 # was also scanned to follow the Bragg peak
-specfile_name = "BCDI_2021_03_11_205927"
+specfile_name = "2021_04_10_093013_pt"
 # template for ID01: name of the spec file without '.spec'
 # template for SIXS: full path of the alias dictionnary or
 # None to use the one in the package folder
@@ -164,7 +165,7 @@ specfile_name = "BCDI_2021_03_11_205927"
 ###############################
 # detector related parameters #
 ###############################
-detector = "Eiger4M"  # "Eiger2M", "Maxipix", "Eiger4M", "Merlin" or "Timepix"
+detector = "Maxipix"  # "Eiger2M", "Maxipix", "Eiger4M", "Merlin" or "Timepix"
 linearity_func = None
 # lambda array_1d: (array_1d*(7.484e-22*array_1d**4 - 3.447e-16*array_1d**3 +
 # 5.067e-11*array_1d**2 - 6.022e-07*array_1d + 0.889)) # MIR
@@ -221,8 +222,8 @@ sample_offsets = (0, 0, 0,)
 # tuple of offsets in degrees of the sample for each sample circle (outer first).
 # convention: the sample offsets will be subtracted to the motor values.
 # Leave None if no offset.
-sdd = 1.434  # in m, sample to detector distance in m
-energy = 9000  # np.linspace(11100, 10900, num=51)  # x-ray energy in eV
+sdd = 1.03527  # in m, sample to detector distance in m
+energy = 13000  # np.linspace(11100, 10900, num=51)  # x-ray energy in eV
 custom_motors = None
 # {"mu": 0, "phi": -15.98, "chi": 90, "theta": 0, "delta": -0.5685, "gamma": 33.3147}
 # use this to declare motor positions if there is not log file, None otherwise


### PR DESCRIPTION
Motors for ID01 are now loaded as if they were scanned, and default to positioners otherwise.

The parameter "follow_bragg" is not needed anymore, I removed it from the scripts and API.

For the monitor, now you can provide it in the "actuators" parameter if it is different from "exp1", e.g. actuators ={"monitor": "mon2"}

[X] I have run doit

![final_reciprocal_space_S86_ortho_xrutil_norm_288_270_560_1_3_3](https://user-images.githubusercontent.com/44344327/136615659-571ff154-f018-4baf-a40c-970f4c0da8b5.png)
t