### PR TITLE
implement `__repr__` such that eval(repr(instance)) is an instance

### DIFF
--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -522,7 +522,7 @@ class Beamline(ABC):
 
     def __repr__(self):
         """Representation string of the Beamline instance."""
-        return self.__class__.__name__ + f'(name="{self.name}")'
+        return util.create_repr(self, Beamline)
 
     @property
     def sample_angles(self):

--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -51,7 +51,6 @@ from abc import ABC, abstractmethod
 from math import hypot, isclose
 import numpy as np
 from numbers import Real
-import os
 import xrayutilities as xu
 
 from bcdi.experiment.diffractometer import Diffractometer

--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -520,6 +520,10 @@ class Beamline(ABC):
             array = array[(nb_steps - nb_frames) // 2 : (nb_steps + nb_frames) // 2]
         return array
 
+    def __repr__(self):
+        """Representation string of the Beamline instance."""
+        return self.__class__.__name__ + f'(name="{self.name}")'
+
     @property
     def sample_angles(self):
         """Tuple of goniometer angular values for the sample stages."""

--- a/bcdi/experiment/detector.py
+++ b/bcdi/experiment/detector.py
@@ -64,9 +64,9 @@ import numpy as np
 from numbers import Real, Integral
 import os
 import pathlib
-from typing import Any, Dict, List, Union
+from typing import Any, Dict
 
-from bcdi.utils.utilities import format_repr
+from bcdi.utils.utilities import create_repr
 from bcdi.utils import validation as valid
 
 
@@ -558,24 +558,7 @@ class Detector(ABC):
 
     def __repr__(self):
         """Representation string of the Detector instance."""
-        return (
-            self.__class__.__name__ + "("
-            + format_repr("name", self.name)
-            + format_repr("rootdir", self.rootdir)
-            + format_repr("datadir", self.datadir)
-            + format_repr("savedir", self.savedir)
-            + format_repr("template_file", self.template_file)
-            + format_repr("template_imagefile", self.template_imagefile)
-            + format_repr("specfile", self.specfile)
-            + format_repr("sample_name", self.sample_name)
-            + format_repr("roi", self.sample_name)
-            + format_repr("sum_roi", self.sum_roi)
-            + format_repr("binning", self.binning)
-            + format_repr("preprocessing_binning", self.preprocessing_binning)
-            + format_repr("offsets", self.offsets)
-            + format_repr("linearity_func", self.linearity_func)
-            + ")"
-        )
+        return create_repr(self, Detector)
 
     @staticmethod
     def _background_subtraction(data, background):

--- a/bcdi/experiment/detector.py
+++ b/bcdi/experiment/detector.py
@@ -66,6 +66,7 @@ import os
 import pathlib
 from typing import Any, Dict, List, Union
 
+from bcdi.utils.utilities import format_repr
 from bcdi.utils import validation as valid
 
 
@@ -558,22 +559,22 @@ class Detector(ABC):
     def __repr__(self):
         """Representation string of the Detector instance."""
         return (
-            self.__class__.__name__ + '('
-            f'name="{self.name}", '
-            f'rootdir = {self.rootdir}, '
-            f'datadir = {self.datadir}, '
-            f'savedir = {self.savedir}, '
-            f'template_file = {self.template_file}, '
-            f'template_imagefile = {self.template_imagefile}, '
-            f'specfile = {self.specfile}, '
-            f'sample_name = {self.sample_name}, '
-            f'roi={self.roi}, '
-            f'sum_roi={self.sum_roi}, '
-            f'binning={self.binning}, '
-            f'preprocessing_binning={self.preprocessing_binning}, '
-            f'offsets={self.offsets}, '
-            f'linearity_func={self.linearity_func}, '
-            ')'
+            self.__class__.__name__ + "("
+            + format_repr("name", self.name)
+            + format_repr("rootdir", self.rootdir)
+            + format_repr("datadir", self.datadir)
+            + format_repr("savedir", self.savedir)
+            + format_repr("template_file", self.template_file)
+            + format_repr("template_imagefile", self.template_imagefile)
+            + format_repr("specfile", self.specfile)
+            + format_repr("sample_name", self.sample_name)
+            + format_repr("roi", self.sample_name)
+            + format_repr("sum_roi", self.sum_roi)
+            + format_repr("binning", self.binning)
+            + format_repr("preprocessing_binning", self.preprocessing_binning)
+            + format_repr("offsets", self.offsets)
+            + format_repr("linearity_func", self.linearity_func)
+            + ")"
         )
 
     @staticmethod

--- a/bcdi/experiment/detector.py
+++ b/bcdi/experiment/detector.py
@@ -66,7 +66,7 @@ import os
 import pathlib
 from typing import Any, Dict
 
-from bcdi.utils.utilities import create_repr
+from bcdi.utils import utilities as util
 from bcdi.utils import validation as valid
 
 
@@ -558,7 +558,7 @@ class Detector(ABC):
 
     def __repr__(self):
         """Representation string of the Detector instance."""
-        return create_repr(self, Detector)
+        return util.create_repr(self, Detector)
 
     @staticmethod
     def _background_subtraction(data, background):

--- a/bcdi/experiment/detector.py
+++ b/bcdi/experiment/detector.py
@@ -558,22 +558,22 @@ class Detector(ABC):
     def __repr__(self):
         """Representation string of the Detector instance."""
         return (
-            f"{self.__class__.__name__}(name='{self.name}', "
-            f"unbinned_pixel_size={self.unbinned_pixel_size}, "
-            f"nb_pixel_x={self.nb_pixel_x}, "
-            f"nb_pixel_y={self.nb_pixel_y}, "
-            f"binning={self.binning},\n"
-            f"roi={self.roi}, "
-            f"sum_roi={self.sum_roi}, "
-            f"preprocessing_binning={self.preprocessing_binning}, "
-            f"rootdir = {self.rootdir},\n"
-            f"datadir = {self.datadir},\n"
-            f"scandir = {self.scandir},\n"
-            f"savedir = {self.savedir},\n"
-            f"sample_name = {self.sample_name},"
-            f" template_file = {self.template_file}, "
-            f"template_imagefile = {self.template_imagefile},"
-            f" specfile = {self.specfile},\n"
+            self.__class__.__name__ + '('
+            f'name="{self.name}", '
+            f'rootdir = {self.rootdir}, '
+            f'datadir = {self.datadir}, '
+            f'savedir = {self.savedir}, '
+            f'template_file = {self.template_file}, '
+            f'template_imagefile = {self.template_imagefile}, '
+            f'specfile = {self.specfile}, '
+            f'sample_name = {self.sample_name}, '
+            f'roi={self.roi}, '
+            f'sum_roi={self.sum_roi}, '
+            f'binning={self.binning}, '
+            f'preprocessing_binning={self.preprocessing_binning}, '
+            f'offsets={self.offsets}, '
+            f'linearity_func={self.linearity_func}, '
+            ')'
         )
 
     @staticmethod

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -371,6 +371,15 @@ class Diffractometer:
             )
             del self.__getattribute__(self.valid_names[stage_name])[index]
 
+    def __repr__(self):
+        """Representation string of the Diffractometer instance."""
+        return (
+            self.__class__.__name__ + '('
+            f'name="{self.name}", '
+            f'sample_offsets={self.sample_offsets}, '                      
+            ')'
+        )
+
     def rotation_matrix(self, stage_name, angles):
         """
         Calculate a 3D rotation matrix given rotation axes and angles.

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -42,6 +42,7 @@ from numbers import Number, Real
 import numpy as np
 
 from bcdi.experiment.rotation_matrix import RotationMatrix
+from bcdi.utils.utilities import create_repr
 from bcdi.utils import validation as valid
 
 Geometry = namedtuple(
@@ -373,12 +374,7 @@ class Diffractometer:
 
     def __repr__(self):
         """Representation string of the Diffractometer instance."""
-        return (
-            self.__class__.__name__ + "("
-            f'name="{self.name}", '
-            f"sample_offsets={self.sample_offsets}, "
-            ")"
-        )
+        return create_repr(self, Diffractometer)
 
     def rotation_matrix(self, stage_name, angles):
         """

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -374,10 +374,10 @@ class Diffractometer:
     def __repr__(self):
         """Representation string of the Diffractometer instance."""
         return (
-            self.__class__.__name__ + '('
+            self.__class__.__name__ + "("
             f'name="{self.name}", '
-            f'sample_offsets={self.sample_offsets}, '                      
-            ')'
+            f"sample_offsets={self.sample_offsets}, "
+            ")"
         )
 
     def rotation_matrix(self, stage_name, angles):

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -42,7 +42,7 @@ from numbers import Number, Real
 import numpy as np
 
 from bcdi.experiment.rotation_matrix import RotationMatrix
-from bcdi.utils.utilities import create_repr
+from bcdi.utils import utilities as util
 from bcdi.utils import validation as valid
 
 Geometry = namedtuple(
@@ -374,7 +374,7 @@ class Diffractometer:
 
     def __repr__(self):
         """Representation string of the Diffractometer instance."""
-        return create_repr(self, Diffractometer)
+        return util.create_repr(self, Diffractometer)
 
     def rotation_matrix(self, stage_name, angles):
         """

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -510,7 +510,7 @@ class Loader(ABC):
      the sample offsets will be subtracted to measurement the motor values.
     """
 
-    def __init__(self, name, sample_offsets):
+    def __init__(self, name: str, sample_offsets: Tuple[float, ...]) -> None:
         self.name = name
         self.sample_offsets = sample_offsets
 
@@ -922,6 +922,15 @@ class Loader(ABC):
 
         :return: the default monitor values
         """
+
+    def __repr__(self):
+        """Representation string of the Loader instance."""
+        return (
+            self.__class__.__name__ + '('
+            f'name="{self.name}", '
+            f'sample_offsets={self.sample_offsets}, '                      
+            ')'
+        )
 
 
 class LoaderID01(Loader):

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -925,12 +925,7 @@ class Loader(ABC):
 
     def __repr__(self):
         """Representation string of the Loader instance."""
-        return (
-            self.__class__.__name__ + "("
-            f'name="{self.name}", '
-            f"sample_offsets={self.sample_offsets}, "
-            ")"
-        )
+        return util.create_repr(self, Loader)
 
 
 class LoaderID01(Loader):

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -926,10 +926,10 @@ class Loader(ABC):
     def __repr__(self):
         """Representation string of the Loader instance."""
         return (
-            self.__class__.__name__ + '('
+            self.__class__.__name__ + "("
             f'name="{self.name}", '
-            f'sample_offsets={self.sample_offsets}, '                      
-            ')'
+            f"sample_offsets={self.sample_offsets}, "
+            ")"
         )
 
 

--- a/bcdi/experiment/rotation_matrix.py
+++ b/bcdi/experiment/rotation_matrix.py
@@ -10,6 +10,7 @@
 import numpy as np
 from numbers import Real
 
+from bcdi.utils.utilities import create_repr
 from bcdi.utils import validation as valid
 
 
@@ -110,9 +111,4 @@ class RotationMatrix:
 
     def __repr__(self):
         """Representation string of the RotationMatrix instance."""
-        return (
-            self.__class__.__name__ + "("
-            f'circle="{self.circle}", '
-            f"angle={self.angle}, "
-            ")"
-        )
+        return create_repr(self, RotationMatrix)

--- a/bcdi/experiment/rotation_matrix.py
+++ b/bcdi/experiment/rotation_matrix.py
@@ -111,8 +111,8 @@ class RotationMatrix:
     def __repr__(self):
         """Representation string of the RotationMatrix instance."""
         return (
-            self.__class__.__name__ + '('
+            self.__class__.__name__ + "("
             f'circle="{self.circle}", '
-            f'angle={self.angle}, '                      
-            ')'
+            f"angle={self.angle}, "
+            ")"
         )

--- a/bcdi/experiment/rotation_matrix.py
+++ b/bcdi/experiment/rotation_matrix.py
@@ -10,7 +10,7 @@
 import numpy as np
 from numbers import Real
 
-from bcdi.utils.utilities import create_repr
+from bcdi.utils import utilities as util
 from bcdi.utils import validation as valid
 
 
@@ -111,4 +111,4 @@ class RotationMatrix:
 
     def __repr__(self):
         """Representation string of the RotationMatrix instance."""
-        return create_repr(self, RotationMatrix)
+        return util.create_repr(self, RotationMatrix)

--- a/bcdi/experiment/rotation_matrix.py
+++ b/bcdi/experiment/rotation_matrix.py
@@ -29,7 +29,7 @@ class RotationMatrix:
     valid_circles = {"x+", "x-", "y+", "y-", "z+", "z-"}
     # + counter-clockwise, - clockwise
 
-    def __init__(self, circle, angle):
+    def __init__(self, circle: str, angle: Real) -> None:
         self.angle = angle
         self.circle = circle
 
@@ -107,3 +107,12 @@ class RotationMatrix:
                 f" {list(RotationMatrix.valid_circles)}"
             )
         return matrix
+
+    def __repr__(self):
+        """Representation string of the RotationMatrix instance."""
+        return (
+            self.__class__.__name__ + '('
+            f'circle="{self.circle}", '
+            f'angle={self.angle}, '                      
+            ')'
+        )

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -208,16 +208,17 @@ class Setup:
     def beam_direction(self, value):
         valid.valid_container(
             value,
-            container_types=(tuple, list),
+            container_types=(tuple, list, np.ndarray),
             length=3,
             item_types=Real,
             name="Setup.beam_direction",
         )
+        value = np.asarray(value)
         if np.linalg.norm(value) == 0:
             raise ValueError(
                 "At least of component of beam_direction should be non null."
             )
-        self._beam_direction = list(value / np.linalg.norm(value))
+        self._beam_direction = value / np.linalg.norm(value)
 
     @property
     def beam_direction_xrutils(self):

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -94,7 +94,7 @@ class Setup:
 
     def __init__(
         self,
-        beamline,
+        beamline_name,
         detector_name="Dummy",
         beam_direction=(1, 0, 0),
         energy=None,
@@ -151,10 +151,14 @@ class Setup:
         # kwargs for series (several frames per point) at P10
         self.is_series = kwargs.get("is_series", False)  # boolean
 
-        # create the detector and beamline instances
+        # create the detector instance
+        self.detector_name = detector_name
         self.detector = create_detector(name=detector_name, **kwargs)
+
+        # create the beamline instance
+        self.beamline_name = beamline_name
         self.beamline = create_beamline(
-            name=beamline, sample_offsets=kwargs.get("sample_offsets")
+            name=beamline_name, sample_offsets=kwargs.get("sample_offsets")
         )
 
         # load positional arguments corresponding to instance properties
@@ -204,7 +208,7 @@ class Setup:
     def beam_direction(self, value):
         valid.valid_container(
             value,
-            container_types=(tuple, list, np.ndarray),
+            container_types=(tuple, list),
             length=3,
             item_types=Real,
             name="Setup.beam_direction",
@@ -213,7 +217,7 @@ class Setup:
             raise ValueError(
                 "At least of component of beam_direction should be non null."
             )
-        self._beam_direction = value / np.linalg.norm(value)
+        self._beam_direction = list(value / np.linalg.norm(value))
 
     @property
     def beam_direction_xrutils(self):
@@ -659,39 +663,7 @@ class Setup:
 
     def __repr__(self):
         """Representation string of the Setup instance."""
-        return (
-            self.__class__.__name__ + "("
-            f'beamline="{self.beamline.name}", '
-            f'detector_name="{self.detector.name}", '
-            f"beam_direction={list(self.beam_direction)}, "
-            f"energy={self.energy}, "
-            f"distance={self.distance}, "
-            f"outofplane_angle={self.outofplane_angle}, "
-            f"inplane_angle={self.inplane_angle}, "
-            f"tilt_angle={self.tilt_angle}, "
-            "rocking_angle="
-            + (
-                f'"{self.rocking_angle}"'
-                if self.rocking_angle is not None
-                else str(self.rocking_angle)
-            )
-            + ", "
-            f"grazing_angle={self.grazing_angle}, "
-            f"direct_beam={self.direct_beam}, "
-            f"dirbeam_detector_angles={self.dirbeam_detector_angles}, "
-            f"filtered_data={self.filtered_data}, "
-            f"custom_scan={self.custom_scan}, "
-            f"custom_images={self.custom_images}, "
-            f"custom_monitor={self.custom_monitor}, "
-            f"custom_motors={self.custom_motors}, "
-            f"sample_inplane={self.sample_inplane}, "
-            f"sample_outofplane={self.sample_outofplane}, "
-            f"sample_offsets={self.diffractometer.sample_offsets}, "
-            f"offset_inplane={self.offset_inplane}, "
-            f"actuators={self.actuators}, "
-            f"is_series={self.is_series}, "
-            ")"
-        )
+        return util.create_repr(self, Setup)
 
     def calc_qvalues_xrutils(self, hxrd, nb_frames, **kwargs):
         """

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -660,28 +660,30 @@ class Setup:
     def __repr__(self):
         """Representation string of the Setup instance."""
         return (
-            f"{self.__class__.__name__}(beamline='{self.beamline.name}', "
-            f"detector='{self.detector.name}', "
-            f"beam_direction={self.beam_direction}, "
-            f"direct_beam={self.direct_beam}, "
-            f"dirbeam_detector_angles={self.dirbeam_detector_angles}, "
-            f"energy={self.energy}, distance={self.distance}, "
-            f"outofplane_angle={self.outofplane_angle},\n"
-            f"inplane_angle={self.inplane_angle}, "
-            f"tilt_angle={self.tilt_angle}, "
-            f"rocking_angle='{self.rocking_angle}', "
-            f"grazing_angle={self.grazing_angle},\n"
-            f"pixel_size={self.detector.unbinned_pixel_size}, "
-            f"sample_offsets={self.diffractometer.sample_offsets}, "
-            f"filtered_data={self.filtered_data},\n"
-            f"custom_scan={self.custom_scan}, "
-            f"custom_images={self.custom_images},\n"
-            f"custom_monitor={self.custom_monitor},\n"
-            f"custom_motors={self.custom_motors},\n"
-            f"sample_inplane={self.sample_inplane}, "
-            f"sample_outofplane={self.sample_outofplane}, "
-            f"offset_inplane={self.offset_inplane}, "
-            f"is_series={self.is_series})"
+            self.__class__.__name__ + '(beamline="' + self.beamline.name + '", '
+            'detector_name="' + self.detector.name + '", '
+            f'beam_direction={list(self.beam_direction)}, '
+            f'energy={self.energy}, '
+            f'distance={self.distance}, '
+            f'outofplane_angle={self.outofplane_angle}, '
+            f'inplane_angle={self.inplane_angle}, '
+            f'tilt_angle={self.tilt_angle}, '
+            'rocking_angle="' + self.rocking_angle + '", '
+            f'grazing_angle={self.grazing_angle}, '
+            f'direct_beam={self.direct_beam}, '
+            f'dirbeam_detector_angles={self.dirbeam_detector_angles}, '
+            f'filtered_data={self.filtered_data}, '
+            f'custom_scan={self.custom_scan}, '
+            f'custom_images={self.custom_images}, '
+            f'custom_monitor={self.custom_monitor}, '
+            f'custom_motors={self.custom_motors}, '
+            f'sample_inplane={self.sample_inplane}, '
+            f'sample_outofplane={self.sample_outofplane}, '
+            f'sample_offsets={self.diffractometer.sample_offsets}, '
+            f'offset_inplane={self.offset_inplane}, '
+            f'actuators={self.actuators}, '
+            f'is_series={self.is_series}, '
+            ')'
         )
 
     def calc_qvalues_xrutils(self, hxrd, nb_frames, **kwargs):

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -660,31 +660,37 @@ class Setup:
     def __repr__(self):
         """Representation string of the Setup instance."""
         return (
-            self.__class__.__name__ + '('
+            self.__class__.__name__ + "("
             f'beamline="{self.beamline.name}", '
             f'detector_name="{self.detector.name}", '
-            f'beam_direction={list(self.beam_direction)}, '
-            f'energy={self.energy}, '
-            f'distance={self.distance}, '
-            f'outofplane_angle={self.outofplane_angle}, '
-            f'inplane_angle={self.inplane_angle}, '
-            f'tilt_angle={self.tilt_angle}, '
-            f'rocking_angle={self.rocking_angle}, '
-            f'grazing_angle={self.grazing_angle}, '
-            f'direct_beam={self.direct_beam}, '
-            f'dirbeam_detector_angles={self.dirbeam_detector_angles}, '
-            f'filtered_data={self.filtered_data}, '
-            f'custom_scan={self.custom_scan}, '
-            f'custom_images={self.custom_images}, '
-            f'custom_monitor={self.custom_monitor}, '
-            f'custom_motors={self.custom_motors}, '
-            f'sample_inplane={self.sample_inplane}, '
-            f'sample_outofplane={self.sample_outofplane}, '
-            f'sample_offsets={self.diffractometer.sample_offsets}, '
-            f'offset_inplane={self.offset_inplane}, '
-            f'actuators={self.actuators}, '
-            f'is_series={self.is_series}, '
-            ')'
+            f"beam_direction={list(self.beam_direction)}, "
+            f"energy={self.energy}, "
+            f"distance={self.distance}, "
+            f"outofplane_angle={self.outofplane_angle}, "
+            f"inplane_angle={self.inplane_angle}, "
+            f"tilt_angle={self.tilt_angle}, "
+            "rocking_angle="
+            + (
+                f'"{self.rocking_angle}"'
+                if self.rocking_angle is not None
+                else str(self.rocking_angle)
+            )
+            + ", "
+            f"grazing_angle={self.grazing_angle}, "
+            f"direct_beam={self.direct_beam}, "
+            f"dirbeam_detector_angles={self.dirbeam_detector_angles}, "
+            f"filtered_data={self.filtered_data}, "
+            f"custom_scan={self.custom_scan}, "
+            f"custom_images={self.custom_images}, "
+            f"custom_monitor={self.custom_monitor}, "
+            f"custom_motors={self.custom_motors}, "
+            f"sample_inplane={self.sample_inplane}, "
+            f"sample_outofplane={self.sample_outofplane}, "
+            f"sample_offsets={self.diffractometer.sample_offsets}, "
+            f"offset_inplane={self.offset_inplane}, "
+            f"actuators={self.actuators}, "
+            f"is_series={self.is_series}, "
+            ")"
         )
 
     def calc_qvalues_xrutils(self, hxrd, nb_frames, **kwargs):

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -660,15 +660,16 @@ class Setup:
     def __repr__(self):
         """Representation string of the Setup instance."""
         return (
-            self.__class__.__name__ + '(beamline="' + self.beamline.name + '", '
-            'detector_name="' + self.detector.name + '", '
+            self.__class__.__name__ + '('
+            f'beamline="{self.beamline.name}", '
+            f'detector_name="{self.detector.name}", '
             f'beam_direction={list(self.beam_direction)}, '
             f'energy={self.energy}, '
             f'distance={self.distance}, '
             f'outofplane_angle={self.outofplane_angle}, '
             f'inplane_angle={self.inplane_angle}, '
             f'tilt_angle={self.tilt_angle}, '
-            'rocking_angle="' + self.rocking_angle + '", '
+            f'rocking_angle={self.rocking_angle}, '
             f'grazing_angle={self.grazing_angle}, '
             f'direct_beam={self.direct_beam}, '
             f'dirbeam_detector_angles={self.dirbeam_detector_angles}, '

--- a/bcdi/postprocessing/facet_analysis.py
+++ b/bcdi/postprocessing/facet_analysis.py
@@ -15,12 +15,14 @@ import ipywidgets as widgets
 from ipywidgets import Layout, interactive
 import matplotlib.pyplot as plt
 import numpy as np
+import os
 import pathlib
 import pandas as pd
 from pandas import DataFrame
 from typing import Any, Dict, List, no_type_check, Optional, Tuple, Union
 import vtk
 
+from bcdi.utils import utilities as util
 from bcdi.utils import validation as valid
 
 
@@ -83,9 +85,6 @@ class Facets:
 
         # Check input parameters
         valid.valid_container(
-            filename, container_types=str, min_length=1, name="filename"
-        )
-        valid.valid_container(
             pathdir, container_types=str, min_length=1, name="pathdir"
         )
         if not pathdir.endswith("/"):
@@ -96,10 +95,12 @@ class Facets:
         if savedir is not None and not savedir.endswith("/"):
             savedir += "/"
         valid.valid_item(lattice, allowed_types=float, min_excluded=0, name="lattice")
+        self.filename = filename
         self.pathsave = savedir or pathdir + "facets_analysis/"
         self.path_to_data = pathdir + filename
-        self.filename = filename
         self.lattice = lattice
+        self.pathdir = pathdir
+        self.savedir = savedir
 
         # Plotting options
         self.strain_range = 0.001
@@ -175,6 +176,16 @@ class Facets:
                 style={"description_width": "initial"},
             ),
         )
+
+    @property
+    def filename(self):
+        """Path to the VTK file."""
+        return self._filename
+
+    @filename.setter
+    def filename(self, value):
+        valid.valid_container(value, container_types=str, min_length=1, name="filename")
+        self._filename = value
 
     def load_vtk(self) -> None:
         """
@@ -1448,9 +1459,7 @@ class Facets:
 
     def __repr__(self):
         """Unambiguous representation of the class."""
-        return "Facets {}\n".format(
-            self.filename,
-        )
+        return util.create_repr(obj=self, cls=Facets)
 
     def __str__(self):
         """Readable representation of the class."""

--- a/bcdi/postprocessing/postprocessing_runner.py
+++ b/bcdi/postprocessing/postprocessing_runner.py
@@ -142,7 +142,7 @@ def run(prm):
     # define the experimental setup #
     #################################
     setup = Setup(
-        beamline=beamline_name,
+        beamline_name=beamline_name,
         energy=prm.get("energy"),
         outofplane_angle=prm.get("outofplane_angle"),
         inplane_angle=prm.get("inplane_angle"),

--- a/bcdi/preprocessing/preprocessing_runner.py
+++ b/bcdi/preprocessing/preprocessing_runner.py
@@ -322,7 +322,7 @@ def run(prm):
     # Initialize setup #
     ####################
     setup = Setup(
-        beamline=beamline_name,
+        beamline_name=beamline_name,
         energy=prm.get("energy"),
         rocking_angle=rocking_angle,
         distance=prm.get("sdd"),

--- a/bcdi/utils/io_helper.py
+++ b/bcdi/utils/io_helper.py
@@ -12,7 +12,7 @@ from functools import wraps
 import os
 from typing import Callable, Optional, Union
 
-from bcdi.utils.utilities import create_repr
+from bcdi.utils import utilities as util
 import bcdi.utils.validation as valid
 
 
@@ -57,7 +57,7 @@ class ContextFile:
 
     @property
     def filename(self):
-        return self._filename.replace("\\", "/")
+        return self._filename
 
     @filename.setter
     def filename(self, value):
@@ -166,7 +166,7 @@ class ContextFile:
 
     def __repr__(self):
         """Representation string of the ContextFile instance."""
-        return create_repr(obj=self, cls=ContextFile)
+        return util.create_repr(obj=self, cls=ContextFile)
 
 
 def safeload(func: Callable) -> Callable:

--- a/bcdi/utils/io_helper.py
+++ b/bcdi/utils/io_helper.py
@@ -12,6 +12,7 @@ from functools import wraps
 import os
 from typing import Callable, Optional, Union
 
+from bcdi.utils.utilities import create_repr
 import bcdi.utils.validation as valid
 
 
@@ -56,7 +57,7 @@ class ContextFile:
 
     @property
     def filename(self):
-        return self._filename
+        return self._filename.replace("\\", "/")
 
     @filename.setter
     def filename(self, value):
@@ -165,37 +166,7 @@ class ContextFile:
 
     def __repr__(self):
         """Representation string of the ContextFile instance."""
-        filename = self.filename.replace("\\", "/")
-        return (
-            self.__class__.__name__ + "("
-            f'filename="{filename}", '
-            f'open_func={self.open_func.__module__ + "." + self.open_func.__name__}, '
-            f"scan_number={self.scan_number}, "
-            f'mode="{self.mode}", '
-            f'encoding="{self.encoding}", '
-            "longname="
-            + (
-                f'"{self.longname}"'
-                if self.longname is not None
-                else str(self.longname)
-            )
-            + ", "
-            "shortname="
-            + (
-                f'"{self.shortname}"'
-                if self.shortname is not None
-                else str(self.shortname)
-            )
-            + ", "
-            "directory="
-            + (
-                f'"{self.directory}"'
-                if self.directory is not None
-                else str(self.directory)
-            )
-            + ", "
-            ")"
-        )
+        return create_repr(obj=self, cls=ContextFile)
 
 
 def safeload(func: Callable) -> Callable:

--- a/bcdi/utils/io_helper.py
+++ b/bcdi/utils/io_helper.py
@@ -163,6 +163,40 @@ class ContextFile:
         self.file.close()
         return False
 
+    def __repr__(self):
+        """Representation string of the ContextFile instance."""
+        filename = self.filename.replace("\\", "/")
+        return (
+            self.__class__.__name__ + "("
+            f'filename="{filename}", '
+            f'open_func={self.open_func.__module__ + "." + self.open_func.__name__}, '
+            f"scan_number={self.scan_number}, "
+            f'mode="{self.mode}", '
+            f'encoding="{self.encoding}", '
+            "longname="
+            + (
+                f'"{self.longname}"'
+                if self.longname is not None
+                else str(self.longname)
+            )
+            + ", "
+            "shortname="
+            + (
+                f'"{self.shortname}"'
+                if self.shortname is not None
+                else str(self.shortname)
+            )
+            + ", "
+            "directory="
+            + (
+                f'"{self.directory}"'
+                if self.directory is not None
+                else str(self.directory)
+            )
+            + ", "
+            ")"
+        )
+
 
 def safeload(func: Callable) -> Callable:
     """

--- a/bcdi/utils/parameters.py
+++ b/bcdi/utils/parameters.py
@@ -204,7 +204,7 @@ def valid_param(key: str, value: Any) -> Tuple[Any, bool]:
     elif key == "config_file":
         valid.valid_container(value, container_types=str, min_length=1, name=key)
         if not os.path.isfile(value):
-            raise ValueError(f"The directory {value} does not exist")
+            raise ValueError(f"The file {value} does not exist")
     elif key == "correlation_threshold":
         valid.valid_item(
             value, allowed_types=Real, min_included=0, max_included=1, name=key

--- a/bcdi/utils/parser.py
+++ b/bcdi/utils/parser.py
@@ -191,7 +191,7 @@ class ConfigParser:
     @property
     def file_path(self):
         """Path of the configuration file."""
-        return self._file_path.replace("\\", "/")
+        return self._file_path
 
     @file_path.setter
     def file_path(self, value):

--- a/bcdi/utils/parser.py
+++ b/bcdi/utils/parser.py
@@ -16,6 +16,7 @@ from typing import Any, ByteString, Dict, Optional
 import yaml
 
 from bcdi.utils.parameters import valid_param
+from bcdi.utils import utilities as util
 import bcdi.utils.validation as valid
 
 
@@ -190,7 +191,7 @@ class ConfigParser:
     @property
     def file_path(self):
         """Path of the configuration file."""
-        return self._file_path
+        return self._file_path.replace("\\", "/")
 
     @file_path.setter
     def file_path(self, value):
@@ -250,3 +251,7 @@ class ConfigParser:
         with open(self.file_path, "rb") as f:
             raw_config = f.read()
         return raw_config
+
+    def __repr__(self):
+        """Representation string of the ConfigParser instance."""
+        return util.create_repr(self, ConfigParser)

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -11,6 +11,7 @@ from collections import OrderedDict
 import ctypes
 from functools import reduce
 import gc
+from inspect import signature
 import json
 import h5py
 from matplotlib import pyplot as plt
@@ -681,6 +682,30 @@ def fit3d_poly4(x_axis, a, b, c, d, e, f, g, h, i, j, k, m, n):
         + m * x_axis[1] ** 4
         + n * x_axis[2] ** 4
     )
+
+
+def create_repr(obj: Any, cls: type) -> str:
+    """
+    Generate the string representation of the object.
+
+    It uses the parameters given to __init__, except kwargs.
+
+    :param obj: the object for which the string representation should be generated
+    :param cls: the cls from which __init__ parameters should be extracted (e.g., base
+     class in case of inheritance)
+    :return: the string representation
+    """
+    if not isinstance(cls, type):
+        raise TypeError(f"'cls' should be a class, for {type(cls)}")
+    output = obj.__class__.__name__ + "("
+    params = signature(cls.__init__).parameters.keys()  # type:ignore
+    print(params)
+    for _, param in enumerate(signature(cls.__init__).parameters.keys()):
+        if param not in ["self", "kwargs"]:
+            output += format_repr(param, getattr(obj, param))
+
+    output += ")"
+    return output
 
 
 def format_repr(field: str, value: Optional[Any]) -> str:

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -688,7 +688,7 @@ def create_repr(obj: Any, cls: type) -> str:
     output = obj.__class__.__name__ + "("
     for _, param in enumerate(signature(cls.__init__).parameters.keys()):
         if param not in ["self", "args", "kwargs"]:
-            value =  getattr(obj, param)
+            value = getattr(obj, param)
             if isinstance(value, np.ndarray):
                 value = ndarray_to_list(value)
             output += format_repr(param, value)

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -686,7 +686,7 @@ def create_repr(obj: Any, cls: type) -> str:
     if not isinstance(cls, type):
         raise TypeError(f"'cls' should be a class, for {type(cls)}")
     output = obj.__class__.__name__ + "("
-    for _, param in enumerate(signature(cls.__init__).parameters.keys()):
+    for _, param in enumerate(signature(cls.__init__).parameters.keys()):  # type: ignore
         if param not in ["self", "args", "kwargs"]:
             value = getattr(obj, param)
             if isinstance(value, np.ndarray):
@@ -694,7 +694,7 @@ def create_repr(obj: Any, cls: type) -> str:
             output += format_repr(param, value)
 
     output += ")"
-    return output
+    return str(output)
 
 
 def format_repr(field: str, value: Optional[Any]) -> str:
@@ -2427,11 +2427,11 @@ def try_smaller_primes(number, maxprime=13, required_dividers=(4,)):
 
 def unpack_array(
     array: Union[float, List[float], np.ndarray]
-) -> Union[float, List[float], np.ndarray]:
+) -> Union[float, np.ndarray]:
     """Unpack an array or Sequence of length 1 into a single element."""
     if isinstance(array, (list, tuple, np.ndarray)) and len(array) == 1:
         return array[0]
-    return array
+    return np.asarray(array)
 
 
 def wrap(obj, start_angle, range_angle):

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -689,27 +689,34 @@ def create_repr(obj: Any, cls: type) -> str:
     for _, param in enumerate(
         signature(cls.__init__).parameters.keys()  # type: ignore
     ):
+        quote_mark = True
         if param not in ["self", "args", "kwargs"]:
             value = getattr(obj, param)
             if isinstance(value, np.ndarray):
                 value = ndarray_to_list(value)
-            output += format_repr(param, value)
+            if callable(value):
+                value = value.__module__ + "." + value.__name__
+                # it's a string but we don't want to put it in quote mark in order to
+                # be able to call it directly
+                quote_mark = False
+            output += format_repr(param, value, quote_mark=quote_mark)
 
     output += ")"
     return str(output)
 
 
-def format_repr(field: str, value: Optional[Any]) -> str:
+def format_repr(field: str, value: Optional[Any], quote_mark: bool = True) -> str:
     """
     Format a string for the __repr__ method depending on its value.
 
     :param field: str, the value of the field in __repr__
     :param value: string or None
+    :param quote_mark: True to put quote marks around strings
     :return: a string
     """
     if not isinstance(field, str):
         raise TypeError(f"'field should be a string, got {type(field)}'")
-    if isinstance(value, str):
+    if isinstance(value, str) and quote_mark:
         return f'{field}="{value}", '
     return f"{field}={value}, "
 

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -717,8 +717,8 @@ def format_repr(field: str, value: Optional[Any], quote_mark: bool = True) -> st
     if not isinstance(field, str):
         raise TypeError(f"'field should be a string, got {type(field)}'")
     if isinstance(value, str) and quote_mark:
-        return f'{field}="{value}", '
-    return f"{field}={value}, "
+        return f'{field}="{value}", '.replace("\\", "/")
+    return f"{field}={value}, ".replace("\\", "/")
 
 
 def function_lmfit(params, x_axis, distribution, iterator=0):

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -683,6 +683,21 @@ def fit3d_poly4(x_axis, a, b, c, d, e, f, g, h, i, j, k, m, n):
     )
 
 
+def format_repr(field: str, value: Optional[Any]) -> str:
+    """
+    Format a string for the __repr__ method depending on its value.
+
+    :param field: str, the value of the field in __repr__
+    :param value: string or None
+    :return: a string
+    """
+    if not isinstance(field, str):
+        raise TypeError(f"'field should be a string, got {type(field)}'")
+    if isinstance(value, str):
+        return f'{field}="{value}", '
+    return f"{field}={value}, "
+
+
 def function_lmfit(params, x_axis, distribution, iterator=0):
     """
     Calculate distribution defined by lmfit Parameters.

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -688,7 +688,7 @@ def create_repr(obj: Any, cls: type) -> str:
     """
     Generate the string representation of the object.
 
-    It uses the parameters given to __init__, except kwargs.
+    It uses the parameters given to __init__, except self, args and kwargs.
 
     :param obj: the object for which the string representation should be generated
     :param cls: the cls from which __init__ parameters should be extracted (e.g., base
@@ -698,10 +698,8 @@ def create_repr(obj: Any, cls: type) -> str:
     if not isinstance(cls, type):
         raise TypeError(f"'cls' should be a class, for {type(cls)}")
     output = obj.__class__.__name__ + "("
-    params = signature(cls.__init__).parameters.keys()  # type:ignore
-    print(params)
     for _, param in enumerate(signature(cls.__init__).parameters.keys()):
-        if param not in ["self", "kwargs"]:
+        if param not in ["self", "args", "kwargs"]:
             output += format_repr(param, getattr(obj, param))
 
     output += ")"

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -686,7 +686,9 @@ def create_repr(obj: Any, cls: type) -> str:
     if not isinstance(cls, type):
         raise TypeError(f"'cls' should be a class, for {type(cls)}")
     output = obj.__class__.__name__ + "("
-    for _, param in enumerate(signature(cls.__init__).parameters.keys()):  # type: ignore
+    for _, param in enumerate(
+        signature(cls.__init__).parameters.keys()  # type: ignore
+    ):
         if param not in ["self", "args", "kwargs"]:
             value = getattr(obj, param)
             if isinstance(value, np.ndarray):

--- a/scripts/graph/bcdi_scan_analysis.py
+++ b/scripts/graph/bcdi_scan_analysis.py
@@ -250,7 +250,7 @@ plt.ion()
 # initialize the setup #
 ########################
 setup = Setup(
-    beamline=beamline,
+    beamline_name=beamline,
     is_series=is_series,
     detector_name=detector,
     datadir="",

--- a/scripts/graph/bcdi_view_mesh.py
+++ b/scripts/graph/bcdi_view_mesh.py
@@ -258,7 +258,7 @@ plt.ion()
 # initialize the setup #
 ########################
 setup = Setup(
-    beamline=beamline,
+    beamline_name=beamline,
     is_series=is_series,
     detector_name=detector,
     datadir="",

--- a/scripts/postprocessing/bcdi_correct_angles_detector.py
+++ b/scripts/postprocessing/bcdi_correct_angles_detector.py
@@ -132,7 +132,7 @@ plt.ion()
 # Initialize setup #
 ####################
 setup = Setup(
-    beamline=beamline,
+    beamline_name=beamline,
     energy=energy,
     rocking_angle=rocking_angle,
     distance=sdd,

--- a/scripts/postprocessing/bcdi_polarplot.py
+++ b/scripts/postprocessing/bcdi_polarplot.py
@@ -267,7 +267,7 @@ my_cmap = colormap.cmap
 # Initialize setup #
 ####################
 setup = Setup(
-    beamline=beamline,
+    beamline_name=beamline,
     energy=energy,
     rocking_angle=rocking_angle,
     distance=sdd,

--- a/scripts/postprocessing/bcdi_prtf_BCDI.py
+++ b/scripts/postprocessing/bcdi_prtf_BCDI.py
@@ -234,7 +234,7 @@ def press_key(event):
 # Initialize setup #
 ####################
 setup = Setup(
-    beamline=beamline,
+    beamline_name=beamline,
     energy=energy,
     rocking_angle=rocking_angle,
     distance=sdd,

--- a/scripts/postprocessing/bcdi_prtf_BCDI_2D.py
+++ b/scripts/postprocessing/bcdi_prtf_BCDI_2D.py
@@ -148,7 +148,7 @@ debug = False  # True to show more plots
 # Initialize setup #
 ####################
 setup = Setup(
-    beamline=beamline,
+    beamline_name=beamline,
     energy=energy,
     rocking_angle=rocking_angle,
     distance=sdd,

--- a/scripts/postprocessing/bcdi_rocking_curves.py
+++ b/scripts/postprocessing/bcdi_rocking_curves.py
@@ -182,7 +182,7 @@ check_roi = []  # a small ROI around the Bragg peak will be stored for each scan
 # Initialize setup #
 ####################
 setup = Setup(
-    beamline=beamline,
+    beamline_name=beamline,
     energy=energy,
     rocking_angle=rocking_angle,
     distance=sdd,

--- a/scripts/preprocessing/bcdi_preprocess_CDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_CDI.py
@@ -414,7 +414,7 @@ plt.rcParams["keymap.fullscreen"] = [""]
 # Initialize setup #
 ####################
 setup = Setup(
-    beamline=beamline,
+    beamline_name=beamline,
     energy=energy,
     rocking_angle="inplane",
     distance=sdd,

--- a/scripts/preprocessing/bcdi_read_BCDI_scan.py
+++ b/scripts/preprocessing/bcdi_read_BCDI_scan.py
@@ -140,7 +140,7 @@ if normalize not in {"skip", "monitor"}:
 # Initialize setup #
 ####################
 setup = Setup(
-    beamline=beamline,
+    beamline_name=beamline,
     rocking_angle=rocking_angle,
     custom_scan=custom_scan,
     custom_images=custom_images,

--- a/scripts/preprocessing/bcdi_rescale_support.py
+++ b/scripts/preprocessing/bcdi_rescale_support.py
@@ -622,7 +622,7 @@ if not all(
 
     else:  # data in detector frame
         setup = Setup(
-            beamline=beamline,
+            beamline_name=beamline,
             energy=energy,
             outofplane_angle=outofplane_angle,
             inplane_angle=inplane_angle,

--- a/scripts/simulation/bcdi_diffraction_angles.py
+++ b/scripts/simulation/bcdi_diffraction_angles.py
@@ -60,7 +60,7 @@ bounds = (
 # Initialize setup #
 ####################
 setup = exp.Setup(
-    beamline=beamline,
+    beamline_name=beamline,
     energy=energy,
     beam_direction=beam_direction,
     sample_inplane=sample_inplane,

--- a/scripts/simulation/bcdi_simu_diffpattern_BCDI.py
+++ b/scripts/simulation/bcdi_simu_diffpattern_BCDI.py
@@ -123,7 +123,7 @@ my_cmap = colormap.cmap
 # define setup #
 ################
 setup = Setup(
-    beamline=beamline,
+    beamline_name=beamline,
     energy=energy,
     outofplane_angle=outofplane_angle,
     inplane_angle=inplane_angle,

--- a/tests/experiment/test_beamline.py
+++ b/tests/experiment/test_beamline.py
@@ -8,7 +8,7 @@
 
 import numpy as np
 import unittest
-from bcdi.experiment.beamline import create_beamline, Beamline
+from bcdi.experiment.beamline import create_beamline, Beamline, BeamlineID01
 from tests.config import run_tests
 
 
@@ -79,6 +79,10 @@ class TestBeamline(unittest.TestCase):
     def test_find_outofplane_34ID(self):
         beamline = create_beamline("34ID")
         self.assertTrue(beamline.find_outofplane() == 1)
+
+    def test_repr(self):
+        beamline = create_beamline("ID01")
+        self.assertIsInstance(eval(repr(beamline)), BeamlineID01)
 
 
 class TestBeamlineCRISTAL(unittest.TestCase):

--- a/tests/experiment/test_detector.py
+++ b/tests/experiment/test_detector.py
@@ -407,9 +407,6 @@ class TestDetector(fake_filesystem_unittest.TestCase):
         det = Maxipix(name="Maxipix", template_imagefile="S")
         self.assertEqual(det.template_imagefile, "S")
 
-    def test_repr(self):
-        self.assertIsInstance(self.det.__repr__(), str)
-
     def test_background_subtraction_correct(self):
         data = np.ones((3, 3))
         background = np.ones((3, 3))
@@ -727,6 +724,9 @@ class TestDetector(fake_filesystem_unittest.TestCase):
         mask = np.zeros((3, 3))
         with self.assertRaises(ValueError):
             det._saturation_correction(data, mask, nb_frames=0)
+
+    def test_repr(self):
+        self.assertIsInstance(eval(repr(self.det)), Maxipix)
 
 
 class TestMaxipix(unittest.TestCase):

--- a/tests/experiment/test_detector.py
+++ b/tests/experiment/test_detector.py
@@ -728,6 +728,10 @@ class TestDetector(fake_filesystem_unittest.TestCase):
     def test_repr(self):
         self.assertIsInstance(eval(repr(self.det)), Maxipix)
 
+    def test_repr_str_not_None(self):
+        self.det.template_file = "test"
+        self.assertIsInstance(eval(repr(self.det)), Maxipix)
+
 
 class TestMaxipix(unittest.TestCase):
     """Tests related to the Maxipix detector."""

--- a/tests/experiment/test_diffractometer.py
+++ b/tests/experiment/test_diffractometer.py
@@ -9,3 +9,18 @@
 import unittest
 from bcdi.experiment.diffractometer import Diffractometer
 from tests.config import run_tests
+
+
+class TestRepr(unittest.TestCase):
+    """Tests related to __repr__."""
+
+    def setUp(self) -> None:
+        self.diffractometer = Diffractometer(name="ID01")
+
+    def test_return_type(self):
+        print(repr(self.diffractometer))
+        self.assertIsInstance(eval(repr(self.diffractometer)), Diffractometer)
+
+
+if __name__ == "__main__":
+    run_tests(TestRepr)

--- a/tests/experiment/test_loader.py
+++ b/tests/experiment/test_loader.py
@@ -263,7 +263,7 @@ class TestRetrieveDistance(fake_filesystem_unittest.TestCase):
 
         with open(self.valid_path + "undefined.spec", "w") as f:
             f.write("test\n#this,is,bad")
-        self.setup = Setup("ID01", detector_name="Maxipix")
+        self.setup = Setup(beamline_name="ID01", detector_name="Maxipix")
         self.setup.detector.rootdir = self.valid_path
         self.beamline = create_beamline(name="ID01")
 

--- a/tests/experiment/test_loader.py
+++ b/tests/experiment/test_loader.py
@@ -9,7 +9,10 @@
 import numpy as np
 import os
 from pyfakefs import fake_filesystem_unittest
+import unittest
+
 from bcdi.experiment.beamline import create_beamline
+from bcdi.experiment.loader import create_loader, LoaderID01
 from bcdi.experiment.setup import Setup
 from tests.config import run_tests
 
@@ -277,6 +280,18 @@ class TestRetrieveDistance(fake_filesystem_unittest.TestCase):
         self.assertTrue(distance is None)
 
 
+class TestRepr(unittest.TestCase):
+    """Tests related to __repr__."""
+
+    def setUp(self) -> None:
+        self.loader = create_loader(name="ID01", sample_offsets=(0, 0, 0))
+
+    def test_return_type(self):
+        print(repr(self.loader))
+        self.assertIsInstance(eval(repr(self.loader)), LoaderID01)
+
+
 if __name__ == "__main__":
     run_tests(TestRetrieveDistance)
     run_tests(TestInitPath)
+    run_tests(TestRepr)

--- a/tests/experiment/test_rotation_matrix.py
+++ b/tests/experiment/test_rotation_matrix.py
@@ -14,9 +14,15 @@ from tests.config import run_tests
 class Test(unittest.TestCase):
     """Tests related to rotation matrix instantiation."""
 
+    def setUp(self) -> None:
+        self.rotmat = RotationMatrix(circle="x+", angle=34)
+
     def test_instantiation_missing_parameter(self):
         with self.assertRaises(TypeError):
             RotationMatrix()
+
+    def test_repr(self):
+        self.assertIsInstance(eval(repr(self.rotmat)), RotationMatrix)
 
 
 if __name__ == "__main__":

--- a/tests/experiment/test_setup.py
+++ b/tests/experiment/test_setup.py
@@ -256,8 +256,19 @@ class TestCorrectDetectorAngles(unittest.TestCase):
         )
 
 
+class TestRepr(unittest.TestCase):
+    """Tests related to __repr__."""
+
+    def setUp(self) -> None:
+        self.setup = Setup(beamline="ID01")
+
+    def test_return_type(self):
+        self.assertIsInstance(eval(repr(self.setup)), Setup)
+
+
 if __name__ == "__main__":
     run_tests(Test)
     run_tests(TestCheckSetup)
     run_tests(TestCorrectDirectBeam)
     run_tests(TestCorrectDetectorAngles)
+    run_tests(TestRepr)

--- a/tests/experiment/test_setup.py
+++ b/tests/experiment/test_setup.py
@@ -265,6 +265,10 @@ class TestRepr(unittest.TestCase):
     def test_return_type(self):
         self.assertIsInstance(eval(repr(self.setup)), Setup)
 
+    def test_rocking_angle_str(self):
+        self.setup.rocking_angle = "outofplane"
+        self.assertIsInstance(eval(repr(self.setup)), Setup)
+
 
 if __name__ == "__main__":
     run_tests(Test)

--- a/tests/experiment/test_setup.py
+++ b/tests/experiment/test_setup.py
@@ -36,7 +36,7 @@ class TestCheckSetup(unittest.TestCase):
     """
 
     def setUp(self) -> None:
-        self.setup = Setup(beamline="ID01")
+        self.setup = Setup(beamline_name="ID01")
         self.params = {
             "grazing_angle": (1, 2),
             "inplane_angle": 1.23,
@@ -162,7 +162,7 @@ class TestCorrectDirectBeam(unittest.TestCase):
 
     def setUp(self) -> None:
         self.setup = Setup(
-            beamline="ID01",
+            beamline_name="ID01",
             direct_beam=[12, 324],
             dirbeam_detector_angles=[-1, 1],
             distance=1.23,
@@ -198,7 +198,7 @@ class TestCorrectDetectorAngles(unittest.TestCase):
 
     def setUp(self) -> None:
         self.setup = Setup(
-            beamline="ID01",
+            beamline_name="ID01",
             direct_beam=[12, 324],
             dirbeam_detector_angles=[0.5, 1],
             distance=1.23,
@@ -260,7 +260,7 @@ class TestRepr(unittest.TestCase):
     """Tests related to __repr__."""
 
     def setUp(self) -> None:
-        self.setup = Setup(beamline="ID01")
+        self.setup = Setup(beamline_name="ID01")
 
     def test_return_type(self):
         self.assertIsInstance(eval(repr(self.setup)), Setup)

--- a/tests/postprocessing/test_facet_analysis.py
+++ b/tests/postprocessing/test_facet_analysis.py
@@ -220,6 +220,9 @@ class TestInitFacetsAttributes(unittest.TestCase):
     def test_init_particle_cmap(self):
         self.assertTrue(self.facets.particle_cmap == "gist_ncar")
 
+    def test_repr(self):
+        self.assertIsInstance(eval(repr(self.facets)), Facets)
+
 
 if __name__ == "__main__":
     run_tests(TestInitFacetsParams)

--- a/tests/utils/test_io_helper.py
+++ b/tests/utils/test_io_helper.py
@@ -25,7 +25,7 @@ class TestContextFile(unittest.TestCase):
 
     def test_instantiate_class(self):
         ctx = ContextFile(filename=self.filename, open_func=self.open_func)
-        self.assertTrue(ctx.filename == self.filename.replace("\\", "/"))
+        self.assertTrue(ctx.filename == self.filename)
         self.assertTrue(ctx.mode == "r")
         self.assertTrue(ctx.encoding == "utf-8")
         self.assertIsNone(ctx.file)

--- a/tests/utils/test_io_helper.py
+++ b/tests/utils/test_io_helper.py
@@ -25,7 +25,7 @@ class TestContextFile(unittest.TestCase):
 
     def test_instantiate_class(self):
         ctx = ContextFile(filename=self.filename, open_func=self.open_func)
-        self.assertTrue(ctx.filename == self.filename)
+        self.assertTrue(ctx.filename == self.filename.replace("\\", "/"))
         self.assertTrue(ctx.mode == "r")
         self.assertTrue(ctx.encoding == "utf-8")
         self.assertIsNone(ctx.file)

--- a/tests/utils/test_io_helper.py
+++ b/tests/utils/test_io_helper.py
@@ -6,6 +6,7 @@
 #       authors:
 #         Jerome Carnis, carnis_jerome@yahoo.fr
 
+import io
 from pathlib import Path
 import unittest
 from bcdi.utils.io_helper import ContextFile
@@ -67,6 +68,20 @@ class TestContextFile(unittest.TestCase):
                 next(file)
             except StopIteration:
                 pass
+
+    def test_repr(self):
+        ctx = ContextFile(
+            filename=self.filename, open_func=self.open_func, shortname="test"
+        )
+        print(repr(ctx))
+        self.assertIsInstance(eval(repr(ctx)), ContextFile)
+
+    def test_repr_str_none(self):
+        ctx = ContextFile(
+            filename=self.filename, open_func=self.open_func, shortname=None
+        )
+        print(repr(ctx))
+        self.assertIsInstance(eval(repr(ctx)), ContextFile)
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_parser.py
+++ b/tests/utils/test_parser.py
@@ -27,7 +27,7 @@ class TestConfigParser(unittest.TestCase):
         self.parser = ConfigParser(CONFIG, self.command_line_args)
 
     def test_init_file_path(self):
-        self.assertTrue(self.parser.file_path == CONFIG)
+        self.assertTrue(self.parser.file_path == CONFIG.replace("\\", "/"))
 
     def test_init_file_path_2(self):
         self.assertTrue(self.parser.arguments is None)
@@ -94,6 +94,9 @@ class TestConfigParser(unittest.TestCase):
     def test_instantiate_configparser_no_cla(self):
         self.parser = ConfigParser(CONFIG)
         self.assertIsNone(self.parser.arguments)
+
+    def test_repr(self):
+        self.assertIsInstance(eval(repr(self.parser)), ConfigParser)
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_parser.py
+++ b/tests/utils/test_parser.py
@@ -27,7 +27,7 @@ class TestConfigParser(unittest.TestCase):
         self.parser = ConfigParser(CONFIG, self.command_line_args)
 
     def test_init_file_path(self):
-        self.assertTrue(self.parser.file_path == CONFIG.replace("\\", "/"))
+        self.assertTrue(self.parser.file_path == CONFIG)
 
     def test_init_file_path_2(self):
         self.assertTrue(self.parser.arguments is None)

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -137,9 +137,9 @@ class TestCreateRepr(unittest.TestCase):
         det = create_detector(name="Maxipix")
         valid = (
             'Maxipix(name="Maxipix", rootdir=None, datadir=None, savedir=None, '
-            'template_file=None, template_imagefile=None, specfile=None, '
-            'sample_name=None, roi=[0, 516, 0, 516], sum_roi=[0, 516, 0, 516], '
-            'binning=(1, 1, 1), )'
+            "template_file=None, template_imagefile=None, specfile=None, "
+            "sample_name=None, roi=[0, 516, 0, 516], sum_roi=[0, 516, 0, 516], "
+            "binning=(1, 1, 1), )"
         )
         out = util.create_repr(obj=det, cls=Detector)
         self.assertEqual(out, valid)
@@ -148,9 +148,9 @@ class TestCreateRepr(unittest.TestCase):
         setup = Setup(beamline_name="34ID", detector_name="Timepix")
         valid = (
             'Setup(beamline_name="34ID", detector_name="Timepix", '
-            'beam_direction=[1.0, 0.0, 0.0], energy=None, distance=None, '
-            'outofplane_angle=None, inplane_angle=None, tilt_angle=None, '
-            'rocking_angle=None, grazing_angle=None, )'
+            "beam_direction=[1.0, 0.0, 0.0], energy=None, distance=None, "
+            "outofplane_angle=None, inplane_angle=None, tilt_angle=None, "
+            "rocking_angle=None, grazing_angle=None, )"
         )
         out = util.create_repr(obj=setup, cls=Setup)
         self.assertEqual(out, valid)
@@ -161,7 +161,7 @@ class TestCreateRepr(unittest.TestCase):
             util.create_repr(obj=det, cls="Detector")
 
     def test_empty_init(self):
-        valid = 'Empty()'
+        valid = "Empty()"
 
         class Empty:
             """This is an empty class"""
@@ -187,15 +187,15 @@ class TestFormatRepr(unittest.TestCase):
 
     def test_float(self):
         out = util.format_repr("field", 0.4)
-        self.assertEqual(out, 'field=0.4, ')
+        self.assertEqual(out, "field=0.4, ")
 
     def test_none(self):
         out = util.format_repr("field", None)
-        self.assertEqual(out, 'field=None, ')
+        self.assertEqual(out, "field=None, ")
 
     def test_tuple(self):
         out = util.format_repr("field", (1.0, 2.0))
-        self.assertEqual(out, 'field=(1.0, 2.0), ')
+        self.assertEqual(out, "field=(1.0, 2.0), ")
 
 
 class TestInRange(unittest.TestCase):

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -134,7 +134,28 @@ class TestCreateRepr(unittest.TestCase):
 
     def test_detector(self):
         det = create_detector(name="Maxipix")
+        valid = (
+            'Maxipix(name="Maxipix", rootdir=None, datadir=None, savedir=None, '
+            'template_file=None, template_imagefile=None, specfile=None, '
+            'sample_name=None, roi=[0, 516, 0, 516], sum_roi=[0, 516, 0, 516], '
+            'binning=(1, 1, 1), )'
+        )
         out = util.create_repr(obj=det, cls=Detector)
+        self.assertEqual(out, valid)
+
+    def test_not_a_class(self):
+        det = create_detector(name="Maxipix")
+        with self.assertRaises(TypeError):
+            util.create_repr(obj=det, cls="Detector")
+
+    def test_empty_init(self):
+        valid = 'Empty()'
+
+        class Empty:
+            """This is an empty class"""
+
+        out = util.create_repr(obj=Empty(), cls=Empty)
+        self.assertEqual(out, valid)
 
 
 class TestFormatRepr(unittest.TestCase):

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -13,7 +13,8 @@ import unittest
 import bcdi.utils.utilities as util
 from tests.config import run_tests
 
-from bcdi.experiment.detector import create_detector, Detector, Maxipix
+from bcdi.experiment.detector import create_detector, Detector
+from bcdi.experiment.setup import Setup
 
 
 class TestCast(unittest.TestCase):
@@ -141,6 +142,17 @@ class TestCreateRepr(unittest.TestCase):
             'binning=(1, 1, 1), )'
         )
         out = util.create_repr(obj=det, cls=Detector)
+        self.assertEqual(out, valid)
+
+    def test_setup(self):
+        setup = Setup(beamline_name="34ID", detector_name="Timepix")
+        valid = (
+            'Setup(beamline_name="34ID", detector_name="Timepix", '
+            'beam_direction=[1.0, 0.0, 0.0], energy=None, distance=None, '
+            'outofplane_angle=None, inplane_angle=None, tilt_angle=None, '
+            'rocking_angle=None, grazing_angle=None, )'
+        )
+        out = util.create_repr(obj=setup, cls=Setup)
         self.assertEqual(out, valid)
 
     def test_not_a_class(self):
@@ -333,6 +345,37 @@ class TestUnpackArray(unittest.TestCase):
         self.assertEqual(val, 5)
 
 
+class TestNdarrayToList(unittest.TestCase):
+    """
+    Tests on the function utilities.ndarray_to_list.
+
+    def ndarray_to_list(array: np.ndarray) -> List
+    """
+
+    def test_not_an_array(self):
+        with self.assertRaises(TypeError):
+            util.ndarray_to_list(array=2.3)
+
+    def test_none(self):
+        with self.assertRaises(TypeError):
+            util.ndarray_to_list(array=None)
+
+    def test_1d_array_int(self):
+        valid = [1, 2, 3]
+        out = util.ndarray_to_list(array=np.array(valid))
+        self.assertTrue(out == valid)
+
+    def test_1d_array_float(self):
+        valid = [1.12333333333333333333333333, 2.77, 3.5]
+        out = util.ndarray_to_list(array=np.array(valid))
+        self.assertTrue(out == valid)
+
+    def test_2d_array_int(self):
+        valid = [[1, 2, 3], [1.2, 3.333333333, 0]]
+        out = util.ndarray_to_list(array=np.array(valid))
+        self.assertTrue(out == valid)
+
+
 if __name__ == "__main__":
     run_tests(TestInRange)
     run_tests(TestIsFloat)
@@ -341,3 +384,4 @@ if __name__ == "__main__":
     run_tests(TestUnpackArray)
     run_tests(TestCreateRepr)
     run_tests(TestFormatRepr)
+    run_tests(TestNdarrayToList)

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -123,6 +123,34 @@ class TestFindFile(fake_filesystem_unittest.TestCase):
             util.find_file(filename="dum.spec", default_folder=self.valid_path)
 
 
+class TestFormatRepr(unittest.TestCase):
+    """
+    Tests on the function utilities.format_repr.
+
+    def format_repr(field: str, value: Optional[Any]) -> str
+    """
+
+    def test_field_undefined(self):
+        with self.assertRaises(TypeError):
+            util.format_repr(None, "test")
+
+    def test_str(self):
+        out = util.format_repr("field", "test")
+        self.assertEqual(out, 'field="test", ')
+
+    def test_float(self):
+        out = util.format_repr("field", 0.4)
+        self.assertEqual(out, 'field=0.4, ')
+
+    def test_none(self):
+        out = util.format_repr("field", None)
+        self.assertEqual(out, 'field=None, ')
+
+    def test_tuple(self):
+        out = util.format_repr("field", (1.0, 2.0))
+        self.assertEqual(out, 'field=(1.0, 2.0), ')
+
+
 class TestInRange(unittest.TestCase):
     """Tests on the function utilities.in_range."""
 
@@ -276,3 +304,4 @@ if __name__ == "__main__":
     run_tests(TestFindFile)
     run_tests(TestGaussianWindow)
     run_tests(TestUnpackArray)
+    run_tests(TestFormatRepr)

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -15,6 +15,7 @@ from tests.config import run_tests
 
 from bcdi.experiment.detector import create_detector, Detector
 from bcdi.experiment.setup import Setup
+from bcdi.utils.io_helper import ContextFile
 
 
 class TestCast(unittest.TestCase):
@@ -126,12 +127,31 @@ class TestFindFile(fake_filesystem_unittest.TestCase):
             util.find_file(filename="dum.spec", default_folder=self.valid_path)
 
 
-class TestCreateRepr(unittest.TestCase):
+class TestCreateRepr(fake_filesystem_unittest.TestCase):
     """
     Tests on the function utilities.create_repr.
 
     def create_repr(obj: type) -> str
     """
+
+    def setUp(self):
+        self.setUpPyfakefs()
+        self.valid_path = "/gpfs/bcdi/data/"
+        self.filename = "dummy.spec"
+        os.makedirs(self.valid_path)
+        with open(self.valid_path + self.filename, "w") as f:
+            f.write("dummy")
+
+    def test_contextfile(self):
+        ctx = ContextFile(filename=self.valid_path + self.filename, open_func=open)
+        valid = (
+            'ContextFile(filename="/gpfs/bcdi/data/dummy.spec", '
+            'open_func=pyfakefs.fake_filesystem.open, scan_number=None, mode="r", '
+            'encoding="utf-8", longname=None, shortname=None, directory=None, )'
+        )
+        out = util.create_repr(obj=ctx, cls=ContextFile)
+        print(out)
+        self.assertEqual(out, valid)
 
     def test_detector(self):
         det = create_detector(name="Maxipix")
@@ -184,6 +204,10 @@ class TestFormatRepr(unittest.TestCase):
     def test_str(self):
         out = util.format_repr("field", "test")
         self.assertEqual(out, 'field="test", ')
+
+    def test_str_quote_mark_false(self):
+        out = util.format_repr("field", "test", quote_mark=False)
+        self.assertEqual(out, "field=test, ")
 
     def test_float(self):
         out = util.format_repr("field", 0.4)

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -13,6 +13,8 @@ import unittest
 import bcdi.utils.utilities as util
 from tests.config import run_tests
 
+from bcdi.experiment.detector import create_detector, Detector, Maxipix
+
 
 class TestCast(unittest.TestCase):
     """
@@ -121,6 +123,18 @@ class TestFindFile(fake_filesystem_unittest.TestCase):
     def test_filename_file_name_inexisting_default_dir_existing(self):
         with self.assertRaises(ValueError):
             util.find_file(filename="dum.spec", default_folder=self.valid_path)
+
+
+class TestCreateRepr(unittest.TestCase):
+    """
+    Tests on the function utilities.create_repr.
+
+    def create_repr(obj: type) -> str
+    """
+
+    def test_detector(self):
+        det = create_detector(name="Maxipix")
+        out = util.create_repr(obj=det, cls=Detector)
 
 
 class TestFormatRepr(unittest.TestCase):
@@ -304,4 +318,5 @@ if __name__ == "__main__":
     run_tests(TestFindFile)
     run_tests(TestGaussianWindow)
     run_tests(TestUnpackArray)
+    run_tests(TestCreateRepr)
     run_tests(TestFormatRepr)


### PR DESCRIPTION
Implement correctly the `__repr__` method in classes such that eval(repr(instance)) is itself an instance of the class.

- Implement generic functions `utilities.create_repr` and `utilities.format_repr` 
- Use the generic functions in all `__repr__` methods
- Add corresponding unit tests
- As a side effect, the parameter `beamline` from Setup had to be renamed `beamline_name`, because it was overlapping with the attribute beamline which is a Beamline instance

Fixes #207 

Tests pass, also checked with the example dataset.

## Type of change

- [X] New feature (breaking change which adds functionality)

## Checklist:

- [X] I have made corresponding changes to the documentation
- [X] I have added corresponding unit tests
- [X] I have run ``doit`` and all tasks have passed
