### PR TITLE
Bug: use the correct key for the config file

### DIFF
--- a/scripts/postprocessing/bcdi_strain.py
+++ b/scripts/postprocessing/bcdi_strain.py
@@ -1453,7 +1453,7 @@ if __name__ == "__main__":
     cli_args = vars(ap.parse_args())
 
     # load the config file
-    file = cli_args.get("config") or CONFIG_FILE
+    file = cli_args.get("config_file") or CONFIG_FILE
     parser = ConfigParser(file, cli_args)
     args = parser.load_arguments()
     args["time"] = f"{datetime.now()}"

--- a/scripts/preprocessing/bcdi_preprocess_BCDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_BCDI.py
@@ -1547,8 +1547,8 @@ if __name__ == "__main__":
     cli_args = vars(ap.parse_args())
 
     # load the config file
-    file = cli_args.get("config") or CONFIG_FILE
-    parser = ConfigParser(CONFIG_FILE, cli_args)
+    file = cli_args.get("config_file") or CONFIG_FILE
+    parser = ConfigParser(file, cli_args)
     args = parser.load_arguments()
     args["time"] = f"{datetime.now()}"
     run(prm=args)


### PR DESCRIPTION
The key corresponding to the config file in the dictionary of command line parameters was wrong.

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have run ``doit`` and all tasks have passed
