### PR TITLE
add numpy, ipywidgets and pandas to autodoc_mock_imports

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -78,6 +78,7 @@ todo_include_todos = False
 autodoc_mock_imports = [
     "ipywidgets",
     "numpy",
+    "pandas",
     "scipy",
     "skimage",
     "matplotlib",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -76,6 +76,7 @@ pygments_style = "sphinx"
 todo_include_todos = False
 
 autodoc_mock_imports = [
+    "ipywidgets",
     "numpy",
     "scipy",
     "skimage",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -76,6 +76,7 @@ pygments_style = "sphinx"
 todo_include_todos = False
 
 autodoc_mock_imports = [
+    "numpy",
     "scipy",
     "skimage",
     "matplotlib",


### PR DESCRIPTION
add numpy, ipywidgets and pandas to autodoc_mock_imports in order to solve an improper building of the documentation on ReadTheDocs