### PR TITLE
Update the parameter "Linearity_function"

### DIFF
--- a/bcdi/experiment/detector.py
+++ b/bcdi/experiment/detector.py
@@ -278,7 +278,6 @@ class Detector(ABC):
 
     @linearity_func.setter
     def linearity_func(self, value):
-
         def poly4(array_1d, coeffs):
             """
             Define a 4th order polynomial and apply it on a 1D array.
@@ -288,8 +287,13 @@ class Detector(ABC):
              of the polynomial ax^4 + bx^3 + cx^2 + dx + e
             :return: the updated 1D array
             """
-            return (coeffs[0] * array_1d ** 4 + coeffs[1] * array_1d ** 3 +
-                    coeffs[2] * array_1d ** 2 + coeffs[3] * array_1d + coeffs[4])
+            return (
+                coeffs[0] * array_1d ** 4
+                + coeffs[1] * array_1d ** 3
+                + coeffs[2] * array_1d ** 2
+                + coeffs[3] * array_1d
+                + coeffs[4]
+            )
 
         if value is None:
             self._linearity_func = None
@@ -300,7 +304,7 @@ class Detector(ABC):
             container_types=(tuple, list, np.ndarray),
             length=5,
             item_types=Real,
-            name="linearity_func"
+            name="linearity_func",
         )
         self._linearity_func = partial(poly4, coeffs=value)
 

--- a/bcdi/experiment/detector.py
+++ b/bcdi/experiment/detector.py
@@ -630,7 +630,7 @@ class Detector(ABC):
         :param data: a 2D numpy array
         :return: the corrected data array
         """
-        if self.linearity_func is not None:
+        if self.linearity_func is not None and callable(self.linearity_func):
             valid.valid_ndarray(data, ndim=2)
             data = data.astype(float)
             nby, nbx = data.shape

--- a/bcdi/experiment/detector.py
+++ b/bcdi/experiment/detector.py
@@ -279,21 +279,21 @@ class Detector(ABC):
     @linearity_func.setter
     def linearity_func(self, value):
 
-        def poly4(array_1d, value):
+        def poly4(array_1d, coeffs):
             """
             Define a 4th order polynomial and apply it on a 1D array.
 
             :param array_1d: a numpy 1D array
-            :param value: a sequence of 5 Real numbers, the coefficients [a, b, c, d, e]
+            :param coeffs: sequence of 5 Real numbers, the coefficients [a, b, c, d, e]
              of the polynomial ax^4 + bx^3 + cx^2 + dx + e
             :return: the updated 1D array
             """
-            nonlocal value
-            return (value[0] * array_1d ** 4 + value[1] * array_1d ** 3 +
-                    value[2] * array_1d ** 2 + value[3] * array_1d + value[4])
+            return (coeffs[0] * array_1d ** 4 + coeffs[1] * array_1d ** 3 +
+                    coeffs[2] * array_1d ** 2 + coeffs[3] * array_1d + coeffs[4])
 
         if value is None:
             self._linearity_func = None
+            return
 
         valid.valid_container(
             value,
@@ -302,7 +302,7 @@ class Detector(ABC):
             item_types=Real,
             name="linearity_func"
         )
-        self._linearity_func = partial(poly4, value=value)
+        self._linearity_func = partial(poly4, coeffs=value)
 
     @property
     def name(self):

--- a/bcdi/postprocessing/facet_analysis.py
+++ b/bcdi/postprocessing/facet_analysis.py
@@ -1348,7 +1348,7 @@ class Facets:
         with h5py.File(path_to_data, mode="a") as f:
             try:
                 facets = f.create_group("entry_1/process_4/")
-                f["entry_1"]["process_4"].attrs['NX_class'] = 'NXprocess'
+                f["entry_1"]["process_4"].attrs["NX_class"] = "NXprocess"
                 facets.create_dataset("path_to_data", data=self.path_to_data)
                 facets.create_dataset("nb_facets", data=self.nb_facets)
                 facets.create_dataset("comment", data=self.comment)
@@ -1364,7 +1364,7 @@ class Facets:
                 facets.create_dataset("rotation_matrix", data=self.rotation_matrix)
                 facets.create_dataset("hkl_reference", data=self.hkl_reference)
                 facets.create_dataset("planar_dist", data=self.planar_dist)
-                facets["planar_dist"].attrs['units'] = 'Angstrom'
+                facets["planar_dist"].attrs["units"] = "Angstrom"
                 facets.create_dataset("ref_normal", data=self.ref_normal)
                 print("Saved Facets class attributes")
 
@@ -1386,7 +1386,7 @@ class Facets:
                 f["/entry_1/process_4/rotation_matrix"][...] = self.rotation_matrix
                 f["/entry_1/process_4/hkl_reference"][...] = self.hkl_reference
                 f["/entry_1/process_4/planar_dist"][...] = self.planar_dist
-                f["/entry_1/process_4/planar_dist"].attrs['units'] = 'Angstrom'
+                f["/entry_1/process_4/planar_dist"].attrs["units"] = "Angstrom"
                 f["/entry_1/process_4/ref_normal"][...] = self.ref_normal
                 print("Saved Facets class attributes")
 

--- a/bcdi/utils/parameters.py
+++ b/bcdi/utils/parameters.py
@@ -296,7 +296,12 @@ def valid_param(key: str, value: Any) -> Tuple[Any, bool]:
         valid.valid_item(value, allowed_types=Real, min_excluded=0, name=key)
     elif key == "linearity_func":
         valid.valid_container(
-            value, container_types=str, min_length=1, allow_none=True, name=key
+            value,
+            container_types=(tuple, list, np.ndarray),
+            length=5,
+            item_types=Real,
+            allow_none=True,
+            name=key
         )
     elif key == "median_filter":
         allowed = {"median", "interp_isolated", "mask_isolated", "skip"}

--- a/bcdi/utils/parameters.py
+++ b/bcdi/utils/parameters.py
@@ -141,11 +141,7 @@ def valid_param(key: str, value: Any) -> Tuple[Any, bool]:
         )
         value = np.asarray(value)
     elif key == "backend":
-        allowed = {
-            "Agg",
-            "Qt5Agg",
-            "module://matplotlib_inline.backend_inline"
-        }
+        allowed = {"Agg", "Qt5Agg", "module://matplotlib_inline.backend_inline"}
         if value not in allowed:
             raise ParameterError(key, value, allowed)
     elif key == "background_file":
@@ -301,7 +297,7 @@ def valid_param(key: str, value: Any) -> Tuple[Any, bool]:
             length=5,
             item_types=Real,
             allow_none=True,
-            name=key
+            name=key,
         )
     elif key == "median_filter":
         allowed = {"median", "interp_isolated", "mask_isolated", "skip"}

--- a/conf/config_preprocessing.yml
+++ b/conf/config_preprocessing.yml
@@ -103,7 +103,10 @@ detector: "Maxipix"  # "Eiger2M", "Maxipix", "Eiger4M", "Merlin" or "Timepix"
 phasing_binning: [1, 2, 2]  # binning to apply to the data
 # (stacking dimension, detector vertical axis, detector horizontal axis)
 linearity_func: None
-# name of the linearity correction for the detector, leave None otherwise.
+# [a, b, c, d, e] tuple of 5 numbers corresponding to the coefficients of the 4th order
+# polynomial ax^4 + bx^3 + cx^2 + dx + e which it used to correct the non-linearity of
+# the detector at high intensities. Leave None otherwise.
+# polynomial a0linearity correction for the detector, leave None otherwise.
 x_bragg: None  # horizontal pixel number of the Bragg peak,
 # can be used for the definition of the ROI
 y_bragg: None  # vertical pixel number of the Bragg peak,

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,6 +1,10 @@
 Future:
 -------
 
+* Update the parameter "linearity_function" in preprocessing. Now this can be None (if
+  unused) or a sequence of 5 real numbers corresponding to the coefficients of a 4th
+  order polynomial.
+
 * Implement a parser for YAML config files. Now the scripts ``bcdi_strain.py`` and
   ``bcdi_preprocess_BCDI.py`` can be run like scripts, from the command line, with
   optional command line arguments.

--- a/scripts/postprocessing/bcdi_strain.py
+++ b/scripts/postprocessing/bcdi_strain.py
@@ -504,7 +504,9 @@ def run(prm):
         root = tk.Tk()
         root.withdraw()
         file_path = filedialog.askopenfilenames(
-            initialdir=detector.scandir if prm["data_dir"] is None else detector.datadir,
+            initialdir=detector.scandir
+            if prm["data_dir"] is None
+            else detector.datadir,
             filetypes=[
                 ("NPZ", "*.npz"),
                 ("NPY", "*.npy"),

--- a/scripts/preprocessing/bcdi_preprocess_BCDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_BCDI.py
@@ -191,7 +191,9 @@ Usage:
     :param phasing_binning: e.g. [1, 2, 2]
      binning to apply to the data (stacking dimension, detector vertical axis, detector
      horizontal axis)
-    :param linearity_func: name of the linearity correction for the detector, leave None
+    :param linearity_func: e.g. [1, -2, -0.0021, 32.0, 1.232]
+     coefficients of the 4th order polynomial ax^4 + bx^3 + cx^2 + dx + e which it used
+     to correct the non-linearity of the detector at high intensities. Leave None
      otherwise.
     :param x_bragg: e.g. 1577
      horizontal pixel number of the Bragg peak, used for the definition of roi_detector


### PR DESCRIPTION
In order to keep it compatible with the use of config files, instead of defining a function now the user must specify the coefficients of a 4th order polynomial (or None if unused).
Fixes #191 

## Type of change

- [X] Breaking change (will cause existing functionality to not work as expected)

## How has this been tested?

- preprocessing of ID01 dataset with/without linearity_function runs as expected
- unit tests modified accordingly

## Checklist:

- [X] I have made corresponding changes to the documentation
- [X] I have added corresponding unit tests
- [X] I have run ``doit`` and all tasks have passed
