### PR TITLE
Define default sample offsets for P10

### DIFF
--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -423,7 +423,7 @@ class Diffractometer(ABC):
      'y-', 'z+', 'z-'}. For example: ['y+', 'x-']
     :param kwargs:
      - 'default_offsets': tuple, default sample offsets of the diffractometer. It needs
-       to be implemented as a class parameter in the child class if necessary. See an
+       to be implemented as a class attribute in the child class if necessary. See an
        example in DiffractometerP10
 
     """


### PR DESCRIPTION
## Description

default offsets can now be provided as a class attribute in the child classes, and sent to the __init__ of the base class. When the user does not specify sample_offsets (i.e. None), it will default to this value if it exits or a tuple of zeros otherwise (current behaviour).

This will prevent mistakes from users forgetting to define the parameter sample_offsets, at beamlines with a permanent offset (for example, chi=90 deg at P10).

Fixes #167 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?

Instantiation of the class DiffractometerP10 with sample_offsets=None -> sample_offsets=(0,0,90,0) as expected

## Checklist:

- [X] I have run ``doit`` and all tasks have passed
