### PR TITLE
return the transformation matrix from the detector frame to the laboratory frame

### DIFF
--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -1348,6 +1348,8 @@ class Setup:
          - an array (if a single array was provided) or a tuple of arrays interpolated
            on an orthogonal grid (same length as the number of input arrays)
          - a tuple of 3 voxels size for the interpolated arrays
+         - a numpy array of shape (3, 3): transformation matrix from the detector
+           frame to the laboratory/crystal frame
 
         """
         if isinstance(arrays, np.ndarray):
@@ -1704,7 +1706,7 @@ class Setup:
 
         if nb_arrays == 1:
             output_arrays = output_arrays[0]  # return the array instead of the tuple
-        return output_arrays, voxel_size
+        return output_arrays, voxel_size, transfer_matrix
 
     def ortho_reciprocal(
         self,

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -1754,6 +1754,8 @@ class Setup:
          - an array (if a single array was provided) or a tuple of arrays interpolated
            on an orthogonal grid (same length as the number of input arrays)
          - a tuple of three 1D vectors of q values (qx, qz, qy)
+         - a numpy array of shape (3, 3): transformation matrix from the detector
+           frame to the laboratory/crystal frame
 
         """
         valid.valid_ndarray(arrays, ndim=3)
@@ -2102,7 +2104,7 @@ class Setup:
 
         if nb_arrays == 1:
             output_arrays = output_arrays[0]  # return the array instead of the tuple
-        return output_arrays, (qx, qz, qy)
+        return output_arrays, (qx, qz, qy), transfer_matrix
 
     def orthogonalize_vector(
         self, vector, array_shape, tilt_angle, pixel_x, pixel_y, verbose=False

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -684,8 +684,14 @@ def grid_bcdi_labframe(
        of the interpolation range. The first value is for the data, the second for the
        mask. Default is (0, 0)
 
-    :return: the data and mask interpolated in the laboratory frame, q values
-     (downstream, vertical up, outboard). q values are in inverse angstroms.
+    :return:
+
+     - the data interpolated in the laboratory frame
+     - the mask interpolated in the laboratory frame
+     - a tuple of three 1D vectors of q values (qx, qz, qy)
+     - a numpy array of shape (3, 3): transformation matrix from the detector
+       frame to the laboratory/crystal frame
+
     """
     valid.valid_ndarray(arrays=(data, mask), ndim=3)
     # check and load kwargs

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -724,7 +724,7 @@ def grid_bcdi_labframe(
         " the result will be in the laboratory frame"
     )
     string = "linmat_reciprocal_space_"
-    (interp_data, interp_mask), q_values = setup.ortho_reciprocal(
+    (interp_data, interp_mask), q_values, transfer_matrix = setup.ortho_reciprocal(
         arrays=(data, mask),
         verbose=True,
         debugging=debugging,

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -826,7 +826,7 @@ def grid_bcdi_labframe(
             reciprocal_space=True,
         )
 
-    return interp_data, interp_mask, q_values
+    return interp_data, interp_mask, q_values, transfer_matrix
 
 
 def grid_bcdi_xrayutil(

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,6 +1,9 @@
 Future:
 -------
 
+* The methods setup.ortho_directspace and setup.ortho_reciprocal now return also the
+  transformation matrix from the detector frame to the laboratory frame
+
 * Support APS 34ID-C for data preprocessing (loading of TIFF images)
 
 * Update the parameter "linearity_function" in preprocessing. Now this can be None (if

--- a/scripts/postprocessing/bcdi_strain.py
+++ b/scripts/postprocessing/bcdi_strain.py
@@ -882,7 +882,7 @@ def run(prm):
             del phase
             gc.collect()
 
-        obj_ortho, voxel_size = setup.ortho_directspace(
+        obj_ortho, voxel_size, transfer_matrix = setup.ortho_directspace(
             arrays=avg_obj,
             q_com=np.array([q_lab[2], q_lab[1], q_lab[0]]),
             initial_shape=original_size,
@@ -892,7 +892,7 @@ def run(prm):
             debugging=True,
             title="amplitude",
         )
-
+        prm["transformation_matrix"] = transfer_matrix
     else:  # data already orthogonalized using xrayutilities
         # or the linearized transformation matrix
         obj_ortho = avg_obj

--- a/scripts/preprocessing/bcdi_preprocess_BCDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_BCDI.py
@@ -935,7 +935,7 @@ def run(prm):
                     # (qx downstream, qy outboard, qz vertical up)
                     # for reference_axis, the frame is z downstream, y vertical up,
                     # x outboard but the order must be x,y,z
-                    data, mask, q_values = bu.grid_bcdi_labframe(
+                    data, mask, q_values, transfer_matrix = bu.grid_bcdi_labframe(
                         data=data,
                         mask=mask,
                         detector=detector,
@@ -945,6 +945,7 @@ def run(prm):
                         debugging=debug,
                         fill_value=(0, prm["fill_value_mask"]),
                     )
+                    prm["transformation_matrix"] = transfer_matrix
                 nz, ny, nx = data.shape
                 print(
                     "\nData size after interpolation into an orthonormal frame:"


### PR DESCRIPTION
# Pull Request Template

The methods setup.ortho_directspace and setup.ortho_reciprocal now return also the transformation matrix from the detector frame to the laboratory frame. The matrix can then be saved as other parameters

Fixes #185 

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- 
## How has this been tested?

pre- and postprocessing scripts run as expected.

## Checklist:

- [X] I have made corresponding changes to the documentation
- [X] I have run ``doit`` and all tasks have passed
