### PR TITLE
Set command line parameters as optional

### DIFF
--- a/bcdi/utils/parameters.py
+++ b/bcdi/utils/parameters.py
@@ -52,11 +52,11 @@ def valid_param(key: str, value: Any) -> Tuple[Any, bool]:
         value = None
 
     # convert 'True' to True
-    if value in ("True", "true", "TRUE"):
+    if isinstance(value, str) and value.lower() == "true":
         value = True
 
     # convert 'False' to False
-    if value in ("False", "false", "FALSE"):
+    if isinstance(value, str) and value.lower() == "false":
         value = False
 
     # test the booleans first

--- a/bcdi/utils/parser.py
+++ b/bcdi/utils/parser.py
@@ -12,7 +12,7 @@
 from argparse import ArgumentParser
 import os
 import pathlib
-from typing import Any, ByteString, Dict, Union
+from typing import Any, ByteString, Dict, Optional
 import yaml
 
 from bcdi.utils.parameters import valid_param
@@ -168,12 +168,12 @@ class ConfigParser:
     """
 
     def __init__(
-        self, file_path: str, command_line_args: Union[Dict[str, Any], None] = None
+        self, file_path: str, command_line_args: Optional[Dict[str, Any]] = None
     ) -> None:
         self.file_path = file_path
         self.command_line_args = command_line_args
         self.raw_config = self._open_file()
-        self.arguments: Union[Dict, None] = None
+        self.arguments: Optional[Dict] = None
 
     @property
     def command_line_args(self):
@@ -219,7 +219,7 @@ class ConfigParser:
         return {key: dic[key] for key in checked_keys}
 
     @staticmethod
-    def filter_dict(dic: Dict, filter_value: Any = None) -> Dict:
+    def filter_dict(dic: Optional[Dict], filter_value: Any = None) -> Dict:
         """
         Filter out key where the value is None.
 
@@ -227,7 +227,9 @@ class ConfigParser:
         :param filter_value: value to be filtered out
         :return: a dictionary with only keys where the value is not None
         """
-        return {k: v for k, v in dic.items() if v is not filter_value}
+        if dic is not None:
+            return {k: v for k, v in dic.items() if v is not filter_value}
+        return {}
 
     def load_arguments(self) -> Dict:
         """Parse the byte string, eventually override defaults and check parameters."""

--- a/bcdi/utils/parser.py
+++ b/bcdi/utils/parser.py
@@ -44,7 +44,8 @@ def add_cli_parameters(argument_parser: ArgumentParser) -> ArgumentParser:
     )
 
     argument_parser.add_argument(
-        "-bin" "--phasing_binning",
+        "-bin",
+        "--phasing_binning",
         type=str,
         help="binning factor applied during phasing",
     )
@@ -102,12 +103,6 @@ def add_cli_parameters(argument_parser: ArgumentParser) -> ArgumentParser:
 
     argument_parser.add_argument(
         "--outofplane_angle", type=float, help="detector out-of-plane angle"
-    )
-
-    argument_parser.add_argument(
-        "--phasing_binning",
-        type=str,
-        help="binning factor applied during phasing",
     )
 
     argument_parser.add_argument(

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,6 +1,9 @@
 Version 0.2.3:
 --------------
 
+* Refactor: allow the command line parameters to be None. ConfigParser can now be
+  instantiated providing the path to the config file only.
+
 * Bug: use the binned detector pixel size to calculate the transformation matrices
 
 Version 0.2.2:

--- a/tests/utils/test_parameters.py
+++ b/tests/utils/test_parameters.py
@@ -29,39 +29,40 @@ class TestParameters(unittest.TestCase):
 
     def test_none_str_unexpected(self):
         val, flag = valid_param(key="not_expected", value="None")
-        self.assertTrue(val is None and not flag)
+        self.assertTrue(val is None and flag is False)
 
     def test_none_str_expected(self):
         val, flag = valid_param(key="actuators", value="None")
-        self.assertTrue(val is None and flag)
+        self.assertTrue(val is None and flag is True)
 
     def test_true_expected_1(self):
         val, flag = valid_param(key="align_axis", value="True")
-        self.assertTrue(val and flag)
+        self.assertTrue(val is True and flag is True)
 
     def test_true_expected_2(self):
         val, flag = valid_param(key="align_axis", value="true")
-        self.assertTrue(val and flag)
+        self.assertTrue(val is True and flag is True)
 
     def test_true_expected_3(self):
         val, flag = valid_param(key="align_axis", value="TRUE")
-        self.assertTrue(val and flag)
+        self.assertTrue(val is True and flag is True)
 
     def test_false_expected_1(self):
         val, flag = valid_param(key="align_axis", value="False")
-        self.assertTrue(not val and flag)
+        print(val, flag)
+        self.assertTrue(val is False and flag is True)
 
     def test_false_expected_2(self):
         val, flag = valid_param(key="align_axis", value="false")
-        self.assertTrue(not val and flag)
+        self.assertTrue(val is False and flag is True)
 
     def test_false_expected_3(self):
         val, flag = valid_param(key="align_axis", value="FALSE")
-        self.assertTrue(not val and flag)
+        self.assertTrue(val is False and flag is True)
 
     def test_data_dir_none(self):
         val, flag = valid_param(key="data_dir", value="None")
-        self.assertTrue(val is None and flag)
+        self.assertTrue(val is None and flag is True)
 
     def test_data_dir_not_existing(self):
         with self.assertRaises(ValueError):
@@ -69,7 +70,7 @@ class TestParameters(unittest.TestCase):
 
     def test_data_dir_existing(self):
         val, flag = valid_param(key="data_dir", value=THIS_DIR)
-        self.assertTrue(val == THIS_DIR and flag)
+        self.assertTrue(val == THIS_DIR and flag is True)
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_parser.py
+++ b/tests/utils/test_parser.py
@@ -76,12 +76,13 @@ class TestConfigParser(unittest.TestCase):
         self.assertTrue(args.get("scan") == self.command_line_args["scan"])
 
     def test_load_arguments_no_cl_params_flip(self):
-        self.parser = ConfigParser(CONFIG, {})
         args = self.parser.load_arguments()
         self.assertTrue(args.get("flip_reconstruction") is True)
 
     def test_load_arguments_cl_params_flip(self):
-        self.parser = ConfigParser(CONFIG, {"flip_reconstruction": "False"})
+        self.parser = ConfigParser(
+            CONFIG, {"flip_reconstruction": "False", "root_folder": str(here)}
+        )
         # "flip_reconstruction" is also key in CONFIG, which means that the overriding
         # by the optional --flip_reconstruction argument from the command line works as
         # expected
@@ -89,7 +90,9 @@ class TestConfigParser(unittest.TestCase):
         self.assertTrue(args.get("flip_reconstruction") is False)
 
     def test_load_arguments_cl_params_flip_no_bool(self):
-        self.parser = ConfigParser(CONFIG, {"flip_reconstruction": "weirdstring"})
+        self.parser = ConfigParser(
+            CONFIG, {"flip_reconstruction": "weirdstring", "root_folder": str(here)}
+        )
         with self.assertRaises(TypeError):
             self.parser.load_arguments()
 

--- a/tests/utils/test_parser.py
+++ b/tests/utils/test_parser.py
@@ -96,6 +96,10 @@ class TestConfigParser(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.parser.load_arguments()
 
+    def test_instantiate_configparser_no_cla(self):
+        self.parser = ConfigParser(CONFIG)
+        self.assertIsNone(self.parser.arguments)
+
 
 if __name__ == "__main__":
     run_tests(TestConfigParser)

--- a/tests/utils/test_parser.py
+++ b/tests/utils/test_parser.py
@@ -75,6 +75,24 @@ class TestConfigParser(unittest.TestCase):
         # --scan argument from the command line works as expected
         self.assertTrue(args.get("scan") == self.command_line_args["scan"])
 
+    def test_load_arguments_no_cl_params_flip(self):
+        self.parser = ConfigParser(CONFIG, {})
+        args = self.parser.load_arguments()
+        self.assertTrue(args.get("flip_reconstruction") is True)
+
+    def test_load_arguments_cl_params_flip(self):
+        self.parser = ConfigParser(CONFIG, {"flip_reconstruction": "False"})
+        # "flip_reconstruction" is also key in CONFIG, which means that the overriding
+        # by the optional --flip_reconstruction argument from the command line works as
+        # expected
+        args = self.parser.load_arguments()
+        self.assertTrue(args.get("flip_reconstruction") is False)
+
+    def test_load_arguments_cl_params_flip_no_bool(self):
+        self.parser = ConfigParser(CONFIG, {"flip_reconstruction": "weirdstring"})
+        with self.assertRaises(TypeError):
+            self.parser.load_arguments()
+
 
 if __name__ == "__main__":
     run_tests(TestConfigParser)


### PR DESCRIPTION
# Pull Request Template

## Description

Now the command line parameters do not need to be provided. ConfigParser can be instantiated providing only the path to the config file

Fixes #230 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?

The error with the weird string value of `flip_reconstruction` in the GUI is solved.

## Checklist:

- [X] I have added corresponding unit tests
- [X] I have run ``doit`` and all tasks have passed
