### PR TITLE
Load positions from the log file when available (Lazy user)

### DIFF
--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -816,15 +816,10 @@ class BeamlineID01(Beamline):
             name="filename",
         )
 
-        if os.path.isfile(filename):
-            # filename is already the full path to the .spec file
-            return SpecFile(filename)
-        print(f"Could not find the spec file at: {filename}")
-
-        if not os.path.isdir(root_folder):
-            raise ValueError(f"The directory {root_folder} does not exist")
-        path = root_folder + filename
-        print(f"Trying to load the spec file at: {path}")
+        path = util.find_file(
+            filename=filename,
+            default_folder=root_folder
+        )
         return SpecFile(path)
 
     @property
@@ -2365,15 +2360,10 @@ class Beamline34ID(Beamline):
             name="filename",
         )
 
-        if os.path.isfile(filename):
-            # filename is already the full path to the .spec file
-            return SpecFile(filename)
-        print(f"Could not find the spec file at: {filename}")
-
-        if not os.path.isdir(root_folder):
-            raise ValueError(f"The directory {root_folder} does not exist")
-        path = root_folder + filename
-        print(f"Trying to load the spec file at: {path}")
+        path = util.find_file(
+            filename=filename,
+            default_folder=root_folder
+        )
         return SpecFile(path)
 
     @property

--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -46,7 +46,7 @@ API Reference
 """
 from abc import ABC, abstractmethod
 import h5py
-from math import isclose
+from math import hypot, isclose
 import numpy as np
 from numbers import Real
 import os
@@ -1838,7 +1838,7 @@ class BeamlineP10SAXS(BeamlineP10):
             interp_angle[x_interp == 0]
         )
 
-        interp_radius = np.multiply(sign_array, np.sqrt(x_interp ** 2 + z_interp ** 2))
+        interp_radius = np.multiply(sign_array, hypot(x_interp, z_interp))
 
         if debugging:
             gu.imshow_plot(

--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -2637,7 +2637,8 @@ class Beamline34ID(Beamline):
                         * (
                             np.cos(grazing_angle[0])
                             * (np.cos(inplane) * np.cos(outofplane) - 1)
-                            + np.sin(grazing_angle[0]) * np.sin(inplane)
+                            + np.sin(grazing_angle[0])
+                            * np.sin(inplane)
                             * np.cos(outofplane)
                         ),
                         (

--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -1523,7 +1523,9 @@ class BeamlineP10(Beamline):
 
         homedir = root_folder + default_specfile + "/"
         default_dirname = "e4m/"
-        template_imagefile = default_specfile + template_imagefile
+
+        if template_imagefile is not None:
+            template_imagefile = default_specfile + template_imagefile
         return homedir, default_dirname, specfile, template_imagefile
 
     def process_positions(

--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -1516,13 +1516,14 @@ class BeamlineP10(Beamline):
 
         """
         specfile = kwargs.get("specfile_name")
+        default_specfile = sample_name + "_{:05d}".format(scan_number)
         if specfile is None or not os.path.isfile(specfile):
             # default to the usual position of .fio at P10
-            specfile = sample_name + "_{:05d}".format(scan_number)
+            specfile = default_specfile
 
-        homedir = root_folder + specfile + "/"
+        homedir = root_folder + default_specfile + "/"
         default_dirname = "e4m/"
-        template_imagefile = specfile + template_imagefile
+        template_imagefile = default_specfile + template_imagefile
         return homedir, default_dirname, specfile, template_imagefile
 
     def process_positions(

--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -380,7 +380,6 @@ class Beamline(ABC):
         """
         motor_positions = setup.diffractometer.motor_positions(
             setup=setup,
-            logfile=logfile,
             scan_number=scan_number,
         )
         # remove the motor positions corresponding to deleted frames during data

--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -816,10 +816,7 @@ class BeamlineID01(Beamline):
             name="filename",
         )
 
-        path = util.find_file(
-            filename=filename,
-            default_folder=root_folder
-        )
+        path = util.find_file(filename=filename, default_folder=root_folder)
         return SpecFile(path)
 
     @property
@@ -2360,10 +2357,7 @@ class Beamline34ID(Beamline):
             name="filename",
         )
 
-        path = util.find_file(
-            filename=filename,
-            default_folder=root_folder
-        )
+        path = util.find_file(filename=filename, default_folder=root_folder)
         return SpecFile(path)
 
     @property

--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -820,12 +820,12 @@ class BeamlineID01(Beamline):
         if os.path.isfile(filename):
             # filename is already the full path to the .spec file
             return SpecFile(filename)
-        print(f"Could not find the spec file at {filename}")
+        print(f"Could not find the spec file at: {filename}")
 
         if not os.path.isdir(root_folder):
             raise ValueError(f"The directory {root_folder} does not exist")
         path = root_folder + filename
-        print(f"Trying to load the spec file at {path}")
+        print(f"Trying to load the spec file at: {path}")
         return SpecFile(path)
 
     @property
@@ -1463,14 +1463,14 @@ class BeamlineP10(Beamline):
         if os.path.isfile(filename):
             # filename is already the full path to the .fio file
             return filename
-        print(f"Could not find the spec file at {filename}")
+        print(f"Could not find the fio file at: {filename}")
 
         if not os.path.isdir(root_folder):
             raise ValueError(f"The directory {root_folder} does not exist")
 
         # return the path to the .fio file
         path = root_folder + filename + "/" + filename + ".fio"
-        print(f"Trying to load the fio file at {path}")
+        print(f"Trying to load the fio file at: {path}")
         return path
 
     @property
@@ -2366,12 +2366,12 @@ class Beamline34ID(Beamline):
         if os.path.isfile(filename):
             # filename is already the full path to the .spec file
             return SpecFile(filename)
-        print(f"Could not find the spec file at {filename}")
+        print(f"Could not find the spec file at: {filename}")
 
         if not os.path.isdir(root_folder):
             raise ValueError(f"The directory {root_folder} does not exist")
         path = root_folder + filename
-        print(f"Trying to load the spec file at {path}")
+        print(f"Trying to load the spec file at: {path}")
         return SpecFile(path)
 
     @property

--- a/bcdi/experiment/detector.py
+++ b/bcdi/experiment/detector.py
@@ -534,7 +534,7 @@ class Detector(ABC):
             container_types=str,
             min_length=0,
             allow_none=True,
-            name="Detector.imagefile",
+            name="template_imagefile",
         )
         self._template_imagefile = value
 

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -2072,8 +2072,7 @@ class DiffractometerID01(Diffractometer):
         :return: the detector distance in meters or None
         """
         path = util.find_file(
-            filename=setup.detector.specfile,
-            default_folder=setup.detector.rootdir
+            filename=setup.detector.specfile, default_folder=setup.detector.rootdir
         )
 
         distance = None
@@ -2089,8 +2088,10 @@ class DiffractometerID01(Diffractometer):
                             found_distance += 1
 
         if found_distance > 1:
-            print("multiple dectector distances found in the spec file, using"
-                  f"{distance} m.")
+            print(
+                "multiple dectector distances found in the spec file, using"
+                f"{distance} m."
+            )
         return distance
 
 

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -1435,6 +1435,8 @@ class DiffractometerCRISTAL(Diffractometer):
         else:
             raise ValueError('Wrong value for "rocking_angle" parameter')
 
+        setup.grazing_angle = grazing
+
         # update the energy and the detector distance if not provided by the user
         setup.energy = setup.energy or energy
         setup.distance = setup.distance or detector_distance
@@ -1587,19 +1589,6 @@ class DiffractometerCRISTAL(Diffractometer):
                     actuator_name="i06-c-c07-ex-mg_phi",
                     field_name="position",
                 )
-                delta = self.cristal_load_motor(
-                    datafile=logfile,
-                    root="/" + group_key + "/CRISTAL/Diffractometer/",
-                    actuator_name="I06-C-C07-EX-DIF-DELTA",
-                    field_name="position",
-                )
-                gamma = self.cristal_load_motor(
-                    datafile=logfile,
-                    root="/" + group_key + "/CRISTAL/Diffractometer/",
-                    actuator_name="I06-C-C07-EX-DIF-GAMMA",
-                    field_name="position",
-                )
-
             elif setup.rocking_angle == "inplane":
                 mgphi = scanned_motor  # mgphi is scanned
                 mgomega = self.cristal_load_motor(
@@ -1608,20 +1597,21 @@ class DiffractometerCRISTAL(Diffractometer):
                     actuator_name="i06-c-c07-ex-mg_omega",
                     field_name="position",
                 )
-                delta = self.cristal_load_motor(
-                    datafile=logfile,
-                    root="/" + group_key + "/CRISTAL/Diffractometer/",
-                    actuator_name="I06-C-C07-EX-DIF-DELTA",
-                    field_name="position",
-                )
-                gamma = self.cristal_load_motor(
-                    datafile=logfile,
-                    root="/" + group_key + "/CRISTAL/Diffractometer/",
-                    actuator_name="I06-C-C07-EX-DIF-GAMMA",
-                    field_name="position",
-                )
             else:
                 raise ValueError('Wrong value for "rocking_angle" parameter')
+
+            delta = self.cristal_load_motor(
+                datafile=logfile,
+                root="/" + group_key + "/CRISTAL/Diffractometer/",
+                actuator_name="I06-C-C07-EX-DIF-DELTA",
+                field_name="position",
+            )
+            gamma = self.cristal_load_motor(
+                datafile=logfile,
+                root="/" + group_key + "/CRISTAL/Diffractometer/",
+                actuator_name="I06-C-C07-EX-DIF-GAMMA",
+                field_name="position",
+            )
 
             # remove user-defined sample offsets (sample: mgomega, mgphi)
             mgomega = mgomega - self.sample_offsets[0]
@@ -1832,6 +1822,8 @@ class DiffractometerID01(Diffractometer):
             tilt, inplane, outofplane = phi, nu, delta
         else:
             raise ValueError('Wrong value for "rocking_angle" parameter')
+
+        setup.grazing_angle = grazing
 
         # update the energy and the detector distance if not provided by the user
         setup.energy = setup.energy or energy
@@ -2168,6 +2160,8 @@ class DiffractometerNANOMAX(Diffractometer):
         else:
             raise ValueError('Wrong value for "rocking_angle" parameter')
 
+        setup.grazing_angle = grazing
+
         # update the energy and the detector distance if not provided by the user
         setup.energy = setup.energy or energy
         setup.distance = setup.distance or detector_distance
@@ -2417,6 +2411,8 @@ class DiffractometerP10(Diffractometer):
         else:
             raise ValueError('Wrong value for "rocking_angle" parameter')
 
+        setup.grazing_angle = grazing
+
         # update the energy and the detector distance if not provided by the user
         setup.energy = setup.energy or energy
         setup.distance = setup.distance or detector_distance
@@ -2608,6 +2604,7 @@ class DiffractometerP10(Diffractometer):
                 mu = None
                 gamma = None
                 delta = None
+                energy = None
 
                 fio_lines = fio.readlines()
                 for line in fio_lines:
@@ -2652,6 +2649,10 @@ class DiffractometerP10(Diffractometer):
                         "mu" in words and "=" in words
                     ):  # template for positioners: 'mu = 0.0\n'
                         mu = float(words[2])
+                    if (
+                        "fmbenergy" in words and "=" in words
+                    ):  # template for positioners: 'mu = 0.0\n'
+                        energy = float(words[2])
 
                     if index_om is not None and util.is_float(words[0]):
                         # reading data and index_om is defined (outofplane case)
@@ -2680,7 +2681,9 @@ class DiffractometerP10(Diffractometer):
             delta = setup.custom_motors["delta"]
             gamma = setup.custom_motors["gamma"]
             mu = setup.custom_motors["mu"]
-        return mu, om, chi, phi, gamma, delta, setup.energy, setup.distance
+            energy = setup.energy
+
+        return mu, om, chi, phi, gamma, delta, energy, setup.distance
 
     @staticmethod
     def read_device(logfile, device_name, **kwargs):
@@ -2781,6 +2784,8 @@ class DiffractometerP10SAXS(DiffractometerP10):
             tilt = phi
         else:
             raise ValueError('Wrong value for "rocking_angle" parameter')
+
+        setup.grazing_angle = grazing
 
         # update the energy and the detector distance if not provided by the user
         setup.energy = setup.energy or energy
@@ -2897,6 +2902,8 @@ class DiffractometerSIXS(Diffractometer):
             )
         else:
             raise ValueError("Out-of-plane rocking curve not implemented for SIXS")
+
+        setup.grazing_angle = grazing
 
         # update the energy and the detector distance if not provided by the user
         setup.energy = setup.energy or energy
@@ -3157,6 +3164,8 @@ class Diffractometer34ID(Diffractometer):
             tilt, inplane, outofplane = (phi, delta, gamma)
         else:
             raise ValueError('Wrong value for "rocking_angle" parameter')
+
+        setup.grazing_angle = grazing
 
         # update the energy and the detector distance if not provided by the user
         setup.energy = setup.energy or energy

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -72,7 +72,7 @@ import re
 import sys
 import tkinter as tk
 from tkinter import filedialog
-from typing import List
+from typing import List, Optional
 
 from ..graph import graph_utils as gu
 from .rotation_matrix import RotationMatrix
@@ -2012,6 +2012,8 @@ class DiffractometerID01(Diffractometer):
             nu = setup.custom_motors["nu"]
             energy = setup.energy
 
+        detector_distance = self.retrieve_distance(setup=setup) or setup.distance
+
         return mu, eta, phi, nu, delta, energy, setup.distance
 
     @staticmethod
@@ -2059,6 +2061,21 @@ class DiffractometerID01(Diffractometer):
             return self.read_device(
                 logfile=setup.logfile, scan_number=scan_number, device_name=monitor_name
             )
+        return None
+
+    @staticmethod
+    def retrieve_distance(setup) -> Optional[float]:
+        """
+        Load the spec file and retrieve the detector distance if it has been calibrated.
+
+        :param setup: an instance of the class Setup
+        :return: the detector distance in meters or None
+        """
+        path = util.find_file(
+            filename=setup.detector.specfile,
+            default_folder=setup.detector.rootdir
+        )
+
         return None
 
 

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -2616,8 +2616,6 @@ class DiffractometerP10(Diffractometer):
                 else:  # phi
                     phi = np.asarray(phi, dtype=float)
 
-                fio.close()
-
                 # remove user-defined sample offsets (sample: mu, om, chi, phi)
                 mu = mu - self.sample_offsets[0]
                 om = om - self.sample_offsets[1]

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -2014,7 +2014,7 @@ class DiffractometerID01(Diffractometer):
 
         detector_distance = self.retrieve_distance(setup=setup) or setup.distance
 
-        return mu, eta, phi, nu, delta, energy, setup.distance
+        return mu, eta, phi, nu, delta, energy, detector_distance
 
     @staticmethod
     def read_device(logfile, device_name, **kwargs):
@@ -2076,7 +2076,22 @@ class DiffractometerID01(Diffractometer):
             default_folder=setup.detector.rootdir
         )
 
-        return None
+        distance = None
+        found_distance = 0
+        with open(path, "r") as file:
+            lines = file.readlines()
+            for line in lines:
+                if line.startswith("#UDETCALIB"):
+                    words = line.split(",")
+                    for word in words:
+                        if word.startswith("det_distance_COM"):
+                            distance = float(word[17:])
+                            found_distance += 1
+
+        if found_distance > 1:
+            print("multiple dectector distances found in the spec file, using"
+                  f"{distance} m.")
+        return distance
 
 
 class DiffractometerNANOMAX(Diffractometer):

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -1428,28 +1428,28 @@ class DiffractometerCRISTAL(Diffractometer):
         # define the circles of interest for BCDI
         if setup.rocking_angle == "outofplane":  # mgomega rocking curve
             grazing = None  # nothing below mgomega at CRISTAL
-            tilt = mgomega
+            tilt_angle = mgomega
         elif setup.rocking_angle == "inplane":  # phi rocking curve
             grazing = (mgomega[0],)
-            tilt = mgphi
+            tilt_angle = mgphi
         else:
             raise ValueError('Wrong value for "rocking_angle" parameter')
 
-        setup.grazing_angle = grazing
-
-        # update the energy and the detector distance if not provided by the user
-        setup.energy = setup.energy or energy
-        setup.distance = setup.distance or detector_distance
-        setup.outofplane_angle = setup.outofplane_angle or outofplane_angle
-        setup.inplane_angle = setup.inplane_angle or inplane_angle
-        setup.tilt_angle = setup.tilt_angle or (tilt[1:]-tilt[0:-1]).mean()
+        setup.check_goniometer(
+            grazing_angle=grazing,
+            inplane_angle=inplane_angle,
+            outofplane_angle=outofplane_angle,
+            tilt_angle=tilt_angle,
+            detector_distance=detector_distance,
+            energy=energy
+        )
 
         # CRISTAL goniometer, 2S+2D (sample: mgomega, mgphi / detector: gamma, delta)
         if stage_name == "sample":
             return mgomega, mgphi
         if stage_name == "detector":
             return inplane_angle, outofplane_angle
-        return tilt, grazing, inplane_angle[0], outofplane_angle[0]
+        return tilt_angle, grazing, inplane_angle[0], outofplane_angle[0]
 
     def load_data(
         self,
@@ -1813,28 +1813,28 @@ class DiffractometerID01(Diffractometer):
         # define the circles of interest for BCDI
         if setup.rocking_angle == "outofplane":  # eta rocking curve
             grazing = (mu,)  # mu below eta but not used at ID01
-            tilt = eta
+            tilt_angle = eta
         elif setup.rocking_angle == "inplane":  # phi rocking curve
             grazing = (mu, eta)  # mu below eta but not used at ID01
-            tilt = phi
+            tilt_angle = phi
         else:
             raise ValueError('Wrong value for "rocking_angle" parameter')
 
-        setup.grazing_angle = grazing
-
-        # update the energy and the detector distance if not provided by the user
-        setup.energy = setup.energy or energy
-        setup.distance = setup.distance or detector_distance
-        setup.outofplane_angle = setup.outofplane_angle or outofplane_angle
-        setup.inplane_angle = setup.inplane_angle or inplane_angle
-        setup.tilt_angle = setup.tilt_angle or (tilt[1:]-tilt[0:-1]).mean()
+        setup.check_goniometer(
+            grazing_angle=grazing,
+            inplane_angle=inplane_angle,
+            outofplane_angle=outofplane_angle,
+            tilt_angle=tilt_angle,
+            detector_distance=detector_distance,
+            energy=energy
+        )
 
         # ID01 goniometer, 3S+2D (sample: eta, chi, phi / detector: nu,del)
         if stage_name == "sample":
             return mu, eta, phi
         if stage_name == "detector":
             return inplane_angle, outofplane_angle
-        return tilt, grazing, inplane_angle, outofplane_angle
+        return tilt_angle, grazing, inplane_angle, outofplane_angle
 
     def load_data(
         self,
@@ -2147,28 +2147,28 @@ class DiffractometerNANOMAX(Diffractometer):
         # define the circles of interest for BCDI
         if setup.rocking_angle == "outofplane":  # theta rocking curve
             grazing = None  # nothing below theta at NANOMAX
-            tilt = theta
+            tilt_angle = theta
         elif setup.rocking_angle == "inplane":  # phi rocking curve
             grazing = (theta,)
-            tilt = phi
+            tilt_angle = phi
         else:
             raise ValueError('Wrong value for "rocking_angle" parameter')
 
-        setup.grazing_angle = grazing
-
-        # update the energy and the detector distance if not provided by the user
-        setup.energy = setup.energy or energy
-        setup.distance = setup.distance or detector_distance
-        setup.outofplane_angle = setup.outofplane_angle or outofplane_angle
-        setup.inplane_angle = setup.inplane_angle or inplane_angle
-        setup.tilt_angle = setup.tilt_angle or (tilt[1:]-tilt[0:-1]).mean()
+        setup.check_goniometer(
+            grazing_angle=grazing,
+            inplane_angle=inplane_angle,
+            outofplane_angle=outofplane_angle,
+            tilt_angle=tilt_angle,
+            detector_distance=detector_distance,
+            energy=energy
+        )
 
         # NANOMAX goniometer, 2S+2D (sample: theta, phi / detector: gamma,delta)
         if stage_name == "sample":
             return theta, phi
         if stage_name == "detector":
             return inplane_angle, outofplane_angle
-        return tilt, grazing, inplane_angle, outofplane_angle
+        return tilt_angle, grazing, inplane_angle, outofplane_angle
 
     def load_data(
         self,
@@ -2395,28 +2395,28 @@ class DiffractometerP10(Diffractometer):
         # define the circles of interest for BCDI
         if setup.rocking_angle == "outofplane":  # om rocking curve
             grazing = (mu,)
-            tilt = om
+            tilt_angle = om
         elif setup.rocking_angle == "inplane":  # phi rocking curve
             grazing = (mu, om, chi)
-            tilt = phi
+            tilt_angle = phi
         else:
             raise ValueError('Wrong value for "rocking_angle" parameter')
 
-        setup.grazing_angle = grazing
-
-        # update the energy and the detector distance if not provided by the user
-        setup.energy = setup.energy or energy
-        setup.distance = setup.distance or detector_distance
-        setup.outofplane_angle = setup.outofplane_angle or outofplane_angle
-        setup.inplane_angle = setup.inplane_angle or inplane_angle
-        setup.tilt_angle = setup.tilt_angle or (tilt[1:]-tilt[0:-1]).mean()
+        setup.check_goniometer(
+            grazing_angle=grazing,
+            inplane_angle=inplane_angle,
+            outofplane_angle=outofplane_angle,
+            tilt_angle=tilt_angle,
+            detector_distance=detector_distance,
+            energy=energy
+        )
 
         # P10 goniometer, 4S+2D (sample: mu, omega, chi, phi / detector: gamma, delta)
         if stage_name == "sample":
             return mu, om, chi, phi
         if stage_name == "detector":
             return inplane_angle, outofplane_angle
-        return tilt, grazing, inplane_angle, outofplane_angle
+        return tilt_angle, grazing, inplane_angle, outofplane_angle
 
     def load_data(
         self,
@@ -2770,23 +2770,25 @@ class DiffractometerP10SAXS(DiffractometerP10):
         # no circle yet below phi at P10
         if setup.rocking_angle == "inplane":  # phi rocking curve
             grazing = (0,)
-            tilt = phi
+            tilt_angle = phi
         else:
             raise ValueError('Wrong value for "rocking_angle" parameter')
 
-        setup.grazing_angle = grazing
-
-        # update the energy and the detector distance if not provided by the user
-        setup.energy = setup.energy or energy
-        setup.distance = setup.distance or detector_distance
-        setup.tilt_angle = setup.tilt_angle or (tilt[1:]-tilt[0:-1]).mean()
+        setup.check_goniometer(
+            grazing_angle=grazing,
+            inplane_angle=0,
+            outofplane_angle=0,
+            tilt_angle=tilt_angle,
+            detector_distance=detector_distance,
+            energy=energy
+        )
 
         # P10 SAXS goniometer, 1S + 0D (sample: phi / detector: None)
         if stage_name == "sample":
             return phi,
         if stage_name == "detector":
             return None
-        return tilt, grazing, None, None
+        return tilt_angle, grazing, 0, 0
 
     def motor_positions(self, setup, **kwargs):
         """
@@ -2882,7 +2884,7 @@ class DiffractometerSIXS(Diffractometer):
         # define the circles of interest for BCDI
         if setup.rocking_angle == "inplane":  # mu rocking curve
             grazing = (beta,)  # beta below the whole diffractomter at SIXS
-            tilt = mu
+            tilt_angle = mu
         elif setup.rocking_angle == "outofplane":
             raise NotImplementedError(
                 "outofplane rocking curve not implemented for SIXS"
@@ -2890,21 +2892,21 @@ class DiffractometerSIXS(Diffractometer):
         else:
             raise ValueError("Out-of-plane rocking curve not implemented for SIXS")
 
-        setup.grazing_angle = grazing
-
-        # update the energy and the detector distance if not provided by the user
-        setup.energy = setup.energy or energy
-        setup.distance = setup.distance or detector_distance
-        setup.outofplane_angle = setup.outofplane_angle or outofplane_angle
-        setup.inplane_angle = setup.inplane_angle or inplane_angle
-        setup.tilt_angle = setup.tilt_angle or (tilt[1:]-tilt[0:-1]).mean()
+        setup.check_goniometer(
+            grazing_angle=grazing,
+            inplane_angle=inplane_angle,
+            outofplane_angle=outofplane_angle,
+            tilt_angle=tilt_angle,
+            detector_distance=detector_distance,
+            energy=energy
+        )
 
         # SIXS goniometer, 2S+3D (sample: beta, mu / detector: beta, gamma, del)
         if stage_name == "sample":
             return beta, mu
         if stage_name == "detector":
             return beta, inplane_angle, outofplane_angle
-        return tilt, grazing, inplane_angle, outofplane_angle
+        return tilt_angle, grazing, inplane_angle, outofplane_angle
 
     def load_data(
         self,
@@ -3141,22 +3143,22 @@ class Diffractometer34ID(Diffractometer):
         if setup.rocking_angle == "inplane":
             # theta is the inplane rotation around the vertical axis at 34ID
             grazing = None  # theta (inplane) is below phi
-            tilt = theta
+            tilt_angle = theta
         elif setup.rocking_angle == "outofplane":
             # phi is the incident angle (out of plane rotation) at 34ID
             grazing = (theta, chi)
-            tilt = phi
+            tilt_angle = phi
         else:
             raise ValueError('Wrong value for "rocking_angle" parameter')
 
-        setup.grazing_angle = grazing
-
-        # update the energy and the detector distance if not provided by the user
-        setup.energy = setup.energy or energy
-        setup.distance = setup.distance or detector_distance
-        setup.outofplane_angle = setup.outofplane_angle or outofplane_angle
-        setup.inplane_angle = setup.inplane_angle or inplane_angle
-        setup.tilt_angle = setup.tilt_angle or (tilt[1:]-tilt[0:-1]).mean()
+        setup.check_goniometer(
+            grazing_angle=grazing,
+            inplane_angle=inplane_angle,
+            outofplane_angle=outofplane_angle,
+            tilt_angle=tilt_angle,
+            detector_distance=detector_distance,
+            energy=energy
+        )
 
         # 34ID-C goniometer, 3S+2D (sample: theta (inplane), chi (close to 90 deg),
         # phi (out of plane)   detector: delta (inplane), gamma)
@@ -3164,7 +3166,7 @@ class Diffractometer34ID(Diffractometer):
             return theta, chi, phi
         if stage_name == "detector":
             return inplane_angle, outofplane_angle
-        return tilt, grazing, inplane_angle, outofplane_angle
+        return tilt_angle, grazing, inplane_angle, outofplane_angle
 
     def load_data(
         self,

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -1417,7 +1417,6 @@ class DiffractometerCRISTAL(Diffractometer):
          incidence angles, inplane detector angle, outofplane detector angle). The
          grazing incidence angles are the positions of circles below the rocking circle.
         """
-
         # load the motor positions
         (
             mgomega,

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -2402,7 +2402,7 @@ class DiffractometerP10(Diffractometer):
         else:
             raise ValueError('Wrong value for "rocking_angle" parameter')
 
-        setup.check_goniometer(
+        setup.check_setup(
             grazing_angle=grazing,
             inplane_angle=inplane_angle,
             outofplane_angle=outofplane_angle,

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -1855,7 +1855,8 @@ class DiffractometerID01(Diffractometer):
         scan_number = kwargs.get("scan_number")
         if scan_number is None:
             raise ValueError("'scan_number' parameter required")
-
+        if detector.template_imagefile is None:
+            raise ValueError("'template_imagefile' must be defined to load the images.")
         ccdfiletmp = os.path.join(detector.datadir, detector.template_imagefile)
         data_stack = None
         if not setup.custom_scan:
@@ -2384,6 +2385,8 @@ class DiffractometerP10(Diffractometer):
          - the monitor values for normalization
 
         """
+        if detector.template_imagefile is None:
+            raise ValueError("'template_imagefile' must be defined to load the images.")
         # template for the master file
         ccdfiletmp = os.path.join(detector.datadir, detector.template_imagefile)
         is_series = setup.is_series
@@ -3071,7 +3074,8 @@ class Diffractometer34ID(Diffractometer):
         scan_number = kwargs.get("scan_number")
         if scan_number is None:
             raise ValueError("'scan_number' parameter required")
-
+        if detector.template_imagefile is None:
+            raise ValueError("'template_imagefile' must be defined to load the images.")
         ccdfiletmp = os.path.join(detector.datadir, detector.template_imagefile)
         data_stack = None
         if not setup.custom_scan:

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -1747,7 +1747,7 @@ class DiffractometerID01(Diffractometer):
             "phi": "phi",
             "nu": "nu",
             "delta": "del",
-            "energy": "energy",
+            "energy": "nrj",
         },
     }
 
@@ -1997,7 +1997,7 @@ class DiffractometerID01(Diffractometer):
                 # energy scanned, override the user-defined energy
                 energy = raw_energy * 1000.0  # switch to eV
             else:  # positioner
-                energy = motor_values[motor_names.index(self.motor_table["energy"])]
+                energy = motor_values[motor_names.index(motor_table["energy"])]
 
             # remove user-defined sample offsets (sample: mu, eta, phi)
             mu = mu - self.sample_offsets[0]

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -755,6 +755,7 @@ class Setup:
         if self.inplane_angle is None:
             raise ValueError("the detector in-plane angle is not defined")
 
+        tilt_angle = np.asarray(tilt_angle)
         self.tilt_angle = self.tilt_angle or np.mean(tilt_angle[1:] - tilt_angle[0:-1])
         if self.tilt_angle is None:
             raise ValueError("the tilt angle is not defined")

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -717,22 +717,25 @@ class Setup:
     def check_setup(
         self,
         grazing_angle: Optional[Tuple[Real, ...]],
-        inplane_angle: Union[Real, np.ndarray],
-        outofplane_angle: Union[Real, np.ndarray],
+        inplane_angle: Real,
+        outofplane_angle: Real,
         tilt_angle: np.ndarray,
         detector_distance: Real,
-        energy: Union[Real, np.ndarray],
+        energy: Real,
     ) -> None:
         """
         Check if the required parameters are correctly defined.
 
+        This method is called in Diffractometer.goniometer_value, which is used only for
+        the geometric transformation using the linearized transformation matrix. Hence,
+        arrays for detector angles and the energy are not allowed.
+
         :param grazing_angle:
-        :param inplane_angle:
-        :param outofplane_angle:
-        :param tilt_angle:
-        :param detector_distance:
-        :param energy:
-        :return:
+        :param inplane_angle: detector inplane angle in degrees
+        :param outofplane_angle: detector out-of-plane angle in degrees
+        :param tilt_angle: ndarray of shape (N,), values of the rocking angle
+        :param detector_distance: sample to detector distance in meters
+        :param energy: X-ray energy in eV
         """
         self.grazing_angle = grazing_angle
 

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -742,10 +742,14 @@ class Setup:
         self.energy = self.energy or energy
         if self.energy is None:
             raise ValueError("the X-ray energy is not defined")
+        if not isinstance(self.energy, Real):
+            raise TypeError("the X-ray energy should be fixed")
 
         self.distance = self.distance or detector_distance
         if self.distance is None:
             raise ValueError("the sample to detector distance is not defined")
+        if not isinstance(self.distance, Real):
+            raise TypeError("the sample to detector distance should be fixed")
 
         self.outofplane_angle = self.outofplane_angle or outofplane_angle
         if self.outofplane_angle is None:

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -22,7 +22,7 @@ import numpy as np
 from scipy.interpolate import griddata, RegularGridInterpolator
 import sys
 import time
-from typing import Tuple, Union
+from typing import List, Optional, Tuple, Union
 from ..graph import graph_utils as gu
 from ..utils import utilities as util
 from ..utils import validation as valid
@@ -737,10 +737,10 @@ class Setup:
 
     def check_setup(
         self,
-        grazing_angle: Union[Tuple[Real, ...], None],
+        grazing_angle: Optional[Tuple[Real, ...]],
         inplane_angle: Union[Real, np.ndarray],
         outofplane_angle: Union[Real, np.ndarray],
-        tilt_angle: Union[np.ndarray, None],
+        tilt_angle: np.ndarray,
         detector_distance: Real,
         energy: Union[Real, np.ndarray],
     ) -> None:
@@ -768,7 +768,7 @@ class Setup:
         self.inplane_angle = self.inplane_angle or inplane_angle
         if self.inplane_angle is None:
             raise ValueError("the detector in-plane angle is not defined")
-        self.tilt_angle = self.tilt_angle or (tilt_angle[1:] - tilt_angle[0:-1]).mean()
+        self.tilt_angle = self.tilt_angle or np.mean(tilt_angle[1:] - tilt_angle[0:-1])
         if self.tilt_angle is None:
             raise ValueError("the tilt angle is not defined")
         elif not isinstance(self.tilt_angle, Real):

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -17,11 +17,12 @@ beamline-dependent information from the child classes.
 from collections.abc import Sequence
 import datetime
 import multiprocessing as mp
-from numbers import Real, Integral
+from numbers import Integral, Real
 import numpy as np
 from scipy.interpolate import griddata, RegularGridInterpolator
 import sys
 import time
+from typing import Tuple, Union
 from ..graph import graph_utils as gu
 from ..utils import utilities as util
 from ..utils import validation as valid
@@ -730,6 +731,45 @@ class Setup:
         )
         print("Use the parameter 'sample_offsets' to correct diffractometer values.\n")
         return qx, qz, qy, frames_logical
+
+    def check_setup(
+            self,
+            grazing_angle: Union[Tuple[Real, ...], None],
+            inplane_angle: Union[Real, np.ndarray],
+            outofplane_angle: Union[Real, np.ndarray],
+            tilt_angle: Union[np.ndarray, None],
+            detector_distance: Real,
+            energy: Union[Real, np.ndarray]
+    ) -> None:
+        """
+        Check if the required parameters are correctly defined.
+
+        :param grazing_angle:
+        :param inplane_angle:
+        :param outofplane_angle:
+        :param tilt_angle:
+        :param detector_distance:
+        :param energy:
+        :return:
+        """
+        self.grazing_angle = grazing_angle
+        self.energy = self.energy or energy
+        if not self.energy:
+            raise ValueError("the X-ray energy is not defined")
+        self.distance = self.distance or detector_distance
+        if not self.distance:
+            raise ValueError("the sample to detector distance is not defined")
+        self.outofplane_angle = self.outofplane_angle or outofplane_angle
+        if not self.outofplane_angle:
+            raise ValueError("the detector out-of-plane angle is not defined")
+        self.inplane_angle = self.inplane_angle or inplane_angle
+        if not self.inplane_angle:
+            raise ValueError("the detector in-plane angle is not defined")
+        self.tilt_angle = self.tilt_angle or (tilt_angle[1:]-tilt_angle[0:-1]).mean()
+        if not self.tilt_angle:
+            raise ValueError("the tilt angle is not defined")
+        elif not isinstance(self.tilt_angle, Real):
+            raise TypeError("the tilt angle should be a number")
 
     def create_logfile(self, scan_number, root_folder, filename):
         """

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -754,19 +754,19 @@ class Setup:
         """
         self.grazing_angle = grazing_angle
         self.energy = self.energy or energy
-        if not self.energy:
+        if self.energy is None:
             raise ValueError("the X-ray energy is not defined")
         self.distance = self.distance or detector_distance
-        if not self.distance:
+        if self.distance is None:
             raise ValueError("the sample to detector distance is not defined")
         self.outofplane_angle = self.outofplane_angle or outofplane_angle
-        if not self.outofplane_angle:
+        if self.outofplane_angle is None:
             raise ValueError("the detector out-of-plane angle is not defined")
         self.inplane_angle = self.inplane_angle or inplane_angle
-        if not self.inplane_angle:
+        if self.inplane_angle is None:
             raise ValueError("the detector in-plane angle is not defined")
         self.tilt_angle = self.tilt_angle or (tilt_angle[1:]-tilt_angle[0:-1]).mean()
-        if not self.tilt_angle:
+        if self.tilt_angle is None:
             raise ValueError("the tilt angle is not defined")
         elif not isinstance(self.tilt_angle, Real):
             raise TypeError("the tilt angle should be a number")

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -46,10 +46,8 @@ class Setup:
     :param tilt_angle: angular step of the rocking curve, in degrees.
     :param rocking_angle: angle which is tilted during the rocking curve in
      {'outofplane', 'inplane', 'energy'}
-    :param grazing_angle: motor positions for the goniometer circles below the
-     rocking angle. It should be a list/tuple of lenght 1 for out-of-plane rocking
-     curves (the chi motor value) and length 2 for inplane rocking
-     curves (the chi and omega/om/eta motor values).
+    :param grazing_angle: tuple of motor positions for the goniometer circles below the
+     rocking angle. Leave None if there is no such circle.
     :param kwargs:
 
      - 'direct_beam': tuple of two real numbers indicating the position of the direct
@@ -460,9 +458,7 @@ class Setup:
         """
         Motor positions for the goniometer circles below the rocking angle.
 
-        It should be a list/tuple of lenght 1 for out-of-plane rocking curves (the
-        motor value for mu if it exists) and length 2 for inplane rocking curves (
-        e.g. mu and omega/om/eta motor values).
+        None if there is no such circle.
         """
         return self._grazing_angle
 
@@ -730,7 +726,8 @@ class Setup:
         the geometric transformation using the linearized transformation matrix. Hence,
         arrays for detector angles and the energy are not allowed.
 
-        :param grazing_angle:
+        :param grazing_angle: tuple of motor positions for the goniometer circles below
+         the rocking angle. Leave None if there is no such circle.
         :param inplane_angle: detector inplane angle in degrees
         :param outofplane_angle: detector out-of-plane angle in degrees
         :param tilt_angle: ndarray of shape (N,), values of the rocking angle

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -755,8 +755,11 @@ class Setup:
         if self.inplane_angle is None:
             raise ValueError("the detector in-plane angle is not defined")
 
-        tilt_angle = np.asarray(tilt_angle)
-        self.tilt_angle = self.tilt_angle or np.mean(tilt_angle[1:] - tilt_angle[0:-1])
+        if tilt_angle is not None:
+            tilt_angle = np.mean(
+                np.asarray(tilt_angle)[1:] - np.asarray(tilt_angle)[0:-1]
+            )
+        self.tilt_angle = self.tilt_angle or tilt_angle
         if self.tilt_angle is None:
             raise ValueError("the tilt angle is not defined")
         if not isinstance(self.tilt_angle, Real):

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -468,35 +468,14 @@ class Setup:
 
     @grazing_angle.setter
     def grazing_angle(self, value):
-        if self.rocking_angle == "outofplane":
-            # only the mu angle (rotation around the vertical axis,
-            # below the rocking angle omega/om/eta) is needed
-            # mu is set to 0 if it does not exist
-            valid.valid_container(
-                value,
-                container_types=(tuple, list),
-                item_types=Real,
-                allow_none=True,
-                name="Setup.grazing_angle",
-            )
-            self._grazing_angle = value
-        elif self.rocking_angle == "inplane":
-            # one or more values needed, for example: mu angle,
-            # the omega/om/eta angle, the chi angle
-            # (rotations respectively around the vertical axis,
-            # outboard and downstream, below the rocking angle phi)
-            valid.valid_container(
-                value,
-                container_types=(tuple, list),
-                item_types=Real,
-                allow_none=True,
-                name="Setup.grazing_angle",
-            )
-            self._grazing_angle = value
-        else:  # self.rocking_angle == 'energy'
-            # there is no sample rocking for energy scans,
-            # hence the grazing angle value do not matter
-            self._grazing_angle = None
+        valid.valid_container(
+            value,
+            container_types=(tuple, list),
+            item_types=Real,
+            allow_none=True,
+            name="Setup.grazing_angle",
+        )
+        self._grazing_angle = value
 
     @property
     def incident_wavevector(self):

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -735,22 +735,27 @@ class Setup:
         :return:
         """
         self.grazing_angle = grazing_angle
+
         self.energy = self.energy or energy
         if self.energy is None:
             raise ValueError("the X-ray energy is not defined")
+
         self.distance = self.distance or detector_distance
         if self.distance is None:
             raise ValueError("the sample to detector distance is not defined")
+
         self.outofplane_angle = self.outofplane_angle or outofplane_angle
         if self.outofplane_angle is None:
             raise ValueError("the detector out-of-plane angle is not defined")
+
         self.inplane_angle = self.inplane_angle or inplane_angle
         if self.inplane_angle is None:
             raise ValueError("the detector in-plane angle is not defined")
+
         self.tilt_angle = self.tilt_angle or np.mean(tilt_angle[1:] - tilt_angle[0:-1])
         if self.tilt_angle is None:
             raise ValueError("the tilt angle is not defined")
-        elif not isinstance(self.tilt_angle, Real):
+        if not isinstance(self.tilt_angle, Real):
             raise TypeError("the tilt angle should be a number")
 
     def create_logfile(self, scan_number, root_folder, filename):

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -1113,7 +1113,7 @@ class Setup:
         valid.valid_container(
             specfile_name,
             container_types=str,
-            min_length=1,
+            min_length=0,
             allow_none=True,
             name="specfile_name",
         )

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -1474,9 +1474,15 @@ class Setup:
         # calculate the direct space voxel sizes in nm          #
         # based on the FFT window shape used in phase retrieval #
         #########################################################
+        tilt = (
+                self.tilt_angle
+                * self.detector.preprocessing_binning[0]
+                * self.detector.binning[0]
+        )
+
         dz_realspace, dy_realspace, dx_realspace = self.voxel_sizes(
             initial_shape,
-            tilt_angle=abs(self.tilt_angle),
+            tilt_angle=abs(tilt),
             pixel_x=self.detector.unbinned_pixel_size[1],
             pixel_y=self.detector.unbinned_pixel_size[0],
         )
@@ -1490,7 +1496,7 @@ class Setup:
 
         if input_shape != initial_shape:
             # recalculate the tilt and pixel sizes to accomodate a shape change
-            tilt = self.tilt_angle * initial_shape[0] / input_shape[0]
+            tilt *= initial_shape[0] / input_shape[0]
             pixel_y = (
                 self.detector.unbinned_pixel_size[0] * initial_shape[1] / input_shape[1]
             )
@@ -1518,7 +1524,6 @@ class Setup:
                     f" {dx_realspace:.2f} nm)",
                 )
         else:
-            tilt = self.tilt_angle
             pixel_y = self.detector.unbinned_pixel_size[0]
             pixel_x = self.detector.unbinned_pixel_size[1]
 
@@ -1851,7 +1856,7 @@ class Setup:
         ##########################################################
         transfer_matrix, q_offset = self.transformation_bcdi(
             array_shape=(nbz, nby, nbx),
-            tilt_angle=self.tilt_angle,
+            tilt_angle=self.tilt_angle * self.detector.preprocessing_binning[0],
             direct_space=False,
             verbose=verbose,
             pixel_x=self.detector.unbinned_pixel_size[1],

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -1109,7 +1109,7 @@ class Setup:
         valid.valid_container(
             template_imagefile,
             container_types=str,
-            min_length=1,
+            min_length=0,
             allow_none=True,
             name="template_imagefile",
         )

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -1014,7 +1014,6 @@ def grid_bcdi_xrayutil(
 
 
 def load_bcdi_data(
-    logfile,
     scan_number,
     detector,
     setup,
@@ -1029,8 +1028,6 @@ def load_bcdi_data(
     """
     Load Bragg CDI data, apply optional threshold, normalization and binning.
 
-    :param logfile: file containing the information about the scan and image numbers
-     (specfile, .fio...)
     :param scan_number: the scan number to load
     :param detector: an instance of the class Detector
     :param setup: an instance of the class Setup
@@ -1132,7 +1129,6 @@ def load_bcdi_data(
 def reload_bcdi_data(
     data,
     mask,
-    logfile,
     scan_number,
     detector,
     setup,
@@ -1145,8 +1141,6 @@ def reload_bcdi_data(
 
     :param data: the 3D data array
     :param mask: the 3D mask array
-    :param logfile: file containing the information about the scan and image numbers
-     (specfile, .fio...)
     :param scan_number: the scan number to load
     :param detector: an instance of the class Detector
     :param setup: an instance of the class Setup
@@ -1193,9 +1187,7 @@ def reload_bcdi_data(
     else:  # use the default monitor of the beamline
         monitor = setup.diffractometer.read_monitor(
             scan_number=scan_number,
-            logfile=logfile,
-            beamline=setup.beamline,
-            actuators=setup.actuators,
+            setup=setup,
         )
 
         print("Intensity normalization using " + normalize_method)

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -1075,7 +1075,6 @@ def load_bcdi_data(
     )
 
     rawdata, rawmask, monitor, frames_logical = setup.diffractometer.load_check_dataset(
-        logfile=logfile,
         scan_number=scan_number,
         detector=detector,
         setup=setup,

--- a/bcdi/preprocessing/cdi_utils.py
+++ b/bcdi/preprocessing/cdi_utils.py
@@ -584,7 +584,6 @@ def grid_cdi(
 
 
 def load_cdi_data(
-    logfile,
     scan_number,
     detector,
     setup,
@@ -602,8 +601,6 @@ def load_cdi_data(
     It applies beam stop correction and an optional photon threshold, normalization
     and binning.
 
-    :param logfile: file containing the information about the scan and image numbers
-     (specfile, .fio...)
     :param scan_number: the scan number to load
     :param detector: an instance of the class Detector
     :param setup: an instance of the class Setup
@@ -713,7 +710,6 @@ def load_cdi_data(
 def reload_cdi_data(
     data,
     mask,
-    logfile,
     scan_number,
     detector,
     setup,
@@ -726,8 +722,6 @@ def reload_cdi_data(
 
     :param data: the 3D data array
     :param mask: the 3D mask array
-    :param logfile: file containing the information about the scan and image numbers
-     (specfile, .fio...)
     :param scan_number: the scan number to load
     :param detector: an instance of the class Detector
     :param setup: an instance of the class Setup
@@ -781,9 +775,7 @@ def reload_cdi_data(
         else:  # use the default monitor of the beamline
             monitor = setup.diffractometer.read_monitor(
                 scan_number=scan_number,
-                logfile=logfile,
-                beamline=setup.beamline,
-                actuators=setup.actuators,
+                setup=setup,
             )
 
         print("Intensity normalization using " + normalize_method)

--- a/bcdi/preprocessing/cdi_utils.py
+++ b/bcdi/preprocessing/cdi_utils.py
@@ -388,7 +388,6 @@ def check_cdi_angle(data, mask, cdi_angle, frames_logical, debugging=False):
 def grid_cdi(
     data,
     mask,
-    logfile,
     detector,
     setup,
     frames_logical,
@@ -405,8 +404,6 @@ def grid_cdi(
 
     :param data: the 3D data, already binned in the detector frame
     :param mask: the corresponding 3D mask
-    :param logfile: file containing the information about the scan and image numbers
-     (specfile, .fio...)
     :param detector: an instance of the class Detector.
      The detector orientation is supposed to follow the CXI convention: (z
      downstream, y vertical up, x outboard) Y opposite to y, X opposite to x

--- a/bcdi/preprocessing/cdi_utils.py
+++ b/bcdi/preprocessing/cdi_utils.py
@@ -649,7 +649,6 @@ def load_cdi_data(
     )
 
     rawdata, rawmask, monitor, frames_logical = setup.diffractometer.load_check_dataset(
-        logfile=logfile,
         scan_number=scan_number,
         detector=detector,
         setup=setup,

--- a/bcdi/preprocessing/cdi_utils.py
+++ b/bcdi/preprocessing/cdi_utils.py
@@ -432,9 +432,7 @@ def grid_cdi(
             if setup.custom_scan:
                 cdi_angle = setup.custom_motors["hprz"]
             else:
-                cdi_angle, _, _ = setup.diffractometer.motor_positions(
-                    setup=setup, logfile=logfile
-                )
+                cdi_angle, _, _ = setup.diffractometer.motor_positions(setup=setup)
                 # second return value is the X-ray energy, third the detector distance
         else:
             raise ValueError(

--- a/bcdi/utils/parameters.py
+++ b/bcdi/utils/parameters.py
@@ -231,11 +231,8 @@ def valid_param(key: str, value: Any) -> Tuple[Any, bool]:
     elif key == "energy":
         if value is None or isinstance(value, Number):
             valid.valid_item(
-                value,
-                allowed_types=Real,
-                min_excluded=0,
-                allow_none=True,
-                name=key)
+                value, allowed_types=Real, min_excluded=0, allow_none=True, name=key
+            )
         else:
             valid.valid_container(
                 value,
@@ -486,11 +483,7 @@ def valid_param(key: str, value: Any) -> Tuple[Any, bool]:
 
     elif key == "sdd":
         valid.valid_item(
-            value,
-            allowed_types=Real,
-            min_excluded=0,
-            allow_none=True,
-            name=key
+            value, allowed_types=Real, min_excluded=0, allow_none=True, name=key
         )
     elif key == "sort_method":
         allowed = {"mean_amplitude", "variance", "variance/mean", "volume"}

--- a/bcdi/utils/parameters.py
+++ b/bcdi/utils/parameters.py
@@ -503,7 +503,7 @@ def valid_param(key: str, value: Any) -> Tuple[Any, bool]:
         )
     elif key == "template_imagefile":
         valid.valid_container(
-            value, container_types=str, min_length=1, allow_none=True, name=key
+            value, container_types=str, min_length=0, allow_none=True, name=key
         )
     elif key == "threshold_gradient":
         valid.valid_item(value, allowed_types=Real, min_excluded=0, name=key)

--- a/bcdi/utils/parameters.py
+++ b/bcdi/utils/parameters.py
@@ -229,8 +229,13 @@ def valid_param(key: str, value: Any) -> Tuple[Any, bool]:
     elif key == "dispersion":
         valid.valid_item(value, allowed_types=Real, min_excluded=0, name=key)
     elif key == "energy":
-        if isinstance(value, Number):
-            valid.valid_item(value, allowed_types=Real, min_excluded=0, name=key)
+        if value is None or isinstance(value, Number):
+            valid.valid_item(
+                value,
+                allowed_types=Real,
+                min_excluded=0,
+                allow_none=True,
+                name=key)
         else:
             valid.valid_container(
                 value,
@@ -283,7 +288,7 @@ def valid_param(key: str, value: Any) -> Tuple[Any, bool]:
             value, container_types=str, min_length=1, allow_none=True, name=key
         )
     elif key == "inplane_angle":
-        valid.valid_item(value, allowed_types=Real, name=key)
+        valid.valid_item(value, allowed_types=Real, allow_none=True, name=key)
     elif key == "interpolation_method":
         allowed = {"xrayutilities", "linearization"}
         if value not in allowed:
@@ -330,7 +335,7 @@ def valid_param(key: str, value: Any) -> Tuple[Any, bool]:
             name=key,
         )
     elif key == "outofplane_angle":
-        valid.valid_item(value, allowed_types=Real, name=key)
+        valid.valid_item(value, allowed_types=Real, allow_none=True, name=key)
     elif key == "output_size":
         valid.valid_container(
             value,
@@ -480,7 +485,13 @@ def valid_param(key: str, value: Any) -> Tuple[Any, bool]:
         )
 
     elif key == "sdd":
-        valid.valid_item(value, allowed_types=Real, min_excluded=0, name=key)
+        valid.valid_item(
+            value,
+            allowed_types=Real,
+            min_excluded=0,
+            allow_none=True,
+            name=key
+        )
     elif key == "sort_method":
         allowed = {"mean_amplitude", "variance", "variance/mean", "volume"}
         if value not in allowed:
@@ -516,7 +527,7 @@ def valid_param(key: str, value: Any) -> Tuple[Any, bool]:
     elif key == "tick_width":
         valid.valid_item(value, allowed_types=int, min_included=1, name=key)
     elif key == "tilt_angle":
-        valid.valid_item(value, allowed_types=Real, name=key)
+        valid.valid_item(value, allowed_types=Real, allow_none=True, name=key)
     elif key == "tiltazimuth":
         valid.valid_item(value, allowed_types=Real, name=key)
     elif key == "tilt_detector":

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -501,7 +501,8 @@ def find_file(filename: str, default_folder: str) -> str:
         raise ValueError(f"The directory {default_folder} does not exist")
     full_name = default_folder + filename
     if not os.path.isfile(full_name):
-        raise ValueError(f"Could not llocalize the file at {filename} or {full_name}")
+        raise ValueError(f"Could not localize the file at {filename} or {full_name}")
+    print(f"File localized at: {full_name}")
     return full_name
 
 

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -480,6 +480,31 @@ def dos2unix(input_file, output_file):
             output.write(row + str.encode("\n"))
 
 
+def find_file(filename: str, default_folder: str) -> str:
+    """
+    Localize a file.
+
+    The filename can be either the name of the file (including the extension) or the
+    full path to the file.
+
+    :param filename: the name or full path to the file
+    :param default_folder: it will look for the file in that folder if filename is not
+     the full path.
+    :return: str, the path to the file
+    """
+    if os.path.isfile(filename):
+        # filename is already the full path to the file
+        return filename
+    print(f"Could not find the file at: {filename}")
+
+    if not os.path.isdir(default_folder):
+        raise ValueError(f"The directory {default_folder} does not exist")
+    full_name = default_folder + filename
+    if not os.path.isfile(full_name):
+        raise ValueError(f"Could not llocalize the file at {filename} or {full_name}")
+    return full_name
+
+
 def find_nearest(reference_array, test_values, width=None):
     """
     Find the indices where original_array is nearest to array_values.

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -492,10 +492,18 @@ def find_file(filename: str, default_folder: str) -> str:
      the full path.
     :return: str, the path to the file
     """
+    if not isinstance(filename, str):
+        raise TypeError("filename should be a string")
+
     if os.path.isfile(filename):
         # filename is already the full path to the file
         return filename
     print(f"Could not find the file at: {filename}")
+
+    if not isinstance(default_folder, str):
+        raise TypeError("default_folder should be a string")
+    if not default_folder.endswith("/"):
+        default_folder += "/"
 
     if not os.path.isdir(default_folder):
         raise ValueError(f"The directory {default_folder} does not exist")

--- a/conf/config_postprocessing.yml
+++ b/conf/config_postprocessing.yml
@@ -121,7 +121,7 @@ custom_motors: {
 detector: "Eiger4M"  # "Eiger2M", "Maxipix", "Eiger4M", "Merlin", "Timepix" or "Dummy"
 pixel_size: None
 # use this to declare the pixel size of the "Dummy" detector if different from 55e-6
-template_imagefile: "_master.h5"
+template_imagefile: None
 # template for ID01: 'data_mpx4_%05d.edf.gz' or 'align_eiger2M_%05d.edf.gz'
 # template for SIXS_2018: 'align.spec_ascan_mu_%05d.nxs'
 # template for SIXS_2019: 'spare_ascan_mu_%05d.nxs'

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,6 +1,11 @@
 Future:
 -------
 
+* Allow lazy loading of the experimental parameters: energy, detector distance, tilt
+  angle, detector inplane and out-of-plane angles. If not provided by the user, the
+  values will be looked for in the log/spec file. An exception is raised if they are
+  not available.
+
 * Implement the chi circle at 34ID-C and update the calculation of the transformation
   matrix.
 

--- a/scripts/graph/bcdi_scan_analysis.py
+++ b/scripts/graph/bcdi_scan_analysis.py
@@ -305,7 +305,6 @@ if scale not in {"linear", "log"}:
 # load data #
 #############
 data, mask, monitor, frames_logical = setup.diffractometer.load_check_dataset(
-    logfile=logfile,
     scan_number=scan,
     detector=detector,
     setup=setup,

--- a/scripts/graph/bcdi_view_mesh.py
+++ b/scripts/graph/bcdi_view_mesh.py
@@ -324,7 +324,6 @@ if not (
 # load data #
 #############
 data, mask, monitor, frames_logical = setup.diffractometer.load_check_dataset(
-    logfile=logfile,
     scan_number=scan,
     detector=detector,
     setup=setup,

--- a/scripts/postprocessing/bcdi_correct_angles_detector.py
+++ b/scripts/postprocessing/bcdi_correct_angles_detector.py
@@ -223,10 +223,7 @@ if high_threshold != 0:
     setup.grazing_angle,
     setup.inplane_angle,
     setup.outofplane_angle,
-) = setup.diffractometer.goniometer_values(
-    logfile=logfile, scan_number=scan, setup=setup, frames_logical=frames_logical
-)
-setup.tilt_angle = (tilt_values[1:] - tilt_values[0:-1]).mean()
+) = setup.read_logfile(scan_number=scan)
 
 nb_frames = len(tilt_values)
 if numz != nb_frames:

--- a/scripts/postprocessing/bcdi_correct_angles_detector.py
+++ b/scripts/postprocessing/bcdi_correct_angles_detector.py
@@ -182,7 +182,6 @@ hotpix_array = util.load_hotpixels(hotpixels_file)
 
 if not filtered_data:
     data, _, monitor, frames_logical = setup.diffractometer.load_check_dataset(
-        logfile=logfile,
         scan_number=scan,
         detector=detector,
         setup=setup,

--- a/scripts/postprocessing/bcdi_polarplot.py
+++ b/scripts/postprocessing/bcdi_polarplot.py
@@ -347,7 +347,6 @@ if not reconstructed_data:  # load reciprocal space data
     )
 
     data, mask, frames_logical, monitor = bu.load_bcdi_data(
-        logfile=logfile,
         scan_number=scan,
         detector=detector,
         setup=setup,

--- a/scripts/postprocessing/bcdi_rocking_curves.py
+++ b/scripts/postprocessing/bcdi_rocking_curves.py
@@ -243,7 +243,6 @@ for scan_idx, scan_nb in enumerate(scans, start=1):
     )
 
     data, mask, frames_logical, monitor = bu.load_bcdi_data(
-        logfile=logfile,
         scan_number=scan_nb,
         detector=detector,
         setup=setup,

--- a/scripts/postprocessing/bcdi_rocking_curves.py
+++ b/scripts/postprocessing/bcdi_rocking_curves.py
@@ -253,9 +253,7 @@ for scan_idx, scan_nb in enumerate(scans, start=1):
         debugging=debug,
     )
 
-    tilt, grazing, inplane, outofplane = setup.diffractometer.goniometer_values(
-        frames_logical=frames_logical, logfile=logfile, scan_number=scan_nb, setup=setup
-    )
+    tilt, grazing, inplane, outofplane = setup.read_logfile(scan_number=scan_nb)
 
     nbz, nby, nbx = data.shape
     if peak_method == "max":

--- a/scripts/postprocessing/bcdi_strain.py
+++ b/scripts/postprocessing/bcdi_strain.py
@@ -1155,7 +1155,7 @@ def run(prm):
             q_com=q_lab[::-1],  # q_com needs to be in xyz order
             is_orthogonal=True,
             reciprocal_space=False,
-            rocking_angle=prm["rocking_angle"],
+            rocking_angle=setup.rocking_angle,
             debugging=(True, False, False),
             title=("amp", "phase", "strain"),
         )

--- a/scripts/postprocessing/bcdi_strain.py
+++ b/scripts/postprocessing/bcdi_strain.py
@@ -476,14 +476,6 @@ def run(prm):
         scan_number=scan, root_folder=root_folder, filename=detector.specfile
     )
 
-    #########################################################
-    # get the motor position of goniometer circles which    #
-    # are below the rocking angle (e.g., mu for eta/omega)  #
-    #########################################################
-    _, setup.grazing_angle, _, _ = setup.diffractometer.goniometer_values(
-        logfile=logfile, scan_number=scan, setup=setup
-    )
-
     ###################
     # print instances #
     ###################

--- a/scripts/postprocessing/bcdi_strain.py
+++ b/scripts/postprocessing/bcdi_strain.py
@@ -476,6 +476,14 @@ def run(prm):
         scan_number=scan, root_folder=root_folder, filename=detector.specfile
     )
 
+    # load the goniometer positions needed in the calculation
+    # of the transformation matrix
+    setup.diffractometer.goniometer_values(
+        logfile=logfile,
+        scan_number=scan,
+        setup=setup,
+    )
+
     ###################
     # print instances #
     ###################

--- a/scripts/postprocessing/bcdi_strain.py
+++ b/scripts/postprocessing/bcdi_strain.py
@@ -1153,13 +1153,9 @@ def run(prm):
     if save_frame == "lab_flat_sample":
         comment = comment + "_flat"
         print("\nSending sample stage circles to 0")
-        sample_angles = setup.diffractometer.goniometer_values(
-            logfile=logfile, scan_number=scan, setup=setup, stage_name="sample"
-        )
         (amp, phase, strain), q_final = setup.diffractometer.flatten_sample(
             arrays=(amp, phase, strain),
             voxel_size=voxel_size,
-            angles=sample_angles,
             q_com=q_lab[::-1],  # q_com needs to be in xyz order
             is_orthogonal=True,
             reciprocal_space=False,

--- a/scripts/postprocessing/bcdi_strain.py
+++ b/scripts/postprocessing/bcdi_strain.py
@@ -444,15 +444,13 @@ def run(prm):
     ####################################
     # define the experimental geometry #
     ####################################
-    # correct the tilt_angle for binning
-    tilt_angle = prm["tilt_angle"] * preprocessing_binning[0] * phasing_binning[0]
     setup = Setup(
         beamline=prm["beamline"],
         detector=detector,
         energy=prm.get("energy"),
         outofplane_angle=prm["outofplane_angle"],
         inplane_angle=prm["inplane_angle"],
-        tilt_angle=tilt_angle,
+        tilt_angle=prm.get("tilt_angle"),
         rocking_angle=prm["rocking_angle"],
         distance=prm["sdd"],
         sample_offsets=prm["sample_offsets"],

--- a/scripts/postprocessing/bcdi_strain.py
+++ b/scripts/postprocessing/bcdi_strain.py
@@ -472,17 +472,13 @@ def run(prm):
         template_imagefile=prm["template_imagefile"],
     )
 
-    logfile = setup.create_logfile(
+    setup.create_logfile(
         scan_number=scan, root_folder=root_folder, filename=detector.specfile
     )
 
     # load the goniometer positions needed in the calculation
     # of the transformation matrix
-    setup.diffractometer.goniometer_values(
-        logfile=logfile,
-        scan_number=scan,
-        setup=setup,
-    )
+    setup.read_logfile(scan_number=scan)
 
     ###################
     # print instances #
@@ -798,9 +794,9 @@ def run(prm):
         voxel_z, voxel_y, voxel_x = setup.voxel_sizes_detector(
             array_shape=original_size,
             tilt_angle=(
-                    prm.get("tilt_angle")
-                    * detector.preprocessing_binning[0]
-                    * detector.binning[0]
+                prm.get("tilt_angle")
+                * detector.preprocessing_binning[0]
+                * detector.binning[0]
             ),
             pixel_x=detector.pixelsize_x,
             pixel_y=detector.pixelsize_y,

--- a/scripts/postprocessing/bcdi_strain.py
+++ b/scripts/postprocessing/bcdi_strain.py
@@ -448,15 +448,15 @@ def run(prm):
         beamline=prm["beamline"],
         detector=detector,
         energy=prm.get("energy"),
-        outofplane_angle=prm["outofplane_angle"],
-        inplane_angle=prm["inplane_angle"],
+        outofplane_angle=prm.get("outofplane_angle"),
+        inplane_angle=prm.get("inplane_angle"),
         tilt_angle=prm.get("tilt_angle"),
         rocking_angle=prm["rocking_angle"],
-        distance=prm["sdd"],
-        sample_offsets=prm["sample_offsets"],
-        actuators=prm["actuators"],
-        custom_scan=prm["custom_scan"],
-        custom_motors=prm["custom_motors"],
+        distance=prm.get("sdd"),
+        sample_offsets=prm.get("sample_offsets"),
+        actuators=prm.get("actuators"),
+        custom_scan=prm.get("custom_scan", False),
+        custom_motors=prm.get("custom_motors"),
     )
 
     ########################################
@@ -797,7 +797,11 @@ def run(prm):
         # voxel sizes in the detector frame
         voxel_z, voxel_y, voxel_x = setup.voxel_sizes_detector(
             array_shape=original_size,
-            tilt_angle=tilt_angle,
+            tilt_angle=(
+                    prm.get("tilt_angle")
+                    * detector.preprocessing_binning[0]
+                    * detector.binning[0]
+            ),
             pixel_x=detector.pixelsize_x,
             pixel_y=detector.pixelsize_y,
             verbose=True,

--- a/scripts/postprocessing/bcdi_strain.py
+++ b/scripts/postprocessing/bcdi_strain.py
@@ -478,7 +478,7 @@ def run(prm):
 
     #########################################################
     # get the motor position of goniometer circles which    #
-    # are below the rocking angle (e.g., chi for eta/omega) #
+    # are below the rocking angle (e.g., mu for eta/omega)  #
     #########################################################
     _, setup.grazing_angle, _, _ = setup.diffractometer.goniometer_values(
         logfile=logfile, scan_number=scan, setup=setup

--- a/scripts/preprocessing/bcdi_preprocess_BCDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_BCDI.py
@@ -35,7 +35,7 @@ import bcdi.preprocessing.bcdi_utils as bu
 from bcdi.utils.parser import add_cli_parameters, ConfigParser
 import bcdi.utils.utilities as util
 
-CONFIG_FILE = "C:/Users/Jerome/Documents/myscripts/bcdi/conf/config_preprocessing.yml"
+CONFIG_FILE = "C:/Users/Jerome/Documents/data/dataset_ID01/config_preprocessing.yml"
 
 helptext = """
 Prepare experimental data for Bragg CDI phasing: crop/pad, center, mask, normalize and

--- a/scripts/preprocessing/bcdi_preprocess_BCDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_BCDI.py
@@ -668,25 +668,10 @@ def run(prm):
                 comment += "_lin"
                 # load the goniometer positions needed in the calculation
                 # of the transformation matrix
-                (
-                    tilt_angle,
-                    setup.grazing_angle,
-                    inplane,
-                    outofplane,
-                ) = setup.diffractometer.goniometer_values(
+                setup.diffractometer.goniometer_values(
                     logfile=logfile,
                     scan_number=scan_nb,
                     setup=setup,
-                )
-                setup.tilt_angle = (tilt_angle[1:] - tilt_angle[0:-1]).mean()
-                # override detector motor positions if the corrected values
-                # (taking into account the direct beam position)
-                # are provided by the user
-                setup.inplane_angle = (
-                    inplane_angle if inplane_angle is not None else inplane
-                )
-                setup.outofplane_angle = (
-                    outofplane_angle if outofplane_angle is not None else outofplane
                 )
             else:  # 'xrayutilities'
                 comment += "_xrutil"

--- a/scripts/preprocessing/bcdi_preprocess_BCDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_BCDI.py
@@ -485,8 +485,6 @@ def run(prm):
     rocking_angle = prm["rocking_angle"]
     photon_threshold = prm["photon_threshold"]
     reload_orthogonal = prm["reload_orthogonal"]
-    inplane_angle = prm["inplane_angle"]
-    outofplane_angle = prm["outofplane_angle"]
     roi_detector = create_roi(dic=prm)
     use_rawdata = prm["use_rawdata"]
     normalize_flux = prm["normalize_flux"]
@@ -601,7 +599,7 @@ def run(prm):
         detector=detector,
         energy=prm.get("energy"),
         rocking_angle=rocking_angle,
-        distance=prm["sdd"],
+        distance=prm.get("sdd"),
         beam_direction=prm["beam_direction"],
         sample_inplane=prm["sample_inplane"],
         sample_outofplane=prm["sample_outofplane"],
@@ -613,6 +611,8 @@ def run(prm):
         custom_motors=prm["custom_motors"],
         actuators=prm["actuators"],
         is_series=prm["is_series"],
+        outofplane_angle=prm.get("outofplane_angle"),
+        inplane_angle=prm.get("inplane_angle"),
     )
 
     ########################################

--- a/scripts/preprocessing/bcdi_preprocess_BCDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_BCDI.py
@@ -35,7 +35,7 @@ import bcdi.preprocessing.bcdi_utils as bu
 from bcdi.utils.parser import add_cli_parameters, ConfigParser
 import bcdi.utils.utilities as util
 
-CONFIG_FILE = "C:/Users/Jerome/Documents/data/dataset_ID01/config_preprocessing.yml"
+CONFIG_FILE = "C:/Users/Jerome/Documents/myscripts/bcdi/conf/config_preprocessing.yml"
 
 helptext = """
 Prepare experimental data for Bragg CDI phasing: crop/pad, center, mask, normalize and

--- a/scripts/preprocessing/bcdi_preprocess_BCDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_BCDI.py
@@ -668,11 +668,7 @@ def run(prm):
                 comment += "_lin"
                 # load the goniometer positions needed in the calculation
                 # of the transformation matrix
-                setup.diffractometer.goniometer_values(
-                    logfile=logfile,
-                    scan_number=scan_nb,
-                    setup=setup,
-                )
+                setup.read_logfile(scan_number=scan_nb)
             else:  # 'xrayutilities'
                 comment += "_xrutil"
         if normalize_flux:

--- a/scripts/preprocessing/bcdi_preprocess_BCDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_BCDI.py
@@ -781,7 +781,6 @@ def run(prm):
             background = util.load_background(prm["background_file"])
 
             data, mask, frames_logical, monitor = bu.load_bcdi_data(
-                logfile=logfile,
                 scan_number=scan_nb,
                 detector=detector,
                 setup=setup,

--- a/scripts/preprocessing/bcdi_preprocess_CDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_CDI.py
@@ -564,7 +564,6 @@ for scan_idx, scan_nb in enumerate(scans, start=1):
                     del numz, numy, numx
         else:  # the data is in the detector frame
             data, mask, frames_logical, monitor = cdi.reload_cdi_data(
-                logfile=logfile,
                 scan_number=scan_nb,
                 data=data,
                 mask=mask,

--- a/scripts/preprocessing/bcdi_preprocess_CDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_CDI.py
@@ -581,7 +581,6 @@ for scan_idx, scan_nb in enumerate(scans, start=1):
         background = util.load_background(background_file)
 
         data, mask, frames_logical, monitor = cdi.load_cdi_data(
-            logfile=logfile,
             scan_number=scan_nb,
             detector=detector,
             setup=setup,

--- a/scripts/preprocessing/bcdi_read_BCDI_scan.py
+++ b/scripts/preprocessing/bcdi_read_BCDI_scan.py
@@ -220,9 +220,7 @@ if high_threshold != 0:
 # calculate rocking curve and fit it to get the FWHM #
 ######################################################
 if data.ndim == 3:
-    tilt, _, _, _ = setup.diffractometer.goniometer_values(
-        frames_logical=frames_logical, logfile=logfile, scan_number=scan, setup=setup
-    )
+    tilt, _, _, _ = setup.read_logfile(scan_number=scan)
     rocking_curve = np.zeros(numz)
 
     z0, y0, x0 = tuple(

--- a/scripts/preprocessing/bcdi_read_BCDI_scan.py
+++ b/scripts/preprocessing/bcdi_read_BCDI_scan.py
@@ -194,7 +194,6 @@ logfile = setup.create_logfile(
 # load the data #
 #################
 data, mask, monitor, frames_logical = setup.diffractometer.load_check_dataset(
-    logfile=logfile,
     scan_number=scan,
     detector=detector,
     setup=setup,

--- a/tests/experiment/test_beamline.py
+++ b/tests/experiment/test_beamline.py
@@ -781,16 +781,16 @@ class TestBeamlineP10(fake_filesystem_unittest.TestCase):
 
     def test_init_paths_specfile_full_path(self):
         self.setUpPyfakefs()
-        self.valid_path = "/gpfs/bcdi/data"
-        os.makedirs(self.valid_path)
-        with open(self.valid_path + "/dummy.fio", "w") as f:
+        valid_path = "/gpfs/bcdi/data"
+        os.makedirs(valid_path)
+        with open(valid_path + "/dummy.fio", "w") as f:
             f.write("dummy")
 
         params = {
             "root_folder": self.root_dir,
             "sample_name": self.sample_name,
             "scan_number": self.scan_number,
-            "specfile_name": self.valid_path + "/dummy.fio",
+            "specfile_name": valid_path + "/dummy.fio",
             "template_imagefile": self.template_imagefile,
         }
         (

--- a/tests/experiment/test_beamline.py
+++ b/tests/experiment/test_beamline.py
@@ -783,8 +783,8 @@ class TestBeamlineP10(fake_filesystem_unittest.TestCase):
         self.setUpPyfakefs()
         self.valid_path = "/gpfs/bcdi/data"
         os.makedirs(self.valid_path)
-        with open(self.valid_path + "/dummy.fio", 'w') as f:
-            f.write('dummy')
+        with open(self.valid_path + "/dummy.fio", "w") as f:
+            f.write("dummy")
 
         params = {
             "root_folder": self.root_dir,

--- a/tests/experiment/test_diffractometer.py
+++ b/tests/experiment/test_diffractometer.py
@@ -42,10 +42,12 @@ class TestRetrieveDistance(fake_filesystem_unittest.TestCase):
         self.valid_path = "/gpfs/bcdi/data/"
         os.makedirs(self.valid_path)
         with open(self.valid_path + "defined.spec", "w") as f:
-            f.write("test\n#UDETCALIB cen_pix_x=11.195,cen_pix_y=281.115,"
-                    "pixperdeg=455.257,"
-                    "det_distance_CC=1.434,det_distance_COM=1.193,"
-                    "timestamp=2021-02-28T13:01:16.615422")
+            f.write(
+                "test\n#UDETCALIB cen_pix_x=11.195,cen_pix_y=281.115,"
+                "pixperdeg=455.257,"
+                "det_distance_CC=1.434,det_distance_COM=1.193,"
+                "timestamp=2021-02-28T13:01:16.615422"
+            )
 
         with open(self.valid_path + "undefined.spec", "w") as f:
             f.write("test\n#this,is,bad")

--- a/tests/experiment/test_diffractometer.py
+++ b/tests/experiment/test_diffractometer.py
@@ -7,8 +7,13 @@
 #       authors:
 #         Jerome Carnis, carnis_jerome@yahoo.fr
 
+import numpy as np
+import os
+from pyfakefs import fake_filesystem_unittest
 import unittest
-from bcdi.experiment.diffractometer import Diffractometer
+from bcdi.experiment.diffractometer import create_diffractometer, Diffractometer
+from bcdi.experiment.setup import Setup
+from bcdi.experiment.detector import create_detector
 
 
 def run_tests(test_class):
@@ -25,5 +30,43 @@ class Test(unittest.TestCase):
             Diffractometer(sample_offsets=[])
 
 
+class TestRetrieveDistance(fake_filesystem_unittest.TestCase):
+    """
+    Tests related to DiffractometerID01.retrieve_distance.
+
+    def retrieve_distance(setup) -> Optional[float]:
+    """
+
+    def setUp(self):
+        self.setUpPyfakefs()
+        self.valid_path = "/gpfs/bcdi/data/"
+        os.makedirs(self.valid_path)
+        with open(self.valid_path + "defined.spec", "w") as f:
+            f.write("test\n#UDETCALIB cen_pix_x=11.195,cen_pix_y=281.115,"
+                    "pixperdeg=455.257,"
+                    "det_distance_CC=1.434,det_distance_COM=1.193,"
+                    "timestamp=2021-02-28T13:01:16.615422")
+
+        with open(self.valid_path + "undefined.spec", "w") as f:
+            f.write("test\n#this,is,bad")
+        detector = create_detector("Maxipix")
+        detector.rootdir = self.valid_path
+        self.setup = Setup("ID01", detector=detector)
+        self.diffractometer = create_diffractometer("ID01", sample_offsets=None)
+
+    def test_distance_defined(self):
+        self.setup.detector.specfile = "defined.spec"
+
+        distance = self.diffractometer.retrieve_distance(self.setup)
+        self.assertTrue(np.isclose(distance, 1.193))
+
+    def test_distance_undefined(self):
+        self.setup.detector.specfile = "undefined.spec"
+
+        distance = self.diffractometer.retrieve_distance(self.setup)
+        self.assertTrue(distance is None)
+
+
 if __name__ == "__main__":
     run_tests(Test)
+    run_tests(TestRetrieveDistance)

--- a/tests/experiment/test_setup.py
+++ b/tests/experiment/test_setup.py
@@ -51,6 +51,23 @@ class TestCheckSetup(unittest.TestCase):
                        "energy": 9000,
                        }
 
+    def test_check_setup_tilt_angle_predefined(self):
+        self.setup.tilt_angle = 2
+        self.setup.check_setup(**self.params)
+        self.assertEqual(self.setup.tilt_angle, 2)
+
+    def test_check_setup_tilt_angle_none(self):
+        self.setup.check_setup(**self.params)
+        correct = np.mean(
+            self.params["tilt_angle"][1:] - self.params["tilt_angle"][:-1]
+        )
+        self.assertEqual(self.setup.tilt_angle, correct)
+
+    def test_check_setup_tilt_angle_undefined(self):
+        self.params["tilt_angle"] = None
+        with self.assertRaises(ValueError):
+            self.setup.check_setup(**self.params)
+
     def test_check_setup_outofplane_angle_predefined(self):
         self.setup.outofplane_angle = 2
         self.setup.check_setup(**self.params)

--- a/tests/experiment/test_setup.py
+++ b/tests/experiment/test_setup.py
@@ -51,6 +51,44 @@ class TestCheckSetup(unittest.TestCase):
                        "energy": 9000,
                        }
 
+    def test_check_setup_outofplane_angle_predefined(self):
+        self.setup.outofplane_angle = 2
+        self.setup.check_setup(**self.params)
+        self.assertEqual(self.setup.outofplane_angle, 2)
+
+    def test_check_setup_outofplane_angle_none(self):
+        self.setup.check_setup(**self.params)
+        self.assertEqual(self.setup.outofplane_angle, self.params["outofplane_angle"])
+
+    def test_check_setup_outofplane_angle_ndarray(self):
+        self.params["outofplane_angle"] = np.arange(10)
+        with self.assertRaises(TypeError):
+            self.setup.check_setup(**self.params)
+
+    def test_check_setup_outofplane_angle_undefined(self):
+        self.params["outofplane_angle"] = None
+        with self.assertRaises(ValueError):
+            self.setup.check_setup(**self.params)
+
+    def test_check_setup_inplane_angle_predefined(self):
+        self.setup.inplane_angle = 2
+        self.setup.check_setup(**self.params)
+        self.assertEqual(self.setup.inplane_angle, 2)
+
+    def test_check_setup_inplane_angle_none(self):
+        self.setup.check_setup(**self.params)
+        self.assertEqual(self.setup.inplane_angle, self.params["inplane_angle"])
+
+    def test_check_setup_inplane_angle_ndarray(self):
+        self.params["inplane_angle"] = np.arange(10)
+        with self.assertRaises(TypeError):
+            self.setup.check_setup(**self.params)
+
+    def test_check_setup_inplane_angle_undefined(self):
+        self.params["inplane_angle"] = None
+        with self.assertRaises(ValueError):
+            self.setup.check_setup(**self.params)
+
     def test_check_setup_grazing_angle_predefined(self):
         self.setup.grazing_angle = (0.1,)
         self.setup.check_setup(**self.params)

--- a/tests/experiment/test_setup.py
+++ b/tests/experiment/test_setup.py
@@ -51,6 +51,44 @@ class TestCheckSetup(unittest.TestCase):
                        "energy": 9000,
                        }
 
+    def test_check_setup_distance_predefined(self):
+        self.setup.distance = 1.5
+        self.setup.check_setup(**self.params)
+        self.assertEqual(self.setup.distance, 1.5)
+
+    def test_check_setup_distance_none(self):
+        self.setup.check_setup(**self.params)
+        self.assertEqual(self.setup.distance, self.params["detector_distance"])
+
+    def test_check_setup_distance_undefined(self):
+        self.params["detector_distance"] = None
+        with self.assertRaises(ValueError):
+            self.setup.check_setup(**self.params)
+
+    def test_check_setup_distance_ndarray(self):
+        self.params["distance"] = np.array([1, 1.2, 1.4])
+        with self.assertRaises(TypeError):
+            self.setup.check_setup(**self.params)
+
+    def test_check_setup_energy_predefined(self):
+        self.setup.energy = 12000
+        self.setup.check_setup(**self.params)
+        self.assertEqual(self.setup.energy, 12000)
+
+    def test_check_setup_energy_none(self):
+        self.setup.check_setup(**self.params)
+        self.assertEqual(self.setup.energy, self.params["energy"])
+
+    def test_check_setup_energy_undefined(self):
+        self.params["energy"] = None
+        with self.assertRaises(ValueError):
+            self.setup.check_setup(**self.params)
+
+    def test_check_setup_energy_ndarray(self):
+        self.params["energy"] = np.array([10.005, 10.010, 10.015])
+        with self.assertRaises(TypeError):
+            self.setup.check_setup(**self.params)
+
     def test_check_setup_tilt_angle_predefined(self):
         self.setup.tilt_angle = 2
         self.setup.check_setup(**self.params)

--- a/tests/experiment/test_setup.py
+++ b/tests/experiment/test_setup.py
@@ -7,6 +7,7 @@
 #       authors:
 #         Jerome Carnis, carnis_jerome@yahoo.fr
 
+import numpy as np
 import unittest
 from bcdi.experiment.setup import Setup
 
@@ -25,5 +26,42 @@ class Test(unittest.TestCase):
             Setup()
 
 
+class TestCheckSetup(unittest.TestCase):
+    """
+    Tests related to check_setup.
+
+        def check_setup(
+        self,
+        grazing_angle: Optional[Tuple[Real, ...]],
+        inplane_angle: Union[Real, np.ndarray],
+        outofplane_angle: Union[Real, np.ndarray],
+        tilt_angle: np.ndarray,
+        detector_distance: Real,
+        energy: Union[Real, np.ndarray],
+    ) -> None:
+    """
+    def setUp(self) -> None:
+        self.setup = Setup(beamline="ID01")
+        self.params = {"grazing_angle": (1, 2),
+                       "inplane_angle": 1.23,
+                       "outofplane_angle": 49.2,
+                       "tilt_angle": np.array([1, 1.005, 1.01, 1.015]),
+                       "detector_distance": 0.5,
+                       "energy": 9000,
+                       }
+
+    def test_check_setup_grazing_angle_predefined(self):
+        self.setup.grazing_angle = (0.1,)
+        self.setup.check_setup(**self.params)
+        self.assertEqual(self.setup.grazing_angle, self.params["grazing_angle"])
+
+    def test_check_setup_grazing_angle_None(self):
+        self.setup.grazing_angle = (0.1,)
+        self.params["grazing_angle"] = None
+        self.setup.check_setup(**self.params)
+        self.assertEqual(self.setup.grazing_angle, None)
+
+
 if __name__ == "__main__":
     run_tests(Test)
+    run_tests(TestCheckSetup)

--- a/tests/experiment/test_setup.py
+++ b/tests/experiment/test_setup.py
@@ -43,13 +43,14 @@ class TestCheckSetup(unittest.TestCase):
 
     def setUp(self) -> None:
         self.setup = Setup(beamline="ID01")
-        self.params = {"grazing_angle": (1, 2),
-                       "inplane_angle": 1.23,
-                       "outofplane_angle": 49.2,
-                       "tilt_angle": np.array([1, 1.005, 1.01, 1.015]),
-                       "detector_distance": 0.5,
-                       "energy": 9000,
-                       }
+        self.params = {
+            "grazing_angle": (1, 2),
+            "inplane_angle": 1.23,
+            "outofplane_angle": 49.2,
+            "tilt_angle": np.array([1, 1.005, 1.01, 1.015]),
+            "detector_distance": 0.5,
+            "energy": 9000,
+        }
 
     def test_check_setup_distance_predefined(self):
         self.setup.distance = 1.5

--- a/tests/experiment/test_setup.py
+++ b/tests/experiment/test_setup.py
@@ -40,6 +40,7 @@ class TestCheckSetup(unittest.TestCase):
         energy: Union[Real, np.ndarray],
     ) -> None:
     """
+
     def setUp(self) -> None:
         self.setup = Setup(beamline="ID01")
         self.params = {"grazing_angle": (1, 2),

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -153,3 +153,4 @@ class TestIsFloat(unittest.TestCase):
 if __name__ == "__main__":
     run_tests(TestInRange)
     run_tests(TestIsFloat)
+    run_tests(TestFindFile)

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -45,9 +45,7 @@ class TestFindFile(fake_filesystem_unittest.TestCase):
         self.assertTrue(output == self.valid_path + "dummy.spec")
 
     def test_filename_file_name(self):
-        output = util.find_file(
-            filename="dummy.spec", default_folder=self.valid_path
-        )
+        output = util.find_file(filename="dummy.spec", default_folder=self.valid_path)
         self.assertTrue(output == self.valid_path + "dummy.spec")
 
     def test_filename_file_name_missing_backslash(self):

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -8,6 +8,8 @@
 #         Jerome Carnis, carnis_jerome@yahoo.fr
 
 import numpy as np
+import os
+from pyfakefs import fake_filesystem_unittest
 import unittest
 import bcdi.utils.utilities as util
 
@@ -16,6 +18,55 @@ def run_tests(test_class):
     suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
     runner = unittest.TextTestRunner(verbosity=2)
     return runner.run(suite)
+
+
+class TestFindFile(fake_filesystem_unittest.TestCase):
+    """
+    Tests on the function utilities.find_file.
+
+    def find_file(filename: str, default_folder: str) -> str:
+    """
+
+    def setUp(self):
+        self.setUpPyfakefs()
+        self.valid_path = "/gpfs/bcdi/data/"
+        os.makedirs(self.valid_path)
+        with open(self.valid_path + "dummy.spec", "w") as f:
+            f.write("dummy")
+
+    def test_filename_none(self):
+        with self.assertRaises(TypeError):
+            util.find_file(filename=None, default_folder=None)
+
+    def test_full_path_to_file(self):
+        output = util.find_file(
+            filename=self.valid_path + "dummy.spec", default_folder=None
+        )
+        self.assertTrue(output == self.valid_path + "dummy.spec")
+
+    def test_filename_file_name(self):
+        output = util.find_file(
+            filename="dummy.spec", default_folder=self.valid_path
+        )
+        self.assertTrue(output == self.valid_path + "dummy.spec")
+
+    def test_filename_file_name_missing_backslash(self):
+        output = util.find_file(
+            filename="dummy.spec", default_folder=self.valid_path[:-1]
+        )
+        self.assertTrue(output == self.valid_path + "dummy.spec")
+
+    def test_filename_file_name_default_dir_none(self):
+        with self.assertRaises(TypeError):
+            util.find_file(filename="dummy.spec", default_folder=None)
+
+    def test_filename_file_name_default_dir_inexisting(self):
+        with self.assertRaises(ValueError):
+            util.find_file(filename="dummy.spec", default_folder="/wrong/path")
+
+    def test_filename_file_name_inexisting_default_dir_existing(self):
+        with self.assertRaises(ValueError):
+            util.find_file(filename="dum.spec", default_folder=self.valid_path)
 
 
 class TestInRange(unittest.TestCase):


### PR DESCRIPTION
## Description

When some parameters such as the detector angles, energy, sample to detector distance and tilt_angle are not provided in the config file, the code selects values from the logfile or raises an error if not available. The detector distance is available only for 34ID-C (as a motor) and ID01 (after some parsing).

The parameter "template_imagefile" is now optional for P10 postprocessing.

The redundant parameter "logfile" has been removed from calls to instance methods, because it can be accessed directly as a property of the setup intance. 

Fixes #189 and #190 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?

Preprocessing on ID10 data and postprocessing on 34ID-C data works as expected.

## Checklist:

- [X] I have made corresponding changes to the documentation
- [X] I have added corresponding unit tests
- [X] I have run ``doit`` and all tasks have passed
