### PR TITLE
add support in preprocessing for 34ID-C

### DIFF
--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -18,6 +18,7 @@ from matplotlib import pyplot as plt
 from numbers import Real, Integral
 import numpy as np
 import os
+from PIL import Image
 from scipy.interpolate import interp1d, RegularGridInterpolator
 from scipy.optimize import curve_fit
 from scipy.special import erf
@@ -827,8 +828,6 @@ def image_to_ndarray(filename, convert_grey=True, cmap=None, debug=False):
     :param debug: True to see plots
     :return:
     """
-    from PIL import Image
-
     if cmap is None:
         cmap = gu.Colormap(bad_color="1.0").cmap
 

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -838,8 +838,8 @@ def image_to_ndarray(filename, convert_grey=True, cmap=None, debug=False):
         print("converting image to gray")
         array = rgb2gray(array)
 
-    print(f"Image shape after conversion to ndarray: {array.shape}")
     if debug:
+        print(f"Image shape after conversion to ndarray: {array.shape}")
         gu.imshow_plot(
             array, sum_axis=2, plot_colorbar=True, cmap=cmap, reciprocal_space=False
         )

--- a/conf/config_preprocessing.yml
+++ b/conf/config_preprocessing.yml
@@ -1,7 +1,7 @@
-scans: 11  # scan number or list of scan numbers
-root_folder: "C:/Users/Jerome/Documents/data/dataset_ID01/"
+scans: 622  # scan number or list of scan numbers
+root_folder: "C:/Users/Jerome/Documents/data/dataset_34ID/IzrO/"
 # folder of the experiment, where all scans are stored
-save_dir: "C:/Users/Jerome/Documents/data/dataset_ID01/test/"
+save_dir: "C:/Users/Jerome/Documents/data/dataset_34ID/IzrO/test/"
 # images will be saved here, leave it to None otherwise
 data_dir: None  # leave None to use the beamline default,
 # '' empty string when there is no subfolder
@@ -67,7 +67,7 @@ save_as_int: False
 ######################################
 # define beamline related parameters #
 ######################################
-beamline: "ID01"
+beamline: "34ID"
 # name of the beamline, used for data loading and normalization by monitor
 # supported beamlines: 'ID01', 'SIXS_2018', 'SIXS_2019', 'CRISTAL', 'P10',
 # 'NANOMAX', '34ID'
@@ -76,9 +76,9 @@ actuators: None  # {'rocking_angle': 'actuator_1_1'}
 # actuators in data files (useful at CRISTAL where the location of data keeps changing)
 # e.g.  {'rocking_angle': 'actuator_1_3', 'detector': 'data_04', 'monitor': 'data_05'}
 is_series: True  # specific to series measurement at P10
-rocking_angle: "outofplane"  # "outofplane" for a sample rotation around x outboard,
+rocking_angle: "inplane"  # "outofplane" for a sample rotation around x outboard,
 # "inplane" for a sample rotation around y vertical up, "energy"
-specfile_name: "l5.spec"
+specfile_name: "Dmitry1120c.spec"
 # template for ID01 and 34ID: name of the spec file if it is at the default location
 # (in root_folder) or full path to the spec file
 # template for SIXS: full path of the alias dictionnary or None to use the one in the
@@ -99,14 +99,13 @@ custom_monitor: None
 ###############################
 # detector related parameters #
 ###############################
-detector: "Maxipix"  # "Eiger2M", "Maxipix", "Eiger4M", "Merlin" or "Timepix"
-phasing_binning: [1, 2, 2]  # binning to apply to the data
+detector: "Timepix"  # "Eiger2M", "Maxipix", "Eiger4M", "Merlin" or "Timepix"
+phasing_binning: [1, 1, 1]  # binning to apply to the data
 # (stacking dimension, detector vertical axis, detector horizontal axis)
 linearity_func: None
 # [a, b, c, d, e] tuple of 5 numbers corresponding to the coefficients of the 4th order
 # polynomial ax^4 + bx^3 + cx^2 + dx + e which it used to correct the non-linearity of
 # the detector at high intensities. Leave None otherwise.
-# polynomial a0linearity correction for the detector, leave None otherwise.
 x_bragg: None  # horizontal pixel number of the Bragg peak,
 # can be used for the definition of the ROI
 y_bragg: None  # vertical pixel number of the Bragg peak,
@@ -134,7 +133,7 @@ frames_pattern: None
 background_file: None  # non-empty file path or None
 hotpixels_file: None  # non-empty file path or None
 flatfield_file: None  # non-empty file path or None
-template_imagefile: "data_mpx4_%05d.edf.gz"
+template_imagefile: "Dmitry1120c_S0622_%05d.tif"
 # template for ID01: 'data_mpx4_%05d.edf.gz' or 'align_eiger2M_%05d.edf.gz'
 # template for SIXS_2018: 'align.spec_ascan_mu_%05d.nxs'
 # template for SIXS_2019: 'spare_ascan_mu_%05d.nxs'
@@ -149,10 +148,10 @@ use_rawdata: True  # False for using data gridded in laboratory frame
 # True for using data in detector frame
 interpolation_method: "xrayutilities"  # 'xrayutilities' or 'linearization'
 fill_value_mask: 0  # 0 (not masked) or 1 (masked).
-# It will define how the pixels outside of the data range are
+# It will define how the pixels outside the data range are
 # processed during the interpolation. Because of the large number of masked pixels,
 # phase retrieval converges better if the pixels are not masked (0 intensity
-# imposed). The data is by default set to 0 outside of the defined range.
+# imposed). The data is by default set to 0 outside the defined range.
 beam_direction: [1, 0, 0]
 # beam direction in the laboratory frame (downstream, vertical up, outboard)
 sample_offsets: None

--- a/conf/config_preprocessing.yml
+++ b/conf/config_preprocessing.yml
@@ -140,7 +140,7 @@ template_imagefile: "Dmitry1120c_S0622_%05d.tif"
 # template for Cristal: 'S%d.nxs'
 # template for P10: '_master.h5'
 # template for NANOMAX: '%06d.h5'
-# template for 34ID: 'Sample%dC_ES_data_51_256_256.npz'
+# template for 34ID: 'some_name_%05d.tif'
 ################################################################################
 # define parameters below if you want to orthogonalize the data before phasing #
 ################################################################################

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,6 +1,8 @@
 Future:
 -------
 
+* Support APS 34ID-C for data preprocessing (loading of TIFF images)
+
 * Update the parameter "linearity_function" in preprocessing. Now this can be None (if
   unused) or a sequence of 5 real numbers corresponding to the coefficients of a 4th
   order polynomial.

--- a/doc/modules/experiment/index.rst
+++ b/doc/modules/experiment/index.rst
@@ -52,7 +52,7 @@ The geometry of the following beamlines is implemented:
  * CRISTAL (SOLEIL)
  * SIXS (SOLEIL)
  * NANOMAX (MAX IV)
- * 34ID-C (APS): only for postprocessing
+ * 34ID-C (APS)
 
 The following detectors are implemented:
 

--- a/scripts/postprocessing/bcdi_correct_angles_detector.py
+++ b/scripts/postprocessing/bcdi_correct_angles_detector.py
@@ -33,11 +33,11 @@ Supported beamlines: ESRF ID01, PETRAIII P10, SOLEIL SIXS, SOLEIL CRISTAL.
 Input: direct beam and Bragg peak position, sample to detector distance, energy.
 Output: corrected inplane, out-of-plane detector angles for the Bragg peak.
 """
-scan = 76
-root_folder = "C:/Users/Jerome/Documents/data/dataset_P10/"
-data_dir = None
+scan = 622
+root_folder = "C:/Users/Jerome/Documents/data/dataset_34ID/IzrO/"
+data_dir = "C:/Users/Jerome/Documents/data/dataset_34ID/IzrO/S622/data/"
 # leave None to use the beamline default. It will look for the data at this location
-sample_name = "B15_syn_S1_2"
+sample_name = "S"
 filtered_data = False  # set to True if the data is already a 3D array, False otherwise
 # Should be the same shape as in specfile
 peak_method = "maxcom"  # Bragg peak determination: 'max', 'com' or 'maxcom'.
@@ -48,77 +48,70 @@ debug = False  # True to see more plots
 ######################################
 # define beamline related parameters #
 ######################################
-beamline = "P10"
+beamline = "34ID"
 # name of the beamline, used for data loading and normalization by monitor
 # supported beamlines: 'ID01', 'SIXS_2018', 'SIXS_2019', 'CRISTAL', 'P10'
-actuators = None  # {'rocking_angle': 'actuator_1_3'}
+actuators = None
 # Optional dictionary that can be used to define the entries corresponding to
 # actuators in data files
 # (useful at CRISTAL where the location of data keeps changing)
 # e.g.  {'rocking_angle': 'actuator_1_3', 'detector': 'data_04', 'monitor': 'data_05'}
-is_series = True  # specific to series measurement at P10
-
+is_series = False  # specific to series measurement at P10
 custom_scan = False  # True for a stack of images acquired without scan,
 # e.g. with ct in a macro (no info in spec file)
-custom_images = np.arange(11353, 11453, 1)  # list of image numbers for the custom_scan
-custom_monitor = np.ones(
-    len(custom_images)
-)  # monitor values for normalization for the custom_scan
-custom_motors = {
-    "eta": np.linspace(16.989, 18.989, num=100, endpoint=False),
-    "phi": 0,
-    "nu": -0.75,
-    "delta": 36.65,
-}
+custom_images = None
+# list of image numbers for the custom_scan
+custom_monitor = None
+# monitor values for normalization for the custom_scan
+custom_motors = None
 # ID01: eta, phi, nu, delta
 # CRISTAL: mgomega, gamma, delta
 # P10: om, phi, chi, mu, gamma, delta
 # SIXS: beta, mu, gamma, delta
-
-rocking_angle = "outofplane"  # "outofplane" or "inplane"
-specfile_name = ""
-# template for ID01: name of the spec file without '.spec'
+rocking_angle = "inplane"  # "outofplane" or "inplane"
+specfile_name = "C:/Users/Jerome/Documents/data/dataset_34ID/Dmitry1120c.spec"
+# template for ID01 and 34ID: name of the spec file if it is at the default location
+# (in root_folder) or full path to the spec file
 # template for SIXS_2018: full path of the alias dictionnary 'alias_dict.txt',
 # typically: root_folder + 'alias_dict.txt'
 # template for all other beamlines: ''
 #############################################################
 # define detector related parameters and region of interest #
 #############################################################
-detector = "Eiger4M"  # "Eiger2M" or "Maxipix" or "Eiger4M"
-x_bragg = 1355  # horizontal pixel number of the Bragg peak,
+detector = "Timepix"  # detector name
+x_bragg = None  # horizontal pixel number of the Bragg peak,
 # can be used for the definition of the ROI
-y_bragg = 796  # vertical pixel number of the Bragg peak,
+y_bragg = None  # vertical pixel number of the Bragg peak,
 # can be used for the definition of the ROI
-roi_detector = [y_bragg - 400, y_bragg + 400, x_bragg - 400, x_bragg + 400]  #
+roi_detector = None  # [y_bragg - 400, y_bragg + 400, x_bragg - 400, x_bragg + 400]  #
 # leave it as None to use the full detector.
 # Use with center_fft='do_nothing' if you want this exact size.
-high_threshold = 1000000  # everything above will be considered as hotpixel
+high_threshold = 500000  # everything above will be considered as hotpixel
 hotpixels_file = None
 # non empty file path or None
-flatfield_file = (
-    None  # root_folder + "flatfield_maxipix_8kev.npz"  # non empty file path or None
-)
-template_imagefile = "_master.h5"
+flatfield_file = None
+# non empty file path or None
+template_imagefile = "Dmitry1120c_S0622_%05d.tif"
 # template for ID01: 'data_mpx4_%05d.edf.gz' or 'align_eiger2M_%05d.edf.gz'
 # template for SIXS_2018: 'align.spec_ascan_mu_%05d.nxs'
 # template for SIXS_2019: 'spare_ascan_mu_%05d.nxs'
 # template for Cristal: 'S%d.nxs'
 # template for P10: '_master.h5'
 # template for NANOMAX: '%06d.h5'
-# template for 34ID: 'Sample%dC_ES_data_51_256_256.npz'
+# template for 34ID: "Dmitry1120c_S0622_%05d.tif"
 ###################################
 # define setup related parameters #
 ###################################
 beam_direction = (1, 0, 0)  # beam along z
-sample_offsets = (0, 0, 90, 0)
+sample_offsets = None
 # tuple of offsets in degrees of the sample around (downstream, vertical up, outboard)
 # convention: the sample offsets will be subtracted to the motor values
-directbeam_x = 913.64  # x horizontal,  cch2 in xrayutilities
-directbeam_y = 1055  # y vertical,  cch1 in xrayutilities
+directbeam_x = 0  # x horizontal,  cch2 in xrayutilities
+directbeam_y = 0  # y vertical,  cch1 in xrayutilities
 direct_inplane = 0.0  # outer angle in xrayutilities
 direct_outofplane = 0.0
-sdd = 1.83  # sample to detector distance in m
-energy = 8170  # in eV, offset of 6eV at ID01
+sdd = 0.5002125  # sample to detector distance in m
+energy = 9000  # in eV, offset of 6eV at ID01
 ################################################
 # parameters related to temperature estimation #
 ################################################
@@ -130,9 +123,9 @@ reference_spacing = None  # for calibrating the thermal expansion,
 # if None it is fixed to Pt 3.9236/norm(reflection)
 reference_temperature = None
 # used to calibrate the thermal expansion, if None it is fixed to 293.15K (RT)
-##########################################################
-# end of user parameters
-##########################################################
+##########################
+# end of user parameters #
+##########################
 
 plt.ion()
 #######################

--- a/scripts/postprocessing/bcdi_correct_angles_detector.py
+++ b/scripts/postprocessing/bcdi_correct_angles_detector.py
@@ -69,7 +69,7 @@ custom_motors = None
 # P10: om, phi, chi, mu, gamma, delta
 # SIXS: beta, mu, gamma, delta
 rocking_angle = "inplane"  # "outofplane" or "inplane"
-specfile_name = "C:/Users/Jerome/Documents/data/dataset_34ID/Dmitry1120c.spec"
+specfile_name = "Dmitry1120c.spec"
 # template for ID01 and 34ID: name of the spec file if it is at the default location
 # (in root_folder) or full path to the spec file
 # template for SIXS_2018: full path of the alias dictionnary 'alias_dict.txt',

--- a/scripts/preprocessing/bcdi_preprocess_BCDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_BCDI.py
@@ -235,7 +235,7 @@ Usage:
      - template for Cristal: 'S%d.nxs'
      - template for P10: '_master.h5'
      - template for NANOMAX: '%06d.h5'
-     - template for 34ID: 'Sample%dC_ES_data_51_256_256.npz'
+     - template for 34ID: 'some_name_%05d.tif'
 
     Parameters below if you want to orthogonalize the data before phasing:
 


### PR DESCRIPTION
Add support in preprocessing for 34ID (loading TIFF images)

Fixes #192 

- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?

preprocessing_BCDI.py and correct_angles_detector.py runs as expected for a 34ID dataset

## Checklist:

- [X] I have made corresponding changes to the documentation
- [X] I have run ``doit`` and all tasks have passed
