### PR TITLE
Open files within context managers

### DIFF
--- a/bcdi/__init__.py
+++ b/bcdi/__init__.py
@@ -6,4 +6,4 @@
 #       authors:
 #         Jerome Carnis, carnis_jerome@yahoo.fr
 """The main bcdi package, which contains the whole framework."""
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -632,7 +632,7 @@ class BeamlineCRISTAL(Beamline):
             grazing = None  # nothing below mgomega at CRISTAL
             tilt_angle = mgomega
         elif setup.rocking_angle == "inplane":  # phi rocking curve
-            grazing = (mgomega[0],)
+            grazing = (mgomega,)
             tilt_angle = mgphi
         else:
             raise ValueError('Wrong value for "rocking_angle" parameter')
@@ -650,7 +650,7 @@ class BeamlineCRISTAL(Beamline):
         self.sample_angles = (mgomega, mgphi)
         self.detector_angles = (inplane_angle, outofplane_angle)
 
-        return tilt_angle, grazing, inplane_angle[0], outofplane_angle[0]
+        return tilt_angle, grazing, inplane_angle, outofplane_angle
 
     def process_positions(
         self,

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -3023,6 +3023,7 @@ class LoaderNANOMAX(Loader):
         default_dirname = "data/"
         return homedir, default_dirname, None, template_imagefile
 
+    @safeload
     def load_data(
         self,
         setup: Setup,

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -1204,12 +1204,12 @@ class LoaderID01(Loader):
                 nu = motor_values[motor_names.index(motor_table["nu"])]
 
             if motor_table["energy"] in labels:
-                raw_energy = labels_data[labels.index(motor_table["energy"]), :]
+                energy = labels_data[labels.index(motor_table["energy"]), :]
                 # energy scanned, override the user-defined energy
-                energy = raw_energy * 1000.0  # switch to eV
             else:  # positioner
                 energy = motor_values[motor_names.index(motor_table["energy"])]
 
+            energy = energy * 1000.0  # switch to eV
             # remove user-defined sample offsets (sample: mu, eta, phi)
             mu = mu - self.sample_offsets[0]
             eta = eta - self.sample_offsets[1]
@@ -2063,12 +2063,12 @@ class Loader34ID(Loader):
                 gamma = motor_values[motor_names.index(self.motor_table["gamma"])]
 
             if self.motor_table["energy"] in labels:  # scanned
-                raw_energy = labels_data[labels.index(self.motor_table["energy"]), :]
+                energy = labels_data[labels.index(self.motor_table["energy"]), :]
                 # energy scanned, override the user-defined energy
-                energy = raw_energy * 1000.0  # switch to eV
             else:  # positioner
                 energy = motor_values[motor_names.index(self.motor_table["energy"])]
 
+            energy = energy * 1000.0  # switch to eV
             detector_distance = motor_values[
                 motor_names.index(self.motor_table["detector_distance"])
             ]

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -515,24 +515,26 @@ class Loader(ABC):
 
     @staticmethod
     @abstractmethod
-    def create_logfile(**kwargs):
+    def create_logfile(
+        datadir: str,
+        name: str,
+        root_folder: str,
+        scan_number: int,
+        filename: Optional[str] = None,
+        template_imagefile: Optional[str] = None,
+    ):
         """
         Create the logfile, which can be a log/spec file or the data itself.
 
         The nature of this file is beamline dependent.
 
-        :param kwargs: beamline_specific parameters, which may include part of the
-         totality of the following keys:
-
-          - 'scan_number': the scan number to load.
-          - 'root_folder': the root directory of the experiment, where is e.g. the
-            specfile/.fio file.
-          - 'filename': the file name to load, or the path of 'alias_dict.txt' for SIXS.
-          - 'datadir': the data directory
-          - 'template_imagefile': the template for data/image file names
-          - 'name': str, the name of the beamline, e.g. 'SIXS_2019'
-
-        :return: logfile
+        :param datadir: str, the data directory
+        :param name: str, the name of the beamline, e.g. 'SIXS_2019'
+        :param root_folder: str, the root directory of the experiment
+        :param scan_number: the scan number to load
+        :param filename: str, absolute path to the spec/fio/alias file when it exists
+        :param template_imagefile: str, template for the data file name
+        :return: an instance of a context manager ContextFile
         """
 
     def init_data_mask(
@@ -946,16 +948,24 @@ class LoaderID01(Loader):
 
     @staticmethod
     def create_logfile(
-        root_folder: str, filename: str, scan_number: int, **kwargs
+        datadir: str,
+        name: str,
+        root_folder: str,
+        scan_number: int,
+        filename: Optional[str] = None,
+        template_imagefile: Optional[str] = None,
     ) -> ContextFile:
         """
         Create the logfile, which is the spec file for ID01.
 
+        :param datadir: str, the data directory
+        :param name: str, the name of the beamline, e.g. 'SIXS_2019'
         :param root_folder: str, the root directory of the experiment, where is e.g. the
            specfile file.
-        :param filename: str, name of the spec file or full path of the spec file
         :param scan_number: the scan number to load
-        :return: an instance of a context manager for opening the file later
+        :param filename: str, name of the spec file or full path of the spec file
+        :param template_imagefile: str, template for the data file name
+        :return: an instance of a context manager ContextFile
         """
         valid.valid_container(
             root_folder,
@@ -1313,16 +1323,24 @@ class LoaderID01BLISS(Loader):
 
     @staticmethod
     def create_logfile(
-        datadir: str, template_imagefile: str, scan_number: int, **kwargs
+        datadir: str,
+        name: str,
+        root_folder: str,
+        scan_number: int,
+        filename: Optional[str] = None,
+        template_imagefile: Optional[str] = None,
     ) -> ContextFile:
         """
         Create the logfile, which is the h5 file for ID01BLISS.
 
         :param datadir: str, the data directory
+        :param name: str, the name of the beamline, e.g. 'ID01BLISS'
+        :param root_folder: str, the root directory of the experiment
+        :param scan_number: the scan number to load
+        :param filename: str, absolute path to the spec/fio/alias file when it exists
         :param template_imagefile: str, template for data file name,
          e.g. 'ihhc3715_sample5.h5'
-        :param scan_number: the scan number to load
-        :return: an instance of a context manager for opening the file later
+        :return: an instance of a context manager ContextFile
         """
         valid.valid_container(datadir, container_types=str, name="datadir")
         if not os.path.isdir(datadir):
@@ -1554,25 +1572,26 @@ class LoaderSIXS(Loader):
     @staticmethod
     def create_logfile(
         datadir: str,
-        template_imagefile: str,
-        scan_number: int,
-        filename: str,
         name: str,
-        **kwargs,
+        root_folder: str,
+        scan_number: int,
+        filename: Optional[str] = None,
+        template_imagefile: Optional[str] = None,
     ) -> ContextFile:
         """
         Create the logfile, which is the data itself for SIXS.
 
         :param datadir: str, the data directory
+        :param name: str, the name of the beamline, e.g. 'SIXS_2019'
+        :param root_folder: str, the root directory of the experiment
+        :param scan_number: the scan number to load
+        :param filename: str, absolute path of 'alias_dict.txt'
         :param template_imagefile: str, template for data file name:
 
           - SIXS_2018: 'align.spec_ascan_mu_%05d.nxs'
           - SIXS_2019: 'spare_ascan_mu_%05d.nxs'
 
-        :param scan_number: int, the scan number to load
-        :param filename: str, absolute path of 'alias_dict.txt'
-        :param name: str, the name of the beamline, e.g. 'SIXS_2019'
-        :return: an instance of a context manager for opening the file later
+        :return: an instance of a context manager ContextFile
         """
         if not os.path.isdir(datadir):
             raise ValueError(f"The directory {datadir} does not exist")
@@ -1833,16 +1852,23 @@ class Loader34ID(Loader):
 
     @staticmethod
     def create_logfile(
-        root_folder: str, filename: str, scan_number: int, **kwargs
+        datadir: str,
+        name: str,
+        root_folder: str,
+        scan_number: int,
+        filename: Optional[str] = None,
+        template_imagefile: Optional[str] = None,
     ) -> ContextFile:
         """
         Create the logfile, which is the spec file for 34ID-C.
 
-        :param root_folder: str, the root directory of the experiment, where is e.g. the
-           specfile file.
-        :param filename: str, name of the spec file or full path of the spec file
+        :param datadir: str, the data directory
+        :param name: str, the name of the beamline, e.g. '34ID'
+        :param root_folder: str, the root directory of the experiment
         :param scan_number: the scan number to load
-        :return: an instance of a context manager for opening the file later
+        :param filename: str, absolute path to the spec/fio/alias file when it exists
+        :param template_imagefile: str, template for the data file name
+        :return: an instance of a context manager ContextFile
         """
         valid.valid_container(
             root_folder,
@@ -2144,14 +2170,24 @@ class LoaderP10(Loader):
     """Loader for PETRAIII P10 beamline."""
 
     @staticmethod
-    def create_logfile(root_folder: str, filename: str, **kwargs) -> ContextFile:
+    def create_logfile(
+        datadir: str,
+        name: str,
+        root_folder: str,
+        scan_number: int,
+        filename: Optional[str] = None,
+        template_imagefile: Optional[str] = None,
+    ) -> ContextFile:
         """
         Create the logfile, which is the .fio file for P10.
 
-        :param root_folder: str, the root directory of the experiment, where the scan
-           folders are located.
+        :param datadir: str, the data directory
+        :param name: str, the name of the beamline, e.g. 'P10'
+        :param root_folder: str, the root directory of the experiment
+        :param scan_number: the scan number to load
         :param filename: str, name of the .fio file or full path of the .fio file
-        :return: an instance of a context manager for opening the file later
+        :param template_imagefile: str, template for the data file name
+        :return: an instance of a context manager ContextFile
         """
         valid.valid_container(
             root_folder,
@@ -2167,11 +2203,17 @@ class LoaderP10(Loader):
             min_length=1,
             name="filename",
         )
-
+        valid.valid_item(
+            scan_number, allowed_types=int, min_included=1, name="scan_number"
+        )
         if os.path.isfile(filename):
             # filename is already the full path to the .fio file
             return ContextFile(
-                filename=filename, open_func=open, mode="r", encoding="utf-8"
+                filename=filename,
+                open_func=open,
+                scan_number=scan_number,
+                mode="r",
+                encoding="utf-8",
             )
 
         print(f"Could not find the fio file at: {filename}")
@@ -2576,15 +2618,23 @@ class LoaderCRISTAL(Loader):
 
     @staticmethod
     def create_logfile(
-        datadir: str, template_imagefile: str, scan_number: int, **kwargs
+        datadir: str,
+        name: str,
+        root_folder: str,
+        scan_number: int,
+        filename: Optional[str] = None,
+        template_imagefile: Optional[str] = None,
     ) -> ContextFile:
         """
         Create the logfile, which is the data itself for CRISTAL.
 
         :param datadir: str, the data directory
+        :param name: str, the name of the beamline, e.g. 'CRISTAL'
+        :param root_folder: str, the root directory of the experiment
+        :param scan_number: the scan number to load
+        :param filename: str, absolute path to the spec/fio/alias file when it exists
         :param template_imagefile: str, template for data file name, e.g. 'S%d.nxs'
-        :param scan_number: int, the scan number to load
-        :return: logfile
+        :return: an instance of a context manager ContextFile
         """
         valid.valid_container(datadir, container_types=str, name="datadir")
         if not os.path.isdir(datadir):
@@ -2971,15 +3021,23 @@ class LoaderNANOMAX(Loader):
 
     @staticmethod
     def create_logfile(
-        datadir: str, template_imagefile: str, scan_number: int, **kwargs
+        datadir: str,
+        name: str,
+        root_folder: str,
+        scan_number: int,
+        filename: Optional[str] = None,
+        template_imagefile: Optional[str] = None,
     ) -> ContextFile:
         """
         Create the logfile, which is the data itself for Nanomax.
 
         :param datadir: str, the data directory
+        :param name: str, the name of the beamline, e.g. 'Nanomax'
+        :param root_folder: str, the root directory of the experiment
+        :param scan_number: the scan number to load
+        :param filename: str, absolute path to the spec/fio/alias file when it exists
         :param template_imagefile: str, template for data file name, e.g. '%06d.h5'
-        :param scan_number: int, the scan number to load
-        :return: an instance of a context manager for opening the file later
+        :return: an instance of a context manager ContextFile
         """
         valid.valid_container(datadir, container_types=str, name="datadir")
         if not os.path.isdir(datadir):

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -6,7 +6,6 @@
 #       authors:
 #         Jerome Carnis, carnis_jerome@yahoo.fr
 #         Clement Atlan, c.atlan@outlook.com
-from __future__ import annotations
 
 """
 Implementation of beamline-dependent data loading classes.
@@ -42,6 +41,8 @@ API Reference
 -------------
 
 """
+
+from __future__ import annotations
 
 try:
     import hdf5plugin  # for P10, should be imported before h5py or PyTables

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -2071,7 +2071,7 @@ class Loader34ID(Loader):
             energy = energy * 1000.0  # switch to eV
             detector_distance = motor_values[
                 motor_names.index(self.motor_table["detector_distance"])
-            ]
+            ] / 1000  # convert to m
 
             # remove user-defined sample offsets (sample: mu, eta, phi)
             theta = theta - self.sample_offsets[0]

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -2069,9 +2069,10 @@ class Loader34ID(Loader):
                 energy = motor_values[motor_names.index(self.motor_table["energy"])]
 
             energy = energy * 1000.0  # switch to eV
-            detector_distance = motor_values[
-                motor_names.index(self.motor_table["detector_distance"])
-            ] / 1000  # convert to m
+            detector_distance = (
+                motor_values[motor_names.index(self.motor_table["detector_distance"])]
+                / 1000
+            )  # convert to m
 
             # remove user-defined sample offsets (sample: mu, eta, phi)
             theta = theta - self.sample_offsets[0]

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -2673,6 +2673,8 @@ class LoaderCRISTAL(Loader):
                         f" {list(file[root + '/' + actuator_name].keys())}\n"
                     )
                     return 0
+        if isinstance(dataset, (list, tuple, np.ndarray)) and len(dataset) == 1:
+            dataset = dataset[0]
         return dataset
 
     @staticmethod
@@ -2860,7 +2862,7 @@ class LoaderCRISTAL(Loader):
                 )
                 * 1000
             )  # in eV
-            if abs(energy - setup.energy) > 1:
+            if setup.energy is not None and abs(energy - setup.energy) > 1:
                 # difference larger than 1 eV
                 print(
                     f"\nWarning: user-defined energy = {setup.energy:.1f} eV different "

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -278,13 +278,6 @@ def check_pixels(data, mask, debugging=False):
     return data, mask
 
 
-def unpack_array(dataset):
-    """Unpack an array of length 1 into a single element."""
-    if isinstance(dataset, (list, tuple, np.ndarray)) and len(dataset) == 1:
-        return dataset[0]
-    return dataset
-
-
 def load_filtered_data(detector):
     """
     Load a filtered dataset and the corresponding mask.
@@ -2681,7 +2674,7 @@ class LoaderCRISTAL(Loader):
                         f" {list(file[root + '/' + actuator_name].keys())}\n"
                     )
                     return 0
-        return unpack_array(dataset)
+        return util.unpack_array(dataset)
 
     @staticmethod
     @safeload_static
@@ -3123,22 +3116,22 @@ class LoaderNANOMAX(Loader):
             group_key = list(file.keys())[0]  # currently 'entry'
 
             # positionners
-            delta = unpack_array(file["/" + group_key + "/snapshot/delta"][:])
-            gamma = unpack_array(file["/" + group_key + "/snapshot/gamma"][:])
-            energy = unpack_array(file["/" + group_key + "/snapshot/energy"][:])
+            delta = util.unpack_array(file["/" + group_key + "/snapshot/delta"][:])
+            gamma = util.unpack_array(file["/" + group_key + "/snapshot/gamma"][:])
+            energy = util.unpack_array(file["/" + group_key + "/snapshot/energy"][:])
 
             if setup.rocking_angle == "inplane":
                 try:
-                    phi = unpack_array(file["/" + group_key + "/measurement/gonphi"][:])
+                    phi = util.unpack_array(file["/" + group_key + "/measurement/gonphi"][:])
                 except KeyError:
                     raise KeyError(
                         "phi not in measurement data,"
                         ' check the parameter "rocking_angle"'
                     )
-                theta = unpack_array(file["/" + group_key + "/snapshot/gontheta"][:])
+                theta = util.unpack_array(file["/" + group_key + "/snapshot/gontheta"][:])
             else:
                 try:
-                    theta = unpack_array(
+                    theta = util.unpack_array(
                         file["/" + group_key + "/measurement/gontheta"][:]
                     )
                 except KeyError:
@@ -3146,7 +3139,7 @@ class LoaderNANOMAX(Loader):
                         "theta not in measurement data,"
                         ' check the parameter "rocking_angle"'
                     )
-                phi = unpack_array(file["/" + group_key + "/snapshot/gonphi"][:])
+                phi = util.unpack_array(file["/" + group_key + "/snapshot/gonphi"][:])
 
             # remove user-defined sample offsets (sample: theta, phi)
             theta = theta - self.sample_offsets[0]

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -293,17 +293,16 @@ def load_filtered_data(detector):
         title="Select data file",
         filetypes=[("NPZ", "*.npz")],
     )
-    data = np.load(file_path)
-    npz_key = data.files
-    data = data[npz_key[0]]
+    with np.load(file_path) as npzfile:
+        data = npzfile[list(npzfile.files)[0]]
+
     file_path = filedialog.askopenfilename(
         initialdir=detector.datadir,
         title="Select mask file",
         filetypes=[("NPZ", "*.npz")],
     )
-    mask = np.load(file_path)
-    npz_key = mask.files
-    mask = mask[npz_key[0]]
+    with np.load(file_path) as npzfile:
+        mask = npzfile[list(npzfile.files)[0]]
 
     monitor = np.ones(data.shape[0])
     frames_logical = np.ones(data.shape[0])
@@ -3122,13 +3121,17 @@ class LoaderNANOMAX(Loader):
 
             if setup.rocking_angle == "inplane":
                 try:
-                    phi = util.unpack_array(file["/" + group_key + "/measurement/gonphi"][:])
+                    phi = util.unpack_array(
+                        file["/" + group_key + "/measurement/gonphi"][:]
+                    )
                 except KeyError:
                     raise KeyError(
                         "phi not in measurement data,"
                         ' check the parameter "rocking_angle"'
                     )
-                theta = util.unpack_array(file["/" + group_key + "/snapshot/gontheta"][:])
+                theta = util.unpack_array(
+                    file["/" + group_key + "/snapshot/gontheta"][:]
+                )
             else:
                 try:
                     theta = util.unpack_array(

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -60,7 +60,7 @@ from silx.io.specfile import SpecFile
 import sys
 import tkinter as tk
 from tkinter import filedialog
-from typing import Dict, List, Optional, Tuple, TYPE_CHECKING, Union
+from typing import List, Optional, Tuple, TYPE_CHECKING, Union
 
 from bcdi.graph import graph_utils as gu
 from bcdi.utils.io_helper import ContextFile, safeload, safeload_static

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -935,7 +935,7 @@ class Setup:
                 filename=filename,
                 datadir=self.detector.datadir,
                 template_imagefile=self.detector.template_imagefile,
-                name=self.beamline,
+                name=self.beamline.name,
             )
         self.logfile = logfile
 

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -930,12 +930,12 @@ class Setup:
             logfile = None
         else:
             logfile = self.loader.create_logfile(
+                datadir=self.detector.datadir,
+                name=self.beamline.name,
                 scan_number=scan_number,
                 root_folder=root_folder,
                 filename=filename,
-                datadir=self.detector.datadir,
                 template_imagefile=self.detector.template_imagefile,
-                name=self.beamline.name,
             )
         self.logfile = logfile
 

--- a/bcdi/preprocessing/ReadNxs3.py
+++ b/bcdi/preprocessing/ReadNxs3.py
@@ -20,6 +20,7 @@ import os
 import numpy as np
 import pickle
 import time
+from typing import Optional
 from matplotlib import pyplot as plt
 import bcdi.utils.utilities as util
 import inspect
@@ -57,6 +58,7 @@ class DataSet:
         self.directory = directory
         self.filename = filename
         self.end_time = 2
+        self.file: Optional[tables.File] = None
         self.start_time = 1
         self.attlist = []
         self._list2d = []
@@ -95,13 +97,13 @@ class DataSet:
 
         # Load the file
         fullpath = os.path.join(self.directory, self.filename)
-        ff = tables.open_file(fullpath, "r")
-        f = ff.list_nodes("/")[0]
+        self.file = tables.open_file(fullpath, "r")
+        f = self.file.list_nodes("/")[0]
 
         # check if any scanned data a are present
         if not hasattr(f, "scan_data"):
             self.scantype = "unknown"
-            ff.close()
+            self.file.close()
             return
 
         # Discriminating between SBS or FLY scans
@@ -602,11 +604,15 @@ class DataSet:
         except tables.NoSuchNodeError:
             print("No Xpad Publisher defined")
         print("### End of ReadNxs3 ###\n")
-        ff.close()
+        self.file.close()
 
     ############################################
     # down here useful function in the NxsRead #
     ############################################
+    def close(self):
+        """Close the data file."""
+        self.file.close()
+
     def get_stack(self, det2d_name):
         """
         Check in the attribute-list for a given 2D detector.

--- a/bcdi/preprocessing/nxsReady.py
+++ b/bcdi/preprocessing/nxsReady.py
@@ -61,9 +61,9 @@ class DataSet:
         if scan == "HCS":
             shift = 1
         try:
-            fichier = tables.open_file(longname, "r")
+            self.file = tables.open_file(longname, "r")
             self.nodedatasizes = []  # list of data array lengths
-            for leaf in fichier.list_nodes("/")[0].scan_data:
+            for leaf in self.file.list_nodes("/")[0].scan_data:
                 self.nodedatasizes.append(leaf.shape[0])
             self.npts = max(self.nodedatasizes)
 
@@ -77,15 +77,15 @@ class DataSet:
             # shortening of the long name AKA the last part of longname
             self.alias = []
             self.data = numpy.empty(0)  # empty table creation
-            self.waveL = fichier.list_nodes("/")[0].SIXS.Monochromator.wavelength[0]
-            self.energymono = fichier.list_nodes("/")[0].SIXS.Monochromator.energy[0]
-            if fichier.list_nodes("/")[0].end_time.shape == ():
-                self.end_time = fichier.list_nodes("/")[0].end_time.read().tostring()
-            if fichier.list_nodes("/")[0].end_time.shape == (1,):
-                self.end_time = fichier.list_nodes("/")[0].end_time[0]
+            self.waveL = self.file.list_nodes("/")[0].SIXS.Monochromator.wavelength[0]
+            self.energymono = self.file.list_nodes("/")[0].SIXS.Monochromator.energy[0]
+            if self.file.list_nodes("/")[0].end_time.shape == ():
+                self.end_time = self.file.list_nodes("/")[0].end_time.read().tostring()
+            if self.file.list_nodes("/")[0].end_time.shape == (1,):
+                self.end_time = self.file.list_nodes("/")[0].end_time[0]
 
             # here we assign the values to the attributes previously generated
-            for leaf in fichier.list_nodes("/")[0].scan_data:
+            for leaf in self.file.list_nodes("/")[0].scan_data:
                 nodelongname = ""
                 nodenickname = ""
                 if len(leaf.shape) == 1:
@@ -166,7 +166,7 @@ class DataSet:
             self.mins = numpy.empty(0)
             self.maxs = numpy.empty(0)
             self.data = numpy.empty(0)
-            fichier.close()
+            self.file.close()
             return
 
         except tables.exceptions.NoSuchNodeError:
@@ -176,11 +176,11 @@ class DataSet:
             self.mins = numpy.empty(0)
             self.maxs = numpy.empty(0)
             self.data = numpy.empty(0)
-            fichier.close()
+            self.file.close()
             return
 
         else:
-            fichier.close()
+            self.file.close()
 
         self.npts = self.npts - 1  # remove the 1st point that is uncorrect due to
         # the operation strategy of simplescan
@@ -248,3 +248,7 @@ class DataSet:
             self.maxs = numpy.amax(self.data, axis=1)
 
         self.namelist = self.alias
+
+    def close(self):
+        """Close the data file."""
+        self.file.close()

--- a/bcdi/utils/io_helper.py
+++ b/bcdi/utils/io_helper.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+# BCDI: tools for pre(post)-processing Bragg coherent X-ray diffraction imaging data
+#   (c) 07/2017-06/2019 : CNRS UMR 7344 IM2NP
+#   (c) 07/2019-05/2021 : DESY PHOTON SCIENCE
+#       authors:
+#         Jerome Carnis, carnis_jerome@yahoo.fr
+
+"""Module containing decorators and context manager classes for input-output."""
+
+from functools import wraps
+from inspect import signature
+
+
+class ContextFile:
+
+    def __init__(self, filename, open_func, mode, encoding="utf-8"):
+        self.filename = filename
+        self.open_func = open_func
+        self.mode = mode
+        self.encoding = encoding
+
+    def __enter__(self, open_func, mode, encoding="utf-8"):
+        self.file = open_func(self.filename, mode=mode, encoding=encoding)
+        return self.file
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.file.close()
+        return False
+
+
+def decorator(func):
+    @wraps(func)
+    def helper(*args, setup, **kwargs):
+        if not isinstance(setup.logfile, ContextFile):
+            raise TypeError("setup.logfile undefined")
+        with setup.logfile as file:
+            return func(*args, file=file, **kwargs)
+    return helper

--- a/bcdi/utils/io_helper.py
+++ b/bcdi/utils/io_helper.py
@@ -9,7 +9,10 @@
 """Module containing decorators and context manager classes for input-output."""
 
 from functools import wraps
+import os
 from typing import Callable, Optional, Union
+
+import bcdi.utils.validation as valid
 
 
 class ContextFile:
@@ -40,6 +43,83 @@ class ContextFile:
         self.longname = longname
         self.shortname = shortname
         self.directory = directory
+
+    @property
+    def directory(self):
+        return self._directory
+
+    @directory.setter
+    def directory(self, value):
+        if value is not None and not isinstance(value, str):
+            raise TypeError("directory should be a str")
+        self._directory = value
+
+    @property
+    def filename(self):
+        return self._filename
+
+    @filename.setter
+    def filename(self, value):
+        if not isinstance(value, str):
+            raise TypeError("filename should be a str")
+        if not os.path.isfile(value):
+            raise ValueError(f"Could not find the file at: {value}")
+        self._filename = value
+
+    @property
+    def longname(self):
+        return self._longname
+
+    @longname.setter
+    def longname(self, value):
+        if value is not None and not isinstance(value, str):
+            raise TypeError("longname should be a str")
+        self._longname = value
+
+    @property
+    def mode(self):
+        return self._mode
+
+    @mode.setter
+    def mode(self, value):
+        if not isinstance(value, str):
+            raise TypeError("mode should be a str")
+        self._mode = value
+
+    @property
+    def open_func(self):
+        return self._open_func
+
+    @open_func.setter
+    def open_func(self, value):
+        if not isinstance(value, type) and not isinstance(value, Callable):
+            raise TypeError("open_func should be a class or a function")
+        self._open_func = value
+
+    @property
+    def scan_number(self):
+        return self._scan_number
+
+    @scan_number.setter
+    def scan_number(self, value):
+        valid.valid_item(
+            value,
+            allowed_types=int,
+            min_included=1,
+            allow_none=True,
+            name="scan_number",
+        )
+        self._scan_number = value
+
+    @property
+    def shortname(self):
+        return self._shortname
+
+    @shortname.setter
+    def shortname(self, value):
+        if value is not None and not isinstance(value, str):
+            raise TypeError("shortname should be a str")
+        self._shortname = value
 
     def __enter__(self):
         if (
@@ -90,7 +170,7 @@ def safeload(func: Callable) -> Callable:
 
     :param func: a class method accessing the file
     """
-    if not isinstance(func, Callable):
+    if not callable(func):
         raise ValueError("func should be a callable")
 
     @wraps(func)
@@ -114,7 +194,7 @@ def safeload_static(func: Callable) -> Callable:
 
     :param func: a class static method accessing the file
     """
-    if not isinstance(func, Callable):
+    if not callable(func):
         raise ValueError("func should be a callable")
 
     @wraps(func)

--- a/bcdi/utils/io_helper.py
+++ b/bcdi/utils/io_helper.py
@@ -51,7 +51,10 @@ class ContextFile:
             self.file = self.open_func(
                 self.filename, mode=self.mode, encoding=self.encoding
             )
-        elif self.open_func.__module__ == "h5py._hl.files" and self.open_func.__name__ == "File":
+        elif (
+            self.open_func.__module__ == "h5py._hl.files"
+            and self.open_func.__name__ == "File"
+        ):
             self.file = self.open_func(self.filename, mode=self.mode)
         elif (
             self.open_func.__module__ == "nxsReady"

--- a/bcdi/utils/io_helper.py
+++ b/bcdi/utils/io_helper.py
@@ -177,10 +177,10 @@ def safeload(func: Callable) -> Callable:
     def helper(self, *args, **kwargs):
         setup = kwargs.get("setup")
         if setup is None:
-            raise ValueError
+            raise ValueError("setup undefined")
         if not isinstance(setup.logfile, ContextFile):
             raise TypeError(
-                "setup.logfile should be a ContextFile, " f"got {type(setup.logfile)}"
+                f"setup.logfile should be a ContextFile, got {type(setup.logfile)}"
             )
         with setup.logfile as file:
             return func(self, *args, file=file, **kwargs)
@@ -201,10 +201,10 @@ def safeload_static(func: Callable) -> Callable:
     def helper(*args, **kwargs):
         setup = kwargs.get("setup")
         if setup is None:
-            raise ValueError
+            raise ValueError("setup undefined")
         if not isinstance(setup.logfile, ContextFile):
             raise TypeError(
-                "setup.logfile should be a ContextFile, " f"got {type(setup.logfile)}"
+                f"setup.logfile should be a ContextFile, got {type(setup.logfile)}"
             )
         with setup.logfile as file:
             return func(*args, file=file, **kwargs)

--- a/bcdi/utils/io_helper.py
+++ b/bcdi/utils/io_helper.py
@@ -13,7 +13,12 @@ from typing import Callable, Optional, Union
 
 
 class ContextFile:
-    """Convenience context manager to open files."""
+    """
+    Convenience context manager to open files.
+
+    The supported opening callables are silx.io.specfile.Specfile, io.open, h5py.File
+    and SIXS (nxsReady.Dataset, ReadNxs3.Dataset).
+    """
 
     def __init__(
         self,
@@ -76,7 +81,15 @@ class ContextFile:
         return False
 
 
-def safeload(func):
+def safeload(func: Callable) -> Callable:
+    """
+    Decorator for safely opening files within class methods.
+
+    :param func: a class method accessing the file
+    """
+    if not isinstance(func, Callable):
+        raise ValueError("func should be a callable")
+
     @wraps(func)
     def helper(self, *args, **kwargs):
         setup = kwargs.get("setup")
@@ -92,7 +105,15 @@ def safeload(func):
     return helper
 
 
-def safeload_static(func):
+def safeload_static(func: Callable) -> Callable:
+    """
+    Decorator for safely opening files within class static methods.
+
+    :param func: a class static method accessing the file
+    """
+    if not isinstance(func, Callable):
+        raise ValueError("func should be a callable")
+
     @wraps(func)
     def helper(*args, **kwargs):
         setup = kwargs.get("setup")

--- a/bcdi/utils/io_helper.py
+++ b/bcdi/utils/io_helper.py
@@ -137,7 +137,7 @@ class ContextFile:
         ):
             self.file = self.open_func(self.filename, mode=self.mode)
         elif (
-            self.open_func.__module__ == "nxsReady"
+            "nxsReady" in self.open_func.__module__
             and self.open_func.__name__ == "DataSet"
         ):
             self.file = self.open_func(
@@ -147,7 +147,7 @@ class ContextFile:
                 scan="SBS",
             )
         elif (
-            self.open_func.__module__ == "ReadNxs3"
+            "ReadNxs3" in self.open_func.__module__
             and self.open_func.__name__ == "DataSet"
         ):
             self.file = self.open_func(

--- a/bcdi/utils/io_helper.py
+++ b/bcdi/utils/io_helper.py
@@ -42,21 +42,15 @@ class ContextFile:
             and self.open_func.__name__ == "SpecFile"
         ):
             self.file = self.open_func(self.filename)
-        elif (
-                self.open_func.__module__ == "io"
-                and self.open_func.__name__ == "open"
-        ):
+        elif self.open_func.__module__ == "io" and self.open_func.__name__ == "open":
             self.file = self.open_func(
                 self.filename, mode=self.mode, encoding=self.encoding
             )
-        elif (
-                self.open_func.__module__ == "h5py"
-                and self.open_func.__name__ == "File"
-        ):
+        elif self.open_func.__module__ == "h5py" and self.open_func.__name__ == "File":
             self.file = self.open_func(self.filename, mode=self.mode)
         elif (
-                self.open_func.__module__ == "nxsReady"
-                and self.open_func.__name__ == "DataSet"
+            self.open_func.__module__ == "nxsReady"
+            and self.open_func.__name__ == "DataSet"
         ):
             self.file = self.open_func(
                 longname=self.longname,
@@ -65,8 +59,8 @@ class ContextFile:
                 scan="SBS",
             )
         elif (
-                self.open_func.__module__ == "ReadNxs3"
-                and self.open_func.__name__ == "DataSet"
+            self.open_func.__module__ == "ReadNxs3"
+            and self.open_func.__name__ == "DataSet"
         ):
             self.file = self.open_func(
                 directory=self.directory,

--- a/bcdi/utils/io_helper.py
+++ b/bcdi/utils/io_helper.py
@@ -46,7 +46,7 @@ class ContextFile:
             self.file = self.open_func(
                 self.filename, mode=self.mode, encoding=self.encoding
             )
-        elif self.open_func.__module__ == "h5py" and self.open_func.__name__ == "File":
+        elif self.open_func.__module__ == "h5py._hl.files" and self.open_func.__name__ == "File":
             self.file = self.open_func(self.filename, mode=self.mode)
         elif (
             self.open_func.__module__ == "nxsReady"

--- a/bcdi/utils/io_helper.py
+++ b/bcdi/utils/io_helper.py
@@ -36,11 +36,17 @@ class ContextFile:
             and self.open_func.__name__ == "SpecFile"
         ):
             self.file = self.open_func(self.filename)
-        elif self.open_func.__name__ == "open":
+        elif (
+                self.open_func.__module__ == "io"
+                and self.open_func.__name__ == "open"
+        ):
             self.file = self.open_func(
                 self.filename, mode=self.mode, encoding=self.encoding
             )
-        elif self.open_func.__name__ == "File":
+        elif (
+                self.open_func.__module__ == "h5py"
+                and self.open_func.__name__ == "File"
+        ):
             self.file = self.open_func(self.filename, mode=self.mode)
         else:
             raise NotImplementedError(f"open function {self.open_func} not supported")

--- a/bcdi/utils/io_helper.py
+++ b/bcdi/utils/io_helper.py
@@ -9,19 +9,41 @@
 """Module containing decorators and context manager classes for input-output."""
 
 from functools import wraps
-from inspect import signature
+from typing import Callable, Optional, Union
 
 
 class ContextFile:
+    """Convenience context manager to open files."""
 
-    def __init__(self, filename, open_func, mode="r", encoding="utf-8"):
+    def __init__(
+        self,
+        filename: str,
+        open_func: Union[type, Callable],
+        scan_number: Optional[int] = None,
+        mode: str = "r",
+        encoding: str = "utf-8",
+    ):
         self.filename = filename
+        self.file = None
         self.open_func = open_func
+        self.scan_number = scan_number
         self.mode = mode
         self.encoding = encoding
 
     def __enter__(self):
-        self.file = self.open_func(self.filename) #, mode=self.mode, encoding=self.encoding)
+        if (
+            self.open_func.__module__ == "silx.io.specfile"
+            and self.open_func.__name__ == "SpecFile"
+        ):
+            self.file = self.open_func(self.filename)
+        elif self.open_func.__name__ == "open":
+            self.file = self.open_func(
+                self.filename, mode=self.mode, encoding=self.encoding
+            )
+        elif self.open_func.__name__ == "File":
+            self.file = self.open_func(self.filename, mode=self.mode)
+        else:
+            raise NotImplementedError(f"open function {self.open_func} not supported")
         return self.file
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -36,9 +58,12 @@ def safeload(func):
         if setup is None:
             raise ValueError
         if not isinstance(setup.logfile, ContextFile):
-            raise TypeError("setup.logfile undefined")
+            raise TypeError(
+                "setup.logfile should be a ContextFile, " f"got {type(setup.logfile)}"
+            )
         with setup.logfile as file:
             return func(self, *args, file=file, **kwargs)
+
     return helper
 
 
@@ -49,7 +74,10 @@ def safeload_static(func):
         if setup is None:
             raise ValueError
         if not isinstance(setup.logfile, ContextFile):
-            raise TypeError("setup.logfile undefined")
+            raise TypeError(
+                "setup.logfile should be a ContextFile, " f"got {type(setup.logfile)}"
+            )
         with setup.logfile as file:
             return func(*args, file=file, **kwargs)
+
     return helper

--- a/bcdi/utils/io_helper.py
+++ b/bcdi/utils/io_helper.py
@@ -31,9 +31,12 @@ class ContextFile:
 
 def decorator(func):
     @wraps(func)
-    def helper(*args, setup, **kwargs):
+    def helper(self, *args, setup, **kwargs):
         if not isinstance(setup.logfile, ContextFile):
             raise TypeError("setup.logfile undefined")
         with setup.logfile as file:
-            return func(*args, file=file, **kwargs)
+            if 'self' in signature(func).parameters:
+                return func(self, *args, file=file, **kwargs)
+            else:
+                return func(*args, file=file, **kwargs)
     return helper

--- a/bcdi/utils/io_helper.py
+++ b/bcdi/utils/io_helper.py
@@ -92,7 +92,7 @@ class ContextFile:
 
     @open_func.setter
     def open_func(self, value):
-        if not isinstance(value, type) and not isinstance(value, Callable):
+        if not isinstance(value, type) and not callable(value):
             raise TypeError("open_func should be a class or a function")
         self._open_func = value
 

--- a/bcdi/utils/io_helper.py
+++ b/bcdi/utils/io_helper.py
@@ -22,6 +22,9 @@ class ContextFile:
         scan_number: Optional[int] = None,
         mode: str = "r",
         encoding: str = "utf-8",
+        longname: Optional[str] = None,
+        shortname: Optional[str] = None,
+        directory: Optional[str] = None,
     ):
         self.filename = filename
         self.file = None
@@ -29,6 +32,9 @@ class ContextFile:
         self.scan_number = scan_number
         self.mode = mode
         self.encoding = encoding
+        self.longname = longname
+        self.shortname = shortname
+        self.directory = directory
 
     def __enter__(self):
         if (
@@ -48,6 +54,25 @@ class ContextFile:
                 and self.open_func.__name__ == "File"
         ):
             self.file = self.open_func(self.filename, mode=self.mode)
+        elif (
+                self.open_func.__module__ == "nxsReady"
+                and self.open_func.__name__ == "DataSet"
+        ):
+            self.file = self.open_func(
+                longname=self.longname,
+                shortname=self.shortname,
+                alias_dict=self.filename,
+                scan="SBS",
+            )
+        elif (
+                self.open_func.__module__ == "ReadNxs3"
+                and self.open_func.__name__ == "DataSet"
+        ):
+            self.file = self.open_func(
+                directory=self.directory,
+                filename=self.shortname,
+                alias_dict=self.filename,
+            )
         else:
             raise NotImplementedError(f"open function {self.open_func} not supported")
         return self.file

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -22,7 +22,7 @@ from scipy.interpolate import interp1d, RegularGridInterpolator
 from scipy.optimize import curve_fit
 from scipy.special import erf
 from scipy.stats import multivariate_normal
-from typing import Any, List, Union, Sequence
+from typing import Any, List, Optional, Union, Sequence
 from ..graph import graph_utils as gu
 from ..utils import validation as valid
 
@@ -505,7 +505,7 @@ def dos2unix(input_file, output_file):
             output.write(row + str.encode("\n"))
 
 
-def find_file(filename: str, default_folder: str) -> str:
+def find_file(filename: Optional[str], default_folder: str) -> str:
     """
     Locate a file.
 
@@ -2380,7 +2380,9 @@ def try_smaller_primes(number, maxprime=13, required_dividers=(4,)):
     return True
 
 
-def unpack_array(array: Any) -> Any:
+def unpack_array(
+    array: Union[float, List[float], np.ndarray]
+) -> Union[float, List[float], np.ndarray]:
     """Unpack an array or Sequence of length 1 into a single element."""
     if isinstance(array, (list, tuple, np.ndarray)) and len(array) == 1:
         return array[0]

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -22,7 +22,7 @@ from scipy.interpolate import interp1d, RegularGridInterpolator
 from scipy.optimize import curve_fit
 from scipy.special import erf
 from scipy.stats import multivariate_normal
-from typing import List, Union, Sequence
+from typing import Any, List, Union, Sequence
 from ..graph import graph_utils as gu
 from ..utils import validation as valid
 
@@ -2385,6 +2385,13 @@ def try_smaller_primes(number, maxprime=13, required_dividers=(4,)):
             if number % k != 0:
                 return False
     return True
+
+
+def unpack_array(array: Any) -> Any:
+    """Unpack an array or Sequence of length 1 into a single element."""
+    if isinstance(array, (list, tuple, np.ndarray)) and len(array) == 1:
+        return array[0]
+    return array
 
 
 def wrap(obj, start_angle, range_angle):

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,5 +1,17 @@
-Future:
+Version 0.2.4:
 -------
+
+* Refactor: open files within context managers in `utilities.load_file`.
+
+* Create the class ContextFile implementing the context manager protocol. The method
+  `loader.create_logfile` returns an instance of ContextFile, allowing its safe usage
+  in other methods via the decorators `@safeload` and `@safeload_static`.
+
+* Refactor the signature of `loader.create_logfile`, so that all overriding methods
+  share the same signature with the overriden base class abstract method.
+
+* Implement the function `utilities.unpack_array`, to avoid hard-coding array slices
+  in methods using motor positions.
 
 * Feature: add support for the BLISS flavor of ID01 beamline.
 

--- a/tests/algorithms/test_algorithms_utils.py
+++ b/tests/algorithms/test_algorithms_utils.py
@@ -8,12 +8,7 @@
 
 import unittest
 import bcdi.algorithms.algorithms_utils as alg
-
-
-def run_tests(test_class):
-    suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
-    runner = unittest.TextTestRunner(verbosity=2)
-    return runner.run(suite)
+from tests.config import run_tests
 
 
 class Test(unittest.TestCase):

--- a/tests/config.py
+++ b/tests/config.py
@@ -7,16 +7,9 @@
 #         Jerome Carnis, carnis_jerome@yahoo.fr
 
 import unittest
-import bcdi.simulation.simulation_utils as simu
-from tests.config import run_tests
 
 
-class Test(unittest.TestCase):
-    """Tests."""
-
-    def test_dummy(self):
-        self.assertTrue(True)
-
-
-if __name__ == "__main__":
-    run_tests(Test)
+def run_tests(test_class):
+    suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
+    runner = unittest.TextTestRunner(verbosity=2)
+    return runner.run(suite)

--- a/tests/experiment/test_beamline.py
+++ b/tests/experiment/test_beamline.py
@@ -9,6 +9,8 @@
 import numpy as np
 import unittest
 from bcdi.experiment.beamline import create_beamline, Beamline
+from tests.config import run_tests
+
 
 # conversion table from the laboratory frame (CXI convention)
 # (z downstream, y vertical up, x outboard) to the frame of xrayutilities
@@ -21,12 +23,6 @@ labframe_to_xrayutil = {
     "z+": "x+",
     "z-": "x-",
 }
-
-
-def run_tests(test_class):
-    suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
-    runner = unittest.TextTestRunner(verbosity=2)
-    return runner.run(suite)
 
 
 class TestBeamline(unittest.TestCase):

--- a/tests/experiment/test_detector.py
+++ b/tests/experiment/test_detector.py
@@ -22,12 +22,7 @@ from bcdi.experiment.detector import (
     Eiger4M,
     Maxipix,
 )
-
-
-def run_tests(test_class):
-    suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
-    runner = unittest.TextTestRunner(verbosity=2)
-    return runner.run(suite)
+from tests.config import run_tests
 
 
 class TestCreateDetector(unittest.TestCase):

--- a/tests/experiment/test_diffractometer.py
+++ b/tests/experiment/test_diffractometer.py
@@ -8,9 +8,4 @@
 
 import unittest
 from bcdi.experiment.diffractometer import Diffractometer
-
-
-def run_tests(test_class):
-    suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
-    runner = unittest.TextTestRunner(verbosity=2)
-    return runner.run(suite)
+from tests.config import run_tests

--- a/tests/experiment/test_loader.py
+++ b/tests/experiment/test_loader.py
@@ -9,15 +9,9 @@
 import numpy as np
 import os
 from pyfakefs import fake_filesystem_unittest
-import unittest
 from bcdi.experiment.beamline import create_beamline
 from bcdi.experiment.setup import Setup
-
-
-def run_tests(test_class):
-    suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
-    runner = unittest.TextTestRunner(verbosity=2)
-    return runner.run(suite)
+from tests.config import run_tests
 
 
 class TestInitPath(fake_filesystem_unittest.TestCase):

--- a/tests/experiment/test_rotation_matrix.py
+++ b/tests/experiment/test_rotation_matrix.py
@@ -8,12 +8,7 @@
 
 import unittest
 from bcdi.experiment.rotation_matrix import RotationMatrix
-
-
-def run_tests(test_class):
-    suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
-    runner = unittest.TextTestRunner(verbosity=2)
-    return runner.run(suite)
+from tests.config import run_tests
 
 
 class Test(unittest.TestCase):

--- a/tests/experiment/test_setup.py
+++ b/tests/experiment/test_setup.py
@@ -9,12 +9,7 @@
 import numpy as np
 import unittest
 from bcdi.experiment.setup import Setup
-
-
-def run_tests(test_class):
-    suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
-    runner = unittest.TextTestRunner(verbosity=2)
-    return runner.run(suite)
+from tests.config import run_tests
 
 
 class Test(unittest.TestCase):

--- a/tests/facet_recognition/test_facet_utils.py
+++ b/tests/facet_recognition/test_facet_utils.py
@@ -7,12 +7,7 @@
 #         Jerome Carnis, carnis_jerome@yahoo.fr
 
 import unittest
-
-
-def run_tests(test_class):
-    suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
-    runner = unittest.TextTestRunner(verbosity=2)
-    return runner.run(suite)
+from tests.config import run_tests
 
 
 class Test(unittest.TestCase):

--- a/tests/graph/test_graph_utils.py
+++ b/tests/graph/test_graph_utils.py
@@ -11,12 +11,7 @@ import numpy as np
 import os
 import pathlib
 import bcdi.graph.graph_utils as gu
-
-
-def run_tests(test_class):
-    suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
-    runner = unittest.TextTestRunner(verbosity=2)
-    return runner.run(suite)
+from tests.config import run_tests
 
 
 class TestSaveToVti(unittest.TestCase):

--- a/tests/postprocessing/test_facet_analysis.py
+++ b/tests/postprocessing/test_facet_analysis.py
@@ -11,17 +11,12 @@ from pandas import DataFrame
 from pathlib import Path
 import unittest
 from bcdi.postprocessing.facet_analysis import Facets
+from tests.config import run_tests
 
 here = Path(__file__).parent
 THIS_DIR = str(here)
 SAVEDIR = str(here.parents[1] / "test_output/")
 FILENAME = "3572_fa.vtk"
-
-
-def run_tests(test_class):
-    suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
-    runner = unittest.TextTestRunner(verbosity=2)
-    return runner.run(suite)
 
 
 class TestInitFacetsParams(unittest.TestCase):

--- a/tests/postprocessing/test_postprocessing_utils.py
+++ b/tests/postprocessing/test_postprocessing_utils.py
@@ -8,12 +8,7 @@
 
 import unittest
 import bcdi.postprocessing.postprocessing_utils as pu
-
-
-def run_tests(test_class):
-    suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
-    runner = unittest.TextTestRunner(verbosity=2)
-    return runner.run(suite)
+from tests.config import run_tests
 
 
 class Test(unittest.TestCase):

--- a/tests/preprocessing/test_bcdi_utils.py
+++ b/tests/preprocessing/test_bcdi_utils.py
@@ -11,12 +11,7 @@ import unittest
 
 from bcdi.preprocessing.bcdi_utils import find_bragg
 from bcdi.utils.utilities import gaussian_window
-
-
-def run_tests(test_class):
-    suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
-    runner = unittest.TextTestRunner(verbosity=2)
-    return runner.run(suite)
+from tests.config import run_tests
 
 
 class TestFindBragg(unittest.TestCase):

--- a/tests/simulation/test_supportMaker.py
+++ b/tests/simulation/test_supportMaker.py
@@ -9,12 +9,7 @@
 import numpy as np
 import unittest
 import bcdi.simulation.supportMaker as sM
-
-
-def run_tests(test_class):
-    suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
-    runner = unittest.TextTestRunner(verbosity=2)
-    return runner.run(suite)
+from tests.config import run_tests
 
 
 class Test(unittest.TestCase):

--- a/tests/utils/test_image_registration.py
+++ b/tests/utils/test_image_registration.py
@@ -9,12 +9,7 @@
 import numpy as np
 import unittest
 import bcdi.utils.image_registration as reg
-
-
-def run_tests(test_class):
-    suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
-    runner = unittest.TextTestRunner(verbosity=2)
-    return runner.run(suite)
+from tests.config import run_tests
 
 
 class TestCalcNewPositions(unittest.TestCase):

--- a/tests/utils/test_io_helper.py
+++ b/tests/utils/test_io_helper.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+# BCDI: tools for pre(post)-processing Bragg coherent X-ray diffraction imaging data
+#   (c) 07/2017-06/2019 : CNRS UMR 7344 IM2NP
+#   (c) 07/2019-05/2021 : DESY PHOTON SCIENCE
+#       authors:
+#         Jerome Carnis, carnis_jerome@yahoo.fr
+
+from pathlib import Path
+import unittest
+from bcdi.utils.io_helper import ContextFile
+
+here = Path(__file__).parent
+CONFIG = str(here.parents[1] / "bcdi/examples/S11_config_preprocessing.yml")
+
+
+class TestContextFile(unittest.TestCase):
+    """Tests related to ContextFile class."""
+
+    def setUp(self):
+        self.filename = CONFIG
+        self.open_func = open
+
+    def test_instantiate_class(self):
+        ctx = ContextFile(filename=self.filename, open_func=self.open_func)
+        self.assertTrue(ctx.filename == self.filename)
+        self.assertTrue(ctx.mode == "r")
+        self.assertTrue(ctx.encoding == "utf-8")
+        self.assertIsNone(ctx.file)
+        self.assertIsNone(ctx.longname)
+        self.assertIsNone(ctx.scan_number)
+        self.assertIsNone(ctx.shortname)
+        self.assertIsNone(ctx.directory)
+
+    def test_open_function(self):
+        with ContextFile(filename=self.filename, open_func=self.open_func) as file:
+            first_line = next(file).split()
+        self.assertTrue(first_line[0] == "scans:" and first_line[1] == "11")
+
+    def test_open_function_wrong_type(self):
+        with self.assertRaises(TypeError):
+            ContextFile(filename=self.filename, open_func="weird function")
+
+    def test_open_function_not_supported(self):
+        ctx = ContextFile(filename=self.filename, open_func=int)
+        with self.assertRaises(NotImplementedError):
+            ctx.__enter__()
+
+    def test_scan_number_wrong_type(self):
+        with self.assertRaises(TypeError):
+            ContextFile(filename=self.filename, open_func=open, scan_number="1")
+
+    def test_scan_number_wrong_type_float(self):
+        with self.assertRaises(TypeError):
+            ContextFile(filename=self.filename, open_func=open, scan_number=1.0)
+
+    def test_exit_function(self):
+        with ContextFile(filename=self.filename, open_func=self.open_func) as file:
+            pass
+        with self.assertRaises(ValueError):
+            next(file)

--- a/tests/utils/test_io_helper.py
+++ b/tests/utils/test_io_helper.py
@@ -9,6 +9,7 @@
 from pathlib import Path
 import unittest
 from bcdi.utils.io_helper import ContextFile
+from tests.config import run_tests
 
 here = Path(__file__).parent
 CONFIG = str(here.parents[1] / "bcdi/examples/S11_config_preprocessing.yml")
@@ -59,3 +60,7 @@ class TestContextFile(unittest.TestCase):
             pass
         with self.assertRaises(ValueError):
             next(file)
+
+
+if __name__ == "__main__":
+    run_tests(TestContextFile)

--- a/tests/utils/test_io_helper.py
+++ b/tests/utils/test_io_helper.py
@@ -35,7 +35,10 @@ class TestContextFile(unittest.TestCase):
 
     def test_open_function(self):
         with ContextFile(filename=self.filename, open_func=self.open_func) as file:
-            first_line = next(file).split()
+            try:
+                first_line = next(file).split()
+            except StopIteration:
+                pass
         self.assertTrue(first_line[0] == "scans:" and first_line[1] == "11")
 
     def test_open_function_wrong_type(self):
@@ -59,7 +62,11 @@ class TestContextFile(unittest.TestCase):
         with ContextFile(filename=self.filename, open_func=self.open_func) as file:
             pass
         with self.assertRaises(ValueError):
-            next(file)
+            # file already closed
+            try:
+                next(file)
+            except StopIteration:
+                pass
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_parameters.py
+++ b/tests/utils/test_parameters.py
@@ -9,15 +9,10 @@
 from pathlib import Path
 import unittest
 from bcdi.utils.parameters import valid_param
+from tests.config import run_tests
 
 here = Path(__file__).parent
 THIS_DIR = str(here)
-
-
-def run_tests(test_class):
-    suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
-    runner = unittest.TextTestRunner(verbosity=2)
-    return runner.run(suite)
 
 
 class TestParameters(unittest.TestCase):

--- a/tests/utils/test_parser.py
+++ b/tests/utils/test_parser.py
@@ -9,15 +9,10 @@
 from pathlib import Path
 import unittest
 from bcdi.utils.parser import ConfigParser
+from tests.config import run_tests
 
 here = Path(__file__).parent
 CONFIG = str(here.parents[1] / "bcdi/examples/config_postprocessing.yml")
-
-
-def run_tests(test_class):
-    suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
-    runner = unittest.TextTestRunner(verbosity=2)
-    return runner.run(suite)
 
 
 class TestConfigParser(unittest.TestCase):

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -11,12 +11,7 @@ import os
 from pyfakefs import fake_filesystem_unittest
 import unittest
 import bcdi.utils.utilities as util
-
-
-def run_tests(test_class):
-    suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
-    runner = unittest.TextTestRunner(verbosity=2)
-    return runner.run(suite)
+from tests.config import run_tests
 
 
 class TestCast(unittest.TestCase):

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -238,8 +238,41 @@ class TestGaussianWindow(unittest.TestCase):
         self.assertTrue(np.unravel_index(abs(data).argmax(), data.shape) == (1, 25, 23))
 
 
+class TestUnpackArray(unittest.TestCase):
+    """
+    Tests on the function utilities.unpack_array.
+
+    def unpack_array(array: Any) -> Any
+    """
+
+    def test_array_longer_than_one(self):
+        arr = util.unpack_array(np.ones(2))
+        self.assertTrue(np.array_equal(arr, np.ones(2)))
+
+    def test_array_length_one(self):
+        arr = util.unpack_array(np.array([33]))
+        self.assertEqual(arr, 33)
+
+    def test_list_length_one(self):
+        arr = util.unpack_array([2])
+        self.assertEqual(arr, 2)
+
+    def test_str_length_one(self):
+        val = util.unpack_array("s")
+        self.assertEqual(val, "s")
+
+    def test_none(self):
+        val = util.unpack_array(None)
+        self.assertEqual(val, None)
+
+    def test_number(self):
+        val = util.unpack_array(5)
+        self.assertEqual(val, 5)
+
+
 if __name__ == "__main__":
     run_tests(TestInRange)
     run_tests(TestIsFloat)
     run_tests(TestFindFile)
     run_tests(TestGaussianWindow)
+    run_tests(TestUnpackArray)

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -10,12 +10,7 @@ import unittest
 from numbers import Integral, Real
 import numpy as np
 import bcdi.utils.validation as valid
-
-
-def run_tests(test_class):
-    suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
-    runner = unittest.TextTestRunner(verbosity=2)
-    return runner.run(suite)
+from tests.config import run_tests
 
 
 class TestValidContainer(unittest.TestCase):


### PR DESCRIPTION
Fixes #234 

A class ContextFile implementing the context manager protocol was created. The method `loader.create_logfile` returns an instance of ContextFile, allowing its safe usage in other methods via the decorators `@safeload` and `@safeload_static`.

The signature of `loader.create_logfile` has been refactored, so that all overriding methods share the same signature with the overriden base class abstract method.

A new function `utilities.unpack_array` has been implemented, to avoid hard-coding array slices in methods using motor positions.

Refactor: open files within context managers in `utilities.load_file`.

[X] Breaking change
[X] I implemented unit-tests
[X] Tests pass
[X] I updated the documentation

The modifications have been tested on experimental datasets from ID01, ID01BLISS, P10, SIXS_2019, CRISTAL, NANOMAX and 34ID. 