### PR TITLE
Implement a linecut of the modulus in postprocessing

### DIFF
--- a/.github/workflows/python-package-3.9.yml
+++ b/.github/workflows/python-package-3.9.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: /opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages
-        key: ${{ runner.os }}-pip-v2-${{ hashFiles('**/requirements.txt') }}
+        key: ${{ runner.os }}-pip-v1-${{ hashFiles('**/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
 

--- a/.github/workflows/python-package-3.9.yml
+++ b/.github/workflows/python-package-3.9.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: /opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        key: ${{ runner.os }}-pip-v2-${{ hashFiles('**/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
 

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -2498,14 +2498,14 @@ class LoaderP10(Loader):
                 ):  # template for positioners: 'mu = 0.0\n'
                     energy = float(words[2])
 
-                if index_om is not None and util.is_float(words[0]):
+                if index_om is not None and valid.is_float(words[0]):
                     if index_phi is not None:
                         raise NotImplementedError(
                             "d2scan with om and phi not supported"
                         )
                     # reading data and index_om is defined (outofplane case)
                     rocking_positions.append(float(words[index_om]))
-                if index_phi is not None and util.is_float(words[0]):
+                if index_phi is not None and valid.is_float(words[0]):
                     if index_om is not None:
                         raise NotImplementedError(
                             "d2scan with om and phi not supported"
@@ -2580,7 +2580,7 @@ class LoaderP10(Loader):
                 # device_name scanned, template = ' Col 0 motor_name DOUBLE\n'
                 index_device = int(words[1]) - 1  # python index starts at 0
 
-            if index_device is not None and util.is_float(words[0]):
+            if index_device is not None and valid.is_float(words[0]):
                 # we are reading data and index_motor is defined
                 device_values.append(float(words[index_device]))
 
@@ -2638,7 +2638,7 @@ class LoaderP10SAXS(LoaderP10):
                     # template = ' Col 0 sprz DOUBLE\n'
                     index_phi = int(words[1]) - 1  # python index starts at 0
                     print(words, "  Index Phi=", index_phi)
-                if index_phi is not None and util.is_float(words[0]):
+                if index_phi is not None and valid.is_float(words[0]):
                     # we are reading data and index_phi is defined
                     positions.append(float(words[index_phi]))
 

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -2016,8 +2016,6 @@ class Loader34ID(Loader):
                     ccdraw = util.image_to_ndarray(
                         filename=ccdfiletmp % i,
                         convert_grey=True,
-                        cmap="gray",
-                        debug=False,
                     )
                 except TypeError:
                     raise ValueError(

--- a/bcdi/graph/colormap.py
+++ b/bcdi/graph/colormap.py
@@ -57,7 +57,7 @@ class ColormapFactory:
     def bad_color(self, val: str):
         if not isinstance(val, str):
             raise TypeError(f"bad_color should be a str, got {type(val)})")
-        if not is_float(val) or not (0.0 <= float(val) <= 1.0):
+        if not is_float(val) or not 0.0 <= float(val) <= 1.0:
             raise ValueError("float(bad_color) should be a number between 0 and 1")
         self._bad_color = val
 
@@ -75,6 +75,7 @@ class ColormapFactory:
         self._colormap = val
 
     def generate_cmap(self):
+        """Factory for the colormap."""
         if self.colormap == "turbo":
             self.cmap = ListedColormap(turbo_colormap_data)
         elif self.colormap == "custom":

--- a/bcdi/graph/colormap.py
+++ b/bcdi/graph/colormap.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+
+# BCDI: tools for pre(post)-processing Bragg coherent X-ray diffraction imaging data
+#   (c) 07/2017-06/2019 : CNRS UMR 7344 IM2NP
+#   (c) 07/2019-05/2021 : DESY PHOTON SCIENCE
+#       authors:
+#         Jerome Carnis, carnis_jerome@yahoo.fr
+
+from matplotlib.colors import Colormap, LinearSegmentedColormap, ListedColormap
+from typing import Optional
+
+from bcdi.graph.turbo_colormap import turbo_colormap_data
+from bcdi.utils.validation import is_float
+
+custom_colormap_data = {
+    "red": (
+        (0.0, 1.0, 1.0),
+        (0.11, 0.0, 0.0),
+        (0.36, 0.0, 0.0),
+        (0.62, 1.0, 1.0),
+        (0.87, 1.0, 1.0),
+        (1.0, 0.0, 0.0),
+    ),
+    "green": (
+        (0.0, 1.0, 1.0),
+        (0.11, 0.0, 0.0),
+        (0.36, 1.0, 1.0),
+        (0.62, 1.0, 1.0),
+        (0.87, 0.0, 0.0),
+        (1.0, 0.0, 0.0),
+    ),
+    "blue": (
+        (0.0, 1.0, 1.0),
+        (0.11, 1.0, 1.0),
+        (0.36, 1.0, 1.0),
+        (0.62, 0.0, 0.0),
+        (0.87, 0.0, 0.0),
+        (1.0, 0.0, 0.0),
+    ),
+}
+
+
+class ColormapFactory:
+    """
+    Class to define a colormap.
+
+    :param colormap: a colormap string. Available choices: 'turbo',
+     'custom'
+    :param bad_color: a string which defines the grey level for nan pixels, e.g. '0.7'
+    """
+
+    valid_colormaps = ["turbo", "custom"]
+
+    def __init__(self, bad_color="0.7", colormap="turbo"):
+        self.bad_color = bad_color
+        self.colormap = colormap
+        self.cmap: Optional[Colormap] = None
+
+    @property
+    def bad_color(self):
+        """Color for masked values."""
+        return self._bad_color
+
+    @bad_color.setter
+    def bad_color(self, val: str):
+        if not isinstance(val, str):
+            raise TypeError(f"bad_color should be a str, got {type(val)})")
+        if not is_float(val) or not (0.0 <= float(val) <= 1.0):
+            raise ValueError("float(bad_color) should be a number between 0 and 1")
+        self._bad_color = val
+
+    @property
+    def colormap(self):
+        """Name of the colormap."""
+        return self._colormap
+
+    @colormap.setter
+    def colormap(self, val: str):
+        if not isinstance(val, str):
+            raise TypeError(f"colormap should be a str, got {type(val)})")
+        if val not in self.valid_colormaps:
+            raise NotImplementedError(f"colormap {val} not implemented")
+        self._colormap = val
+
+    def generate_cmap(self):
+        if self.colormap == "turbo":
+            self.cmap = ListedColormap(turbo_colormap_data)
+        elif self.colormap == "custom":
+            self.cmap = LinearSegmentedColormap(
+                "my_colormap", custom_colormap_data, 256
+            )
+        else:
+            raise NotImplementedError(f"colormap {self.colormap} not implemented")
+        self.cmap.set_bad(color=self.bad_color)

--- a/bcdi/graph/colormap.py
+++ b/bcdi/graph/colormap.py
@@ -85,3 +85,4 @@ class ColormapFactory:
         else:
             raise NotImplementedError(f"colormap {self.colormap} not implemented")
         self.cmap.set_bad(color=self.bad_color)
+        return self.cmap

--- a/bcdi/graph/colormap.py
+++ b/bcdi/graph/colormap.py
@@ -5,38 +5,30 @@
 #   (c) 07/2019-05/2021 : DESY PHOTON SCIENCE
 #       authors:
 #         Jerome Carnis, carnis_jerome@yahoo.fr
+"""
+Implementation of the colormap class.
 
+New colormaps can be added to the method generate_colormap.
+"""
 from matplotlib.colors import Colormap, LinearSegmentedColormap, ListedColormap
 from typing import Optional
 
 from bcdi.graph.turbo_colormap import turbo_colormap_data
 from bcdi.utils.validation import is_float
 
+data_table = (
+    (0.0, 1.0, 1.0),
+    (0.11, 0.0, 0.0),
+    (0.36, 0.0, 0.0),
+    (0.62, 1.0, 1.0),
+    (0.87, 1.0, 1.0),
+    (1.0, 0.0, 0.0),
+)
+
 custom_colormap_data = {
-    "red": (
-        (0.0, 1.0, 1.0),
-        (0.11, 0.0, 0.0),
-        (0.36, 0.0, 0.0),
-        (0.62, 1.0, 1.0),
-        (0.87, 1.0, 1.0),
-        (1.0, 0.0, 0.0),
-    ),
-    "green": (
-        (0.0, 1.0, 1.0),
-        (0.11, 0.0, 0.0),
-        (0.36, 1.0, 1.0),
-        (0.62, 1.0, 1.0),
-        (0.87, 0.0, 0.0),
-        (1.0, 0.0, 0.0),
-    ),
-    "blue": (
-        (0.0, 1.0, 1.0),
-        (0.11, 1.0, 1.0),
-        (0.36, 1.0, 1.0),
-        (0.62, 0.0, 0.0),
-        (0.87, 0.0, 0.0),
-        (1.0, 0.0, 0.0),
-    ),
+    "red": data_table,
+    "green": data_table,
+    "blue": data_table,
 }
 
 

--- a/bcdi/graph/graph_utils.py
+++ b/bcdi/graph/graph_utils.py
@@ -26,7 +26,7 @@ from scipy.interpolate import griddata
 from scipy.ndimage import map_coordinates
 from scipy.signal import find_peaks
 import sys
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from bcdi.graph.colormap import ColormapFactory
 from bcdi.utils import utilities as util
@@ -1007,7 +1007,7 @@ def define_labels(reciprocal_space, is_orthogonal, sum_frames, labels=None):
 
 def fit_linecut(
     array: np.ndarray,
-    indices: Optional[List[Tuple[int, ...]]] = None,
+    indices: Optional[List[List[Tuple[int, int]]]] = None,
     fit_derivative: bool = False,
     support_threshold: float = 0.25,
     voxel_sizes: Optional[List[float]] = None,
@@ -1019,8 +1019,8 @@ def fit_linecut(
 
     :param array: a 2D or 3D array, typically the modulus of a real space object after
      phase retrieval
-    :param indices: a list of tuples (start, stop), one tuple for each dimension of the
-     array
+    :param indices: a list of ndim lists of ndim tuples (start, stop), ndim being the
+     number of dimensions of the array (one list per linecut)
     :param fit_derivative: True to fit the gradient of the linecut with a gaussian line
      shape
     :param support_threshold: float, threshold used to define the support, for the
@@ -1062,7 +1062,7 @@ def fit_linecut(
         raise TypeError(f"fit_derivative should be a bool, got {type(fit_derivative)}")
 
     # generate a linecut for each dimension of the array
-    result = {}
+    result: Dict[str, Any] = {}
     for idx in range(ndim):
         result[f"dimension_{idx}"] = {}
         # generate the linecut
@@ -1101,14 +1101,12 @@ def fit_linecut(
                 fit_params.add("sig_%i" % peak_id, value=2, min=0.1, max=10)
 
             # fit the data
-            combined_xaxis = np.asarray(combined_xaxis)
-            combined_data = np.asarray(combined_data)
             fit_result = minimize(
                 util.objective_lmfit,
                 fit_params,
                 args=(
-                    combined_xaxis,
-                    combined_data,
+                    np.asarray(combined_xaxis),
+                    np.asarray(combined_data),
                     "gaussian",
                 ),
             )

--- a/bcdi/graph/graph_utils.py
+++ b/bcdi/graph/graph_utils.py
@@ -1953,19 +1953,21 @@ def plot_linecut(
     """
     Plot linecuts and optionally corresponding fits.
 
-    linecuts = {
-        'dimension_0': {
-            'linecut': np.ndarray (2, M),
-            'derivative_0': np.ndarray (2, N),
-            'derivative_1': np.ndarray (2, O),
-            'fit_0': np.ndarray (2, P),
-            'fit_1': np.ndarray (2, P),
-            'param_0': {'amp': float, 'sig': float, 'cen': float},
-            'param_1': {'amp': float, 'sig': float, 'cen': float},
-        },
-        'dimension_1': {...}
-        ...
-    }
+    Expected structure for linecuts::
+
+        linecuts = {
+            'dimension_0': {
+                'linecut': np.ndarray (2, M),
+                'derivative_0': np.ndarray (2, N),
+                'derivative_1': np.ndarray (2, O),
+                'fit_0': np.ndarray (2, P),
+                'fit_1': np.ndarray (2, P),
+                'param_0': {'amp': float, 'sig': float, 'cen': float},
+                'param_1': {'amp': float, 'sig': float, 'cen': float},
+            },
+            'dimension_1': {...}
+            ...
+        }
 
     :param linecuts: a dictionary containing cuts, with keys 'dim_0', 'dim_1', ...
     :param filename: str, the figure will be saved there

--- a/bcdi/graph/graph_utils.py
+++ b/bcdi/graph/graph_utils.py
@@ -1040,7 +1040,7 @@ def fit_linecut(
 
         for idx, shp in enumerate(shape):
             default = [(val // 2, val // 2) for val in shape]
-            default[idx] = (0, shp)
+            default[idx] = (0, shp - 1)
             indices.append(default)
 
     valid.valid_container(
@@ -1068,7 +1068,7 @@ def fit_linecut(
         # generate the linecut
         cut = linecut(array=array, indices=indices[idx])
         result[f"dimension_{idx}"][f"linecut"] = np.vstack(
-            (np.arange(indices[idx][idx][0], indices[idx][idx][1]), cut)
+            (np.arange(indices[idx][idx][0], indices[idx][idx][1] + 1), cut)
         )
 
         # optionally fit the derivative at the edge of the support

--- a/bcdi/graph/graph_utils.py
+++ b/bcdi/graph/graph_utils.py
@@ -1067,7 +1067,7 @@ def fit_linecut(
         result[f"dimension_{idx}"] = {}
         # generate the linecut
         cut = linecut(array=array, indices=indices[idx])
-        result[f"dimension_{idx}"][f"linecut"] = np.vstack(
+        result[f"dimension_{idx}"]["linecut"] = np.vstack(
             (np.arange(indices[idx][idx][0], indices[idx][idx][1] + 1), cut)
         )
 
@@ -1077,7 +1077,7 @@ def fit_linecut(
             support[array > support_threshold] = 1
             support_cut = linecut(array=support, indices=indices[idx])
 
-            peaks, metadata = find_peaks(
+            peaks, _ = find_peaks(
                 abs(np.gradient(support_cut)), height=0.1, distance=10, width=1
             )
             dcut = abs(np.gradient(cut))
@@ -2054,7 +2054,7 @@ def plot_linecut(
     plt.ioff()
 
     if filename:
-        base, ext = os.path.splitext(filename)
+        base, _ = os.path.splitext(filename)
         fig.savefig(base + "_fits.png")
 
 

--- a/bcdi/graph/graph_utils.py
+++ b/bcdi/graph/graph_utils.py
@@ -18,7 +18,6 @@ from matplotlib.path import Path
 import matplotlib.patches as patches
 import matplotlib.ticker as ticker
 import matplotlib.colors as colors
-from matplotlib.colors import LinearSegmentedColormap
 from operator import itemgetter
 import pathlib
 from scipy.interpolate import griddata
@@ -26,57 +25,10 @@ from scipy.ndimage import map_coordinates
 import sys
 from typing import Optional, Tuple
 
-from bcdi.graph.turbo_colormap import turbo_colormap as my_cmap
+from bcdi.graph.colormap import ColormapFactory
 from bcdi.utils import validation as valid
 
-# define a colormap
-color_dict = {
-    "red": (
-        (0.0, 1.0, 1.0),
-        (0.11, 0.0, 0.0),
-        (0.36, 0.0, 0.0),
-        (0.62, 1.0, 1.0),
-        (0.87, 1.0, 1.0),
-        (1.0, 0.0, 0.0),
-    ),
-    "green": (
-        (0.0, 1.0, 1.0),
-        (0.11, 0.0, 0.0),
-        (0.36, 1.0, 1.0),
-        (0.62, 1.0, 1.0),
-        (0.87, 0.0, 0.0),
-        (1.0, 0.0, 0.0),
-    ),
-    "blue": (
-        (0.0, 1.0, 1.0),
-        (0.11, 1.0, 1.0),
-        (0.36, 1.0, 1.0),
-        (0.62, 0.0, 0.0),
-        (0.87, 0.0, 0.0),
-        (1.0, 0.0, 0.0),
-    ),
-}
-custom_cmap = LinearSegmentedColormap("my_colormap", color_dict, 256)
-custom_cmap.set_bad(color="0.7")
-
-
-class Colormap:
-    """
-    Class to define a colormap.
-
-    :param colormap: a colormap string. Available choices at the moment: 'default'
-    :param bad_color: a string which defines the grey level for nan pixels, e.g. '0.7'
-    """
-
-    def __init__(self, bad_color="0.7", colormap="default"):
-        if colormap == "default":
-            cdict = color_dict
-        else:
-            raise ValueError('Only available colormaps: "default"')
-        self.cdict = cdict
-        self.bad_color = bad_color
-        self.cmap = LinearSegmentedColormap("my_colormap", self.cdict, 256)
-        self.cmap.set_bad(color=self.bad_color)
+default_cmap = ColormapFactory().generate_cmap()
 
 
 def close_event(event):
@@ -126,7 +78,7 @@ def combined_plots(
     tuple_title,
     tuple_scale,
     tuple_sum_axis=None,
-    cmap=my_cmap,
+    cmap=default_cmap,
     tick_direction="out",
     tick_width=1,
     tick_length=4,
@@ -577,7 +529,7 @@ def contour_slices(
     width_y=None,
     width_x=None,
     plot_colorbar=False,
-    cmap=my_cmap,
+    cmap=default_cmap,
     title="",
     scale="linear",
     is_orthogonal=False,
@@ -763,7 +715,7 @@ def contour_stereographic(
     plot_planes=True,
     contour_range=None,
     max_angle=95,
-    cmap=my_cmap,
+    cmap=default_cmap,
     uv_labels=("", ""),
     hide_axis=False,
     scale="linear",
@@ -812,7 +764,7 @@ def contour_stereographic(
             euclidian_v,
             s=6,
             c=color2,
-            cmap=my_cmap,
+            cmap=default_cmap,
             norm=colors.LogNorm(
                 vmin=max(color2[~np.isnan(color2)].min(), 1),
                 vmax=color2[~np.isnan(color2)].max(),
@@ -1058,7 +1010,7 @@ def imshow_plot(
     plot_colorbar=False,
     vmin=np.nan,
     vmax=np.nan,
-    cmap=my_cmap,
+    cmap=default_cmap,
     title="",
     labels=None,
     scale="linear",
@@ -1391,7 +1343,16 @@ def linecut(
 
 
 def loop_thru_scan(
-    key, array, figure, scale, dim, idx, savedir, cmap=my_cmap, vmin=None, vmax=None
+    key,
+    array,
+    figure,
+    scale,
+    dim,
+    idx,
+    savedir,
+    cmap=default_cmap,
+    vmin=None,
+    vmax=None,
 ):
     """
     Update the plot while removing the parasitic diffraction intensity in 3D dataset.
@@ -1544,7 +1505,7 @@ def multislices_plot(
     width_y=None,
     width_x=None,
     plot_colorbar=False,
-    cmap=my_cmap,
+    cmap=default_cmap,
     title="",
     scale="linear",
     vmin=np.nan,
@@ -2490,7 +2451,7 @@ def scatter_stereographic(
     color,
     title="",
     max_angle=95,
-    cmap=my_cmap,
+    cmap=default_cmap,
     uv_labels=("", ""),
 ):
     """
@@ -2801,7 +2762,7 @@ def update_aliens_combined(
     frame_index,
     vmax,
     vmin=0,
-    cmap=my_cmap,
+    cmap=default_cmap,
     invert_yaxis=False,
 ):
     """
@@ -3623,7 +3584,7 @@ def update_mask_combined(
     info_text,
     vmax,
     vmin=0,
-    cmap=my_cmap,
+    cmap=default_cmap,
     invert_yaxis=False,
 ):
     """

--- a/bcdi/graph/graph_utils.py
+++ b/bcdi/graph/graph_utils.py
@@ -24,7 +24,7 @@ import pathlib
 from scipy.interpolate import griddata
 from scipy.ndimage import map_coordinates
 import sys
-from typing import Optional
+from typing import Optional, Tuple
 
 from bcdi.graph.turbo_colormap import turbo_colormap as my_cmap
 from bcdi.utils import validation as valid
@@ -1284,7 +1284,13 @@ def imshow_plot(
     return fig, axis, plot
 
 
-def linecut(array, start_indices, stop_indices, interp_order=3, debugging=False):
+def linecut(
+    array: np.ndarray,
+    start_indices: Tuple[int, ...],
+    stop_indices: Tuple[int, ...],
+    interp_order: int = 3,
+    debugging: bool = False,
+) -> np.ndarray:
     """
     Linecut through a 2D or 3D array.
 

--- a/bcdi/graph/turbo_colormap.py
+++ b/bcdi/graph/turbo_colormap.py
@@ -6,7 +6,6 @@
 
 """Implementation of the turbo colormap."""
 
-from matplotlib.colors import ListedColormap
 from typing import List
 
 turbo_colormap_data = [
@@ -268,8 +267,6 @@ turbo_colormap_data = [
     [0.47960, 0.01583, 0.01055],
 ]
 
-turbo_colormap = ListedColormap(turbo_colormap_data)
-# turbo_colormap.set_bad(color="0.7")
 
 # The look-up table contains 256 entries. Each entry is a floating point sRGB triplet.
 # To use it with matplotlib, pass cmap=ListedColormap(turbo_colormap_data) as an arg

--- a/bcdi/postprocessing/facet_recognition.py
+++ b/bcdi/postprocessing/facet_recognition.py
@@ -20,12 +20,12 @@ import numpy as np
 from matplotlib import pyplot as plt
 from matplotlib import patches
 import sys
+from bcdi.graph.colormap import ColormapFactory
 from bcdi.graph import graph_utils as gu
 from bcdi.utils import utilities as util
 from bcdi.utils import validation as valid
 
-colormap = gu.Colormap()
-default_cmap = colormap.cmap
+default_cmap = ColormapFactory().generate_cmap()
 
 
 def calc_stereoproj_facet(projection_axis, vectors, radius_mean, stereo_center):

--- a/bcdi/postprocessing/facet_recognition.py
+++ b/bcdi/postprocessing/facet_recognition.py
@@ -14,7 +14,7 @@ from scipy.interpolate import griddata
 from scipy import stats
 from scipy import ndimage
 from skimage.feature import corner_peaks
-from skimage.morphology import watershed
+from skimage.segmentation import watershed
 from numbers import Real
 import numpy as np
 from matplotlib import pyplot as plt

--- a/bcdi/postprocessing/postprocessing_runner.py
+++ b/bcdi/postprocessing/postprocessing_runner.py
@@ -207,10 +207,10 @@ def run(prm):
             if prm.get("data_dir") is None
             else setup.detector.datadir,
             filetypes=[
+                ("HDF5", "*.h5"),
+                ("CXI", "*.cxi"),
                 ("NPZ", "*.npz"),
                 ("NPY", "*.npy"),
-                ("CXI", "*.cxi"),
-                ("HDF5", "*.h5"),
             ],
         )
 
@@ -1023,6 +1023,15 @@ def run(prm):
     volume = temp_amp.sum() * reduce(lambda x, y: x * y, voxel_size)  # in nm3
     del temp_amp
     gc.collect()
+
+    ################################
+    # plot linecuts of the results #
+    ################################
+    _ = gu.fit_linecut(
+        array=amp,
+        fit_derivative=True,
+        filename=setup.detector.savedir + "linecut_amp.png",
+    )
 
     ##############################
     # plot slices of the results #

--- a/bcdi/postprocessing/postprocessing_runner.py
+++ b/bcdi/postprocessing/postprocessing_runner.py
@@ -1027,10 +1027,12 @@ def run(prm):
     ################################
     # plot linecuts of the results #
     ################################
-    _ = gu.fit_linecut(
+    gu.fit_linecut(
         array=amp,
         fit_derivative=True,
         filename=setup.detector.savedir + "linecut_amp.png",
+        voxel_sizes=voxel_size,
+        label="modulus",
     )
 
     ##############################

--- a/bcdi/postprocessing/postprocessing_runner.py
+++ b/bcdi/postprocessing/postprocessing_runner.py
@@ -23,6 +23,7 @@ import pprint
 import tkinter as tk
 from tkinter import filedialog
 
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 from bcdi.experiment.detector import create_roi
 from bcdi.experiment.setup import Setup
@@ -135,8 +136,7 @@ def run(prm):
         bad_color = "0.7"
     else:
         bad_color = "1.0"  # white background
-    colormap = gu.Colormap(bad_color=bad_color)
-    my_cmap = colormap.cmap
+    my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
 
     #################################
     # define the experimental setup #

--- a/bcdi/preprocessing/preprocessing_runner.py
+++ b/bcdi/preprocessing/preprocessing_runner.py
@@ -26,6 +26,7 @@ from scipy.io import savemat
 import tkinter as tk
 from tkinter import filedialog
 import xrayutilities as xu
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 from bcdi.experiment.detector import create_roi
 from bcdi.experiment.setup import Setup
@@ -314,8 +315,7 @@ def run(prm):
     ###################
     # define colormap #
     ###################
-    colormap = gu.Colormap()
-    my_cmap = colormap.cmap
+    my_cmap = ColormapFactory().generate_cmap()
     plt.rcParams["keymap.fullscreen"] = [""]
 
     ####################

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -934,12 +934,6 @@ def image_to_ndarray(filename, convert_grey=True, cmap=None, debug=False):
     if array.ndim == 3 and convert_grey:
         print("converting image to gray")
         array = rgb2gray(array)
-
-    if debug:
-        print(f"Image shape after conversion to ndarray: {array.shape}")
-        gu.imshow_plot(
-            array, sum_axis=2, plot_colorbar=True, cmap=cmap, reciprocal_space=False
-        )
     return array
 
 
@@ -991,22 +985,6 @@ def in_range(point, extent):
         ):
             return True
     return False
-
-
-def is_float(string):
-    """
-    Return True is the string represents a number.
-
-    :param string: the string to be checked
-    :return: True of False
-    """
-    if not isinstance(string, str):
-        raise TypeError("the input should be a string")
-    try:
-        float(string)
-        return True
-    except ValueError:
-        return False
 
 
 def linecut(array, point, direction, direction_basis="voxel", voxel_size=1):

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -988,8 +988,6 @@ def linecut(array, point, direction, direction_basis="voxel", voxel_size=1):
     """
     Calculate iteratively a linecut through an array without interpolation.
 
-
-
     :param array: 2D or 3D numpy array from which the linecut will be extracted
     :param point: tuple of three integral indices, point by which the linecut pass.
     :param direction: list of 2 (for 2D) or 3 (for 3D) vector components,

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -912,7 +912,7 @@ def higher_primes(number, maxprime=13, required_dividers=(4,)):
     return number
 
 
-def image_to_ndarray(filename, convert_grey=True, cmap=None, debug=False):
+def image_to_ndarray(filename, convert_grey=True):
     """
     Convert an image to a numpy array using pillow.
 
@@ -921,13 +921,8 @@ def image_to_ndarray(filename, convert_grey=True, cmap=None, debug=False):
     :param filename: absolute path of the image to open
     :param convert_grey: if True and the number of layers is 3, it will be converted
      to a single layer of grey
-    :param cmap: colormap for the plots
-    :param debug: True to see plots
     :return:
     """
-    if cmap is None:
-        cmap = gu.Colormap(bad_color="1.0").cmap
-
     im = Image.open(filename)
 
     array = np.asarray(im)

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -24,8 +24,9 @@ from scipy.optimize import curve_fit
 from scipy.special import erf
 from scipy.stats import multivariate_normal
 from typing import Any, List, Optional, Union, Sequence
-from ..graph import graph_utils as gu
-from ..utils import validation as valid
+
+from bcdi.graph import graph_utils as gu
+from bcdi.utils import validation as valid
 
 
 class CustomEncoder(json.JSONEncoder):

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -482,16 +482,19 @@ def decode_json(dct):
     return dct
 
 
-def dos2unix(input_file, output_file):
+def dos2unix(input_file: str, savedir: str) -> None:
     """
     Convert DOS linefeeds (crlf) to UNIX (lf).
 
     :param input_file: the original filename (absolute path)
-    :param output_file: the output filename (absolute path) where to save
+    :param savedir: path of the directory where to save
     """
+    filename = os.path.splitext(os.path.basename(input_file))[0]
+    if not input_file.endswith(".txt"):
+        raise ValueError("Expecting a text file as input, e.g. 'alias_dict.txt'")
     with open(input_file, "rb") as infile:
         content = infile.read()
-    with open(output_file, "wb") as output:
+    with open(os.path.join(savedir, f"{filename}_unix.txt"), "wb") as output:
         for row in content.splitlines():
             output.write(row + str.encode("\n"))
 

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -2443,13 +2443,10 @@ def upsample(array: Union[np.ndarray, List], factor: int = 2) -> np.ndarray:
     upsampled_positions = [
         np.linspace(0, val - 1, num=val * factor) for val in array.shape
     ]
-    new_grid = np.meshgrid(*upsampled_positions, indexing="ij")
+    grid = np.meshgrid(*upsampled_positions, indexing="ij")
     new_grid = np.asarray(
         np.concatenate(
-            [
-                new_grid.reshape((1, new_grid.size))
-                for _, new_grid in enumerate(new_grid)
-            ]
+            [new_grid.reshape((1, new_grid.size)) for _, new_grid in enumerate(grid)]
         ).transpose()
     )
     # interpolate array #

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -734,26 +734,26 @@ def function_lmfit(params, x_axis, distribution, iterator=0):
     :return: the gaussian function calculated at x_axis positions
     """
     if distribution == "gaussian":
-        amp = params["amp_%i" % (iterator + 1)].value
-        cen = params["cen_%i" % (iterator + 1)].value
-        sig = params["sig_%i" % (iterator + 1)].value
+        amp = params["amp_%i" % iterator].value
+        cen = params["cen_%i" % iterator].value
+        sig = params["sig_%i" % iterator].value
         return gaussian(x_axis=x_axis, amp=amp, cen=cen, sig=sig)
     if distribution == "skewed_gaussian":
-        amp = params["amp_%i" % (iterator + 1)].value
-        loc = params["loc_%i" % (iterator + 1)].value
-        sig = params["sig_%i" % (iterator + 1)].value
-        alpha = params["alpha_%i" % (iterator + 1)].value
+        amp = params["amp_%i" % iterator].value
+        loc = params["loc_%i" % iterator].value
+        sig = params["sig_%i" % iterator].value
+        alpha = params["alpha_%i" % iterator].value
         return skewed_gaussian(x_axis=x_axis, amp=amp, loc=loc, sig=sig, alpha=alpha)
     if distribution == "lorentzian":
-        amp = params["amp_%i" % (iterator + 1)].value
-        cen = params["cen_%i" % (iterator + 1)].value
-        sig = params["sig_%i" % (iterator + 1)].value
+        amp = params["amp_%i" % iterator].value
+        cen = params["cen_%i" % iterator].value
+        sig = params["sig_%i" % iterator].value
         return lorentzian(x_axis=x_axis, amp=amp, cen=cen, sig=sig)
     if distribution == "pseudovoigt":
-        amp = params["amp_%i" % (iterator + 1)].value
-        cen = params["cen_%i" % (iterator + 1)].value
-        sig = params["sig_%i" % (iterator + 1)].value
-        ratio = params["ratio_%i" % (iterator + 1)].value
+        amp = params["amp_%i" % iterator].value
+        cen = params["cen_%i" % iterator].value
+        sig = params["sig_%i" % iterator].value
+        ratio = params["ratio_%i" % iterator].value
         return pseudovoigt(x_axis, amp=amp, cen=cen, sig=sig, ratio=ratio)
     raise ValueError(distribution + " not implemented")
 
@@ -2445,7 +2445,6 @@ def upsample(
         ),
         order=interp_order,
     )
-    print("\n", array, "\n", result)
     return np.asarray(result)
 
 

--- a/bcdi/utils/validation.py
+++ b/bcdi/utils/validation.py
@@ -11,6 +11,22 @@ from numbers import Real, Number
 import numpy as np
 
 
+def is_float(string):
+    """
+    Return True is the string represents a number.
+
+    :param string: the string to be checked
+    :return: True of False
+    """
+    if not isinstance(string, str):
+        raise TypeError("the input should be a string")
+    try:
+        float(string)
+        return True
+    except ValueError:
+        return False
+
+
 def valid_container(
     obj,
     container_types,

--- a/doc/scripts/index.rst
+++ b/doc/scripts/index.rst
@@ -453,14 +453,6 @@ bcdi_simu_signe_phase.py
 
 Utilities
 ---------
-   
-bcdi_apodize.py
-^^^^^^^^^^^^^^^
-
-.. literalinclude:: ../../scripts/utils/bcdi_apodize.py
-   :start-after: helptext
-   :end-before: """
-   :language: rst
 
 bcdi_angular_avg_3Dto1D.py
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/mypy.ini
+++ b/mypy.ini
@@ -7,6 +7,8 @@ warn_unused_configs = True
 plugins = numpy.typing.mypy_plugin
 
 # Per-module options
+[mypy-lmfit]
+ignore_missing_imports = True
 
 [mypy-mpl_toolkits.*]
 ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-black==22.3.0
+black==22.2.0
 coverage==6.3.2
 doit==0.34.2
 fabio==0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-black==22.2.0
+black==22.3.0
 coverage==6.3.2
 doit==0.34.2
 fabio==0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-black==22.1.0
+black==22.3.0
 coverage==6.3.2
 doit==0.34.2
 fabio==0.13.0

--- a/scripts/algorithms/bcdi_blurring_function.py
+++ b/scripts/algorithms/bcdi_blurring_function.py
@@ -306,14 +306,14 @@ for key in linecuts_dict.keys():  # order is maintained in OrderedDict
 # create nb_fit sets of parameters, one per data set
 fit_params = Parameters()
 for idx in range(3):  # 3 linecuts in orthogonal directions to be fitted by a gaussian
-    fit_params.add("amp_%i" % (idx + 1), value=1, min=0.1, max=100)
+    fit_params.add("amp_%i" % idx, value=1, min=0.1, max=100)
     fit_params.add(
-        "cen_%i" % (idx + 1),
+        "cen_%i" % idx,
         value=linecuts[idx, :].mean(),
         min=linecuts[idx, :].min(),
         max=linecuts[idx, :].max(),
     )
-    fit_params.add("sig_%i" % (idx + 1), value=5, min=0.1, max=100)
+    fit_params.add("sig_%i" % idx, value=5, min=0.1, max=100)
 
 # run the global fit to all the data sets
 minimization = minimize(

--- a/scripts/graph/bcdi_3D_object_movie.py
+++ b/scripts/graph/bcdi_3D_object_movie.py
@@ -15,6 +15,7 @@ import tkinter as tk
 import sys
 from tkinter import filedialog
 
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.utils.utilities as util
 
@@ -57,8 +58,7 @@ output_format = "gif"  # 'gif', 'mp4'
 ###################
 # define colormap #
 ###################
-colormap = gu.Colormap()
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory().generate_cmap()
 
 ###############
 # load FFMpeg #

--- a/scripts/graph/bcdi_linecut_diffpattern.py
+++ b/scripts/graph/bcdi_linecut_diffpattern.py
@@ -124,10 +124,8 @@ def on_click(event):
         print(f"starting_point = {starting_point}, endpoint = {endpoint}")
         cut = gu.linecut(
             diff_pattern,
-            start_indices=starting_point,
-            stop_indices=endpoint,
+            indices=list(zip(starting_point, endpoint)),
             interp_order=1,
-            debugging=False,
         )
         if qx.ndim == 1:
             d_q = np.sqrt(
@@ -365,7 +363,6 @@ cut = gu.linecut(
     diff_pattern,
     indices=list(zip(starting_point, endpoint)),
     interp_order=1,
-    debugging=False,
 )
 if qx.ndim == 1:
     dq = np.sqrt(

--- a/scripts/graph/bcdi_linecut_diffpattern.py
+++ b/scripts/graph/bcdi_linecut_diffpattern.py
@@ -13,6 +13,7 @@ from scipy.ndimage.measurements import center_of_mass
 import tkinter as tk
 from tkinter import filedialog
 import gc
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.utils.utilities as util
 import bcdi.utils.validation as valid
@@ -249,8 +250,7 @@ valid.valid_container(
 ###################
 # define colormap #
 ###################
-colormap = gu.Colormap()
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory().generate_cmap()
 
 #################
 # load the data #

--- a/scripts/graph/bcdi_linecut_diffpattern.py
+++ b/scripts/graph/bcdi_linecut_diffpattern.py
@@ -363,8 +363,7 @@ starting_point = starting_point or [nz // 2, 0, nx // 2]
 endpoint = endpoint or [nz // 2, ny - 1, nx // 2]
 cut = gu.linecut(
     diff_pattern,
-    start_indices=starting_point,
-    stop_indices=endpoint,
+    indices=list(zip(starting_point, endpoint)),
     interp_order=1,
     debugging=False,
 )

--- a/scripts/graph/bcdi_scan_analysis.py
+++ b/scripts/graph/bcdi_scan_analysis.py
@@ -17,6 +17,7 @@ import matplotlib.pyplot as plt
 from matplotlib.widgets import RectangleSelector
 import matplotlib.ticker as ticker
 import os
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.utils.utilities as util
 from bcdi.experiment.setup import Setup
@@ -242,8 +243,7 @@ def press_key(event):
 # define colormap #
 ###################
 bad_color = "1.0"  # white background
-colormap = gu.Colormap(bad_color=bad_color)
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
 plt.ion()
 
 ########################

--- a/scripts/graph/bcdi_view_mesh.py
+++ b/scripts/graph/bcdi_view_mesh.py
@@ -16,6 +16,7 @@ import matplotlib.pyplot as plt
 from matplotlib.widgets import RectangleSelector
 import numpy as np
 import os
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 from bcdi.experiment.setup import Setup
 
@@ -250,8 +251,7 @@ def press_key(event):
 # define colormap #
 ###################
 bad_color = "1.0"  # white background
-colormap = gu.Colormap(bad_color=bad_color)
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
 plt.ion()
 
 ########################

--- a/scripts/graph/bcdi_view_psf.py
+++ b/scripts/graph/bcdi_view_psf.py
@@ -16,6 +16,7 @@ import h5py
 import pathlib
 import tkinter as tk
 from tkinter import filedialog
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.utils.validation as valid
 
@@ -46,8 +47,7 @@ linewidth = 2  # linewidth for the plot frame
 # define colormap #
 ###################
 bad_color = "1.0"  # white background
-colormap = gu.Colormap(bad_color=bad_color)
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
 mpl.rcParams["axes.linewidth"] = tick_width  # set the linewidth globally
 
 #########################

--- a/scripts/graph/bcdi_visu_2D_slice.py
+++ b/scripts/graph/bcdi_visu_2D_slice.py
@@ -12,6 +12,8 @@ import matplotlib
 import matplotlib.pyplot as plt
 import tkinter as tk
 from tkinter import filedialog
+
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.utils.utilities as util
 
@@ -72,8 +74,7 @@ if grey_background:
     bad_color = "0.7"
 else:
     bad_color = "1.0"  # white background
-colormap = gu.Colormap(bad_color=bad_color)
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
 
 if field in {"angle", "modulus"}:
     scale = "linear"

--- a/scripts/postprocessing/bcdi_amp_histogram.py
+++ b/scripts/postprocessing/bcdi_amp_histogram.py
@@ -101,10 +101,10 @@ if fit:
     fit_params = Parameters()
     if lineshape == "pseudovoigt":
         cen = newbin_axis[np.unravel_index(newhist.argmax(), newhist.shape)]
-        fit_params.add("amp_1", value=50000, min=100, max=1000000)
-        fit_params.add("cen_1", value=cen, min=cen - 0.2, max=cen + 0.2)
-        fit_params.add("sig_1", value=0.1, min=0.01, max=0.5)
-        fit_params.add("ratio_1", value=0.5, min=0, max=1)
+        fit_params.add("amp_0", value=50000, min=100, max=1000000)
+        fit_params.add("cen_0", value=cen, min=cen - 0.2, max=cen + 0.2)
+        fit_params.add("sig_0", value=0.1, min=0.01, max=0.5)
+        fit_params.add("ratio_0", value=0.5, min=0, max=1)
 
     # run the fit
     result = minimize(
@@ -134,14 +134,14 @@ if fit:
         fig.text(
             0.15,
             0.95,
-            "cen_1 = "
-            + str("{:.5f}".format(result.params["cen_1"].value))
+            "cen_0 = "
+            + str("{:.5f}".format(result.params["cen_0"].value))
             + "+/-"
-            + str("{:.5f}".format(result.params["cen_1"].stderr))
-            + "   sig_1 = "
-            + str("{:.5f}".format(result.params["sig_1"].value))
+            + str("{:.5f}".format(result.params["cen_0"].stderr))
+            + "   sig_0 = "
+            + str("{:.5f}".format(result.params["sig_0"].value))
             + "+/-"
-            + str("{:.5f}".format(result.params["sig_1"].stderr)),
+            + str("{:.5f}".format(result.params["sig_0"].stderr)),
             size=12,
         )
     except TypeError:  # one output is None

--- a/scripts/postprocessing/bcdi_angular_profile.py
+++ b/scripts/postprocessing/bcdi_angular_profile.py
@@ -125,9 +125,7 @@ file_path = filedialog.askopenfilename(
 )
 _, ext = os.path.splitext(file_path)
 if ext in {".png", ".jpg", ".tif"}:
-    obj = util.image_to_ndarray(
-        filename=file_path, convert_grey=True, cmap="gray", debug=False
-    )
+    obj = util.image_to_ndarray(filename=file_path, convert_grey=True)
 else:
     obj, _ = util.load_file(file_path)
 

--- a/scripts/postprocessing/bcdi_bulk_surface_strain.py
+++ b/scripts/postprocessing/bcdi_bulk_surface_strain.py
@@ -132,50 +132,49 @@ if save_txt:
             "S" + str(scan) + "_threshold" + str(support_threshold) + "_surface.dat",
         ),
         "w",
-    ) as file_surface:
-        with open(
-            os.path.join(
-                savedir,
-                "S" + str(scan) + "_threshold" + str(support_threshold) + "_bulk.dat",
-            ),
-            "w",
-        ) as file_bulk:
+    ) as file_surface, open(
+        os.path.join(
+            savedir,
+            "S" + str(scan) + "_threshold" + str(support_threshold) + "_bulk.dat",
+        ),
+        "w",
+    ) as file_bulk:
 
-            # write surface points position / strain to file
-            surface_indices = np.nonzero(surface)
-            nb_surface = len(surface_indices[0])
-            ind_z = surface_indices[0]
-            ind_y = surface_indices[1]
-            ind_x = surface_indices[2]
-            for point in range(nb_surface):
-                file_surface.write(
-                    "{0: <10}".format(
-                        str(
-                            "{:.7f}".format(
-                                strain[ind_z[point], ind_y[point], ind_x[point]]
-                            )
+        # write surface points position / strain to file
+        surface_indices = np.nonzero(surface)
+        nb_surface = len(surface_indices[0])
+        ind_z = surface_indices[0]
+        ind_y = surface_indices[1]
+        ind_x = surface_indices[2]
+        for point in range(nb_surface):
+            file_surface.write(
+                "{0: <10}".format(
+                    str(
+                        "{:.7f}".format(
+                            strain[ind_z[point], ind_y[point], ind_x[point]]
                         )
                     )
-                    + "\n"
                 )
+                + "\n"
+            )
 
-            # write bulk points position / strain to file
-            bulk_indices = np.nonzero(bulk)
-            nb_bulk = len(bulk_indices[0])
-            ind_z = bulk_indices[0]
-            ind_y = bulk_indices[1]
-            ind_x = bulk_indices[2]
-            for point in range(nb_bulk):
-                file_bulk.write(
-                    "{0: <10}".format(
-                        str(
-                            "{:.7f}".format(
-                                strain[ind_z[point], ind_y[point], ind_x[point]]
-                            )
+        # write bulk points position / strain to file
+        bulk_indices = np.nonzero(bulk)
+        nb_bulk = len(bulk_indices[0])
+        ind_z = bulk_indices[0]
+        ind_y = bulk_indices[1]
+        ind_x = bulk_indices[2]
+        for point in range(nb_bulk):
+            file_bulk.write(
+                "{0: <10}".format(
+                    str(
+                        "{:.7f}".format(
+                            strain[ind_z[point], ind_y[point], ind_x[point]]
                         )
                     )
-                    + "\n"
                 )
+                + "\n"
+            )
     file_surface.close()
     file_bulk.close()
 

--- a/scripts/postprocessing/bcdi_bulk_surface_strain.py
+++ b/scripts/postprocessing/bcdi_bulk_surface_strain.py
@@ -126,58 +126,56 @@ if debug:
 # save the strain values #
 ##########################
 if save_txt:
-    file_surface = open(
+    with open(
         os.path.join(
             savedir,
             "S" + str(scan) + "_threshold" + str(support_threshold) + "_surface.dat",
         ),
         "w",
-    )
-    file_bulk = open(
-        os.path.join(
-            savedir,
-            "S" + str(scan) + "_threshold" + str(support_threshold) + "_bulk.dat",
-        ),
-        "w",
-    )
-    file_total = open(
-        os.path.join(
-            savedir,
-            "S"
-            + str(scan)
-            + "_threshold"
-            + str(support_threshold)
-            + "_bulk+surface.dat",
-        ),
-        "w",
-    )
-    # write surface points position / strain to file
-    surface_indices = np.nonzero(surface)
-    nb_surface = len(surface_indices[0])
-    ind_z = surface_indices[0]
-    ind_y = surface_indices[1]
-    ind_x = surface_indices[2]
-    for point in range(nb_surface):
-        file_surface.write(
-            "{0: <10}".format(
-                str("{:.7f}".format(strain[ind_z[point], ind_y[point], ind_x[point]]))
-            )
-            + "\n"
-        )
+    ) as file_surface:
+        with open(
+            os.path.join(
+                savedir,
+                "S" + str(scan) + "_threshold" + str(support_threshold) + "_bulk.dat",
+            ),
+            "w",
+        ) as file_bulk:
 
-    # write bulk points position / strain to file
-    bulk_indices = np.nonzero(bulk)
-    nb_bulk = len(bulk_indices[0])
-    ind_z = bulk_indices[0]
-    ind_y = bulk_indices[1]
-    ind_x = bulk_indices[2]
-    for point in range(nb_bulk):
-        file_bulk.write(
-            "{0: <10}".format(
-                str("{:.7f}".format(strain[ind_z[point], ind_y[point], ind_x[point]]))
-            )
-            + "\n"
-        )
+            # write surface points position / strain to file
+            surface_indices = np.nonzero(surface)
+            nb_surface = len(surface_indices[0])
+            ind_z = surface_indices[0]
+            ind_y = surface_indices[1]
+            ind_x = surface_indices[2]
+            for point in range(nb_surface):
+                file_surface.write(
+                    "{0: <10}".format(
+                        str(
+                            "{:.7f}".format(
+                                strain[ind_z[point], ind_y[point], ind_x[point]]
+                            )
+                        )
+                    )
+                    + "\n"
+                )
+
+            # write bulk points position / strain to file
+            bulk_indices = np.nonzero(bulk)
+            nb_bulk = len(bulk_indices[0])
+            ind_z = bulk_indices[0]
+            ind_y = bulk_indices[1]
+            ind_x = bulk_indices[2]
+            for point in range(nb_bulk):
+                file_bulk.write(
+                    "{0: <10}".format(
+                        str(
+                            "{:.7f}".format(
+                                strain[ind_z[point], ind_y[point], ind_x[point]]
+                            )
+                        )
+                    )
+                    + "\n"
+                )
     file_surface.close()
     file_bulk.close()
 
@@ -187,17 +185,28 @@ if save_txt:
     ind_z = total_indices[0]
     ind_y = total_indices[1]
     ind_x = total_indices[2]
-    for point in range(nb_total):
-        file_total.write(
-            "{0: <10}".format(
-                str("{:.7f}".format(strain[ind_z[point], ind_y[point], ind_x[point]]))
+    with open(
+        os.path.join(
+            savedir,
+            "S"
+            + str(scan)
+            + "_threshold"
+            + str(support_threshold)
+            + "_bulk+surface.dat",
+        ),
+        "w",
+    ) as file_total:
+        for point in range(nb_total):
+            file_total.write(
+                "{0: <10}".format(
+                    str(
+                        "{:.7f}".format(
+                            strain[ind_z[point], ind_y[point], ind_x[point]]
+                        )
+                    )
+                )
+                + "\n"
             )
-            + "\n"
-        )
-
-    file_surface.close()
-    file_bulk.close()
-    file_total.close()
 
 ####################################
 # fit the bulk strain distribution #

--- a/scripts/postprocessing/bcdi_bulk_surface_strain.py
+++ b/scripts/postprocessing/bcdi_bulk_surface_strain.py
@@ -219,15 +219,15 @@ x_axis = bin_edges[:-1] + (bin_edges[1] - bin_edges[0]) / 2
 
 fit_params = Parameters()
 if fit_pdf == "skewed_gaussian":
-    fit_params.add("amp_1", value=0.0005, min=0.000001, max=10000)
-    fit_params.add("loc_1", value=0, min=-0.1, max=0.1)
-    fit_params.add("sig_1", value=0.0005, min=0.0000001, max=0.1)
-    fit_params.add("alpha_1", value=0, min=-10, max=10)
+    fit_params.add("amp_0", value=0.0005, min=0.000001, max=10000)
+    fit_params.add("loc_0", value=0, min=-0.1, max=0.1)
+    fit_params.add("sig_0", value=0.0005, min=0.0000001, max=0.1)
+    fit_params.add("alpha_0", value=0, min=-10, max=10)
 else:  # 'pseudovoigt'
-    fit_params.add("amp_1", value=0.0005, min=0.000001, max=10000)
-    fit_params.add("cen_1", value=0, min=-0.1, max=0.1)
-    fit_params.add("sig_1", value=0.0005, min=0.0000001, max=0.1)
-    fit_params.add("ratio_1", value=0.5, min=0, max=1)
+    fit_params.add("amp_0", value=0.0005, min=0.000001, max=10000)
+    fit_params.add("cen_0", value=0, min=-0.1, max=0.1)
+    fit_params.add("sig_0", value=0.0005, min=0.0000001, max=0.1)
+    fit_params.add("ratio_0", value=0.5, min=0, max=1)
 
 # run the global fit to all the data sets
 result = minimize(util.objective_lmfit, fit_params, args=(x_axis, hist, fit_pdf))
@@ -321,7 +321,7 @@ if fit_pdf == "skewed_gaussian":
         0.13,
         0.66,
         "SK std={:.2e}\n   +/-{:.2e}".format(
-            result.params["sig_1"].value, result.params["sig_1"].stderr
+            result.params["sig_0"].value, result.params["sig_0"].stderr
         ),
     )
 else:
@@ -329,21 +329,21 @@ else:
         0.15,
         0.70,
         "PDF center={:.2e}\n   +/-{:.2e}".format(
-            result.params["cen_1"].value, result.params["cen_1"].stderr
+            result.params["cen_0"].value, result.params["cen_0"].stderr
         ),
     )
     fig.text(
         0.15,
         0.60,
         "PDF std={:.2e}\n   +/-{:.2e}".format(
-            result.params["sig_1"].value, result.params["sig_1"].stderr
+            result.params["sig_0"].value, result.params["sig_0"].stderr
         ),
     )
     fig.text(
         0.15,
         0.50,
         "PDF ratio={:.2e}\n   +/-{:.2e}".format(
-            result.params["ratio_1"].value, result.params["ratio_1"].stderr
+            result.params["ratio_0"].value, result.params["ratio_0"].stderr
         ),
     )
 plt.pause(0.1)
@@ -375,15 +375,15 @@ x_axis = bin_edges[:-1] + (bin_edges[1] - bin_edges[0]) / 2
 
 fit_params = Parameters()
 if fit_pdf == "skewed_gaussian":
-    fit_params.add("amp_1", value=0.001, min=0.00000001, max=100000)
-    fit_params.add("loc_1", value=0, min=-0.1, max=0.1)
-    fit_params.add("sig_1", value=0.0005, min=0.0000001, max=0.1)
-    fit_params.add("alpha_1", value=0, min=-10, max=10)
+    fit_params.add("amp_0", value=0.001, min=0.00000001, max=100000)
+    fit_params.add("loc_0", value=0, min=-0.1, max=0.1)
+    fit_params.add("sig_0", value=0.0005, min=0.0000001, max=0.1)
+    fit_params.add("alpha_0", value=0, min=-10, max=10)
 else:  # 'pseudovoigt'
-    fit_params.add("amp_1", value=0.001, min=0.00000001, max=100000)
-    fit_params.add("cen_1", value=0, min=-0.1, max=0.1)
-    fit_params.add("sig_1", value=0.0005, min=0.0000001, max=0.1)
-    fit_params.add("ratio_1", value=0.5, min=0, max=1)
+    fit_params.add("amp_0", value=0.001, min=0.00000001, max=100000)
+    fit_params.add("cen_0", value=0, min=-0.1, max=0.1)
+    fit_params.add("sig_0", value=0.0005, min=0.0000001, max=0.1)
+    fit_params.add("ratio_0", value=0.5, min=0, max=1)
 
 # run the global fit to all the data sets
 result = minimize(util.objective_lmfit, fit_params, args=(x_axis, hist, fit_pdf))
@@ -473,7 +473,7 @@ if fit_pdf == "skewed_gaussian":
         0.13,
         0.66,
         "SK std={:.2e}\n   +/-{:.2e}".format(
-            result.params["sig_1"].value, result.params["sig_1"].stderr
+            result.params["sig_0"].value, result.params["sig_0"].stderr
         ),
     )
 else:
@@ -481,21 +481,21 @@ else:
         0.15,
         0.70,
         "PDF center={:.2e}\n   +/-{:.2e}".format(
-            result.params["cen_1"].value, result.params["cen_1"].stderr
+            result.params["cen_0"].value, result.params["cen_0"].stderr
         ),
     )
     fig.text(
         0.15,
         0.60,
         "PDF std={:.2e}\n   +/-{:.2e}".format(
-            result.params["sig_1"].value, result.params["sig_1"].stderr
+            result.params["sig_0"].value, result.params["sig_0"].stderr
         ),
     )
     fig.text(
         0.15,
         0.50,
         "PDF ratio={:.2e}\n   +/-{:.2e}".format(
-            result.params["ratio_1"].value, result.params["ratio_1"].stderr
+            result.params["ratio_0"].value, result.params["ratio_0"].stderr
         ),
     )
 plt.pause(0.1)

--- a/scripts/postprocessing/bcdi_bulk_surface_strain.py
+++ b/scripts/postprocessing/bcdi_bulk_surface_strain.py
@@ -14,6 +14,8 @@ import pathlib
 import tkinter as tk
 from tkinter import filedialog
 import os
+
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.utils.utilities as util
 import bcdi.postprocessing.postprocessing_utils as pu
@@ -69,8 +71,7 @@ pathlib.Path(savedir).mkdir(parents=True, exist_ok=True)
 ###################
 # define colormap #
 ###################
-colormap = gu.Colormap()
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory().generate_cmap()
 
 #############
 # load data #

--- a/scripts/postprocessing/bcdi_facet_strain.py
+++ b/scripts/postprocessing/bcdi_facet_strain.py
@@ -21,6 +21,8 @@ from skimage import measure
 import logging
 import sys
 import gc
+
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.postprocessing.facet_recognition as fu
 import bcdi.simulation.simulation_utils as simu
@@ -155,8 +157,7 @@ logger = logging.getLogger()
 ###################
 # define colormap #
 ###################
-colormap = gu.Colormap()
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory(.generate_cmap())
 
 #############
 # load data #

--- a/scripts/postprocessing/bcdi_facet_strain.py
+++ b/scripts/postprocessing/bcdi_facet_strain.py
@@ -157,7 +157,7 @@ logger = logging.getLogger()
 ###################
 # define colormap #
 ###################
-my_cmap = ColormapFactory(.generate_cmap())
+my_cmap = ColormapFactory().generate_cmap()
 
 #############
 # load data #

--- a/scripts/postprocessing/bcdi_line_profile.py
+++ b/scripts/postprocessing/bcdi_line_profile.py
@@ -128,9 +128,7 @@ file_path = filedialog.askopenfilename(
 
 _, ext = os.path.splitext(file_path)
 if ext in {".png", ".jpg", ".tif"}:
-    obj = util.image_to_ndarray(
-        filename=file_path, convert_grey=True, cmap="gray", debug=False
-    )
+    obj = util.image_to_ndarray(filename=file_path, convert_grey=True)
 else:
     obj, _ = util.load_file(file_path)
 ndim = obj.ndim

--- a/scripts/postprocessing/bcdi_polarplot.py
+++ b/scripts/postprocessing/bcdi_polarplot.py
@@ -21,6 +21,8 @@ import tkinter as tk
 from tkinter import filedialog
 from numpy.fft import fftn, fftshift
 import gc
+
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 from bcdi.experiment.setup import Setup
 import bcdi.postprocessing.facet_recognition as fu
@@ -260,8 +262,7 @@ tilt = 0  # tilt parameter from xrayutilities 2D detector calibration
 # define colormap #
 ###################
 bad_color = "1.0"  # white background
-colormap = gu.Colormap(bad_color=bad_color)
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
 
 ####################
 # Initialize setup #

--- a/scripts/postprocessing/bcdi_prtf_BCDI.py
+++ b/scripts/postprocessing/bcdi_prtf_BCDI.py
@@ -633,11 +633,11 @@ if flag_interact:
 
     plt.ioff()
     max_colorbar = 5
+    starting_point = [z0, y0, x0]
     endpoint = [0, 0, 0]
     cut = gu.linecut(
         prtf_matrix,
-        start_indices=(z0, y0, x0),
-        stop_indices=endpoint,
+        indices=list(zip(starting_point, endpoint)),
         interp_order=1,
         debugging=False,
     )

--- a/scripts/postprocessing/bcdi_prtf_BCDI.py
+++ b/scripts/postprocessing/bcdi_prtf_BCDI.py
@@ -180,10 +180,8 @@ def on_click(event):
         print(f"endpoint = {endpoint}")
         cut = gu.linecut(
             linecut_prtf,
-            start_indices=(z0, y0, x0),
-            stop_indices=endpoint,
+            indices=list(zip(starting_point, endpoint)),
             interp_order=1,
-            debugging=False,
         )
         plt0.remove()
         plt1.remove()
@@ -639,7 +637,6 @@ if flag_interact:
         prtf_matrix,
         indices=list(zip(starting_point, endpoint)),
         interp_order=1,
-        debugging=False,
     )
     diff_pattern[np.isnan(diff_pattern)] = 0  # discard nans
     fig_prtf, ((ax0, ax1), (ax2, ax3)) = plt.subplots(nrows=2, ncols=2, figsize=(12, 6))

--- a/scripts/postprocessing/bcdi_prtf_BCDI.py
+++ b/scripts/postprocessing/bcdi_prtf_BCDI.py
@@ -21,6 +21,8 @@ import sys
 import tkinter as tk
 from tkinter import filedialog
 import xrayutilities as xu
+
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 from bcdi.experiment.setup import Setup
 import bcdi.utils.image_registration as reg
@@ -296,8 +298,7 @@ hxrd = xu.experiment.HXRD(sample_inplane, sample_outofplane, qconv=qconv)
 ###################
 # define colormap #
 ###################
-colormap = gu.Colormap()
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory().generate_cmap()
 
 ###################################
 # load experimental data and mask #

--- a/scripts/postprocessing/bcdi_prtf_BCDI_2D.py
+++ b/scripts/postprocessing/bcdi_prtf_BCDI_2D.py
@@ -21,6 +21,8 @@ from tkinter import filedialog
 import xrayutilities as xu
 import gc
 import sys
+
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 from bcdi.experiment.setup import Setup
 import bcdi.utils.image_registration as reg
@@ -202,8 +204,7 @@ hxrd = xu.experiment.HXRD(sample_inplane, sample_outofplane, qconv=qconv)
 ###################
 # define colormap #
 ###################
-colormap = gu.Colormap()
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory().generate_cmap()
 
 ##########################################################
 # load experimental data, extracted 2D slice and 2D mask #

--- a/scripts/postprocessing/bcdi_prtf_CDI.py
+++ b/scripts/postprocessing/bcdi_prtf_CDI.py
@@ -21,6 +21,8 @@ from tkinter import filedialog
 from scipy.interpolate import interp1d
 import gc
 import sys
+
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.utils.utilities as util
 
@@ -66,8 +68,7 @@ q_max = None  # in 1/nm, PRTF normalization using only points smaller than q_max
 ###################
 # define colormap #
 ###################
-colormap = gu.Colormap()
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory().generate_cmap()
 
 #########################
 # check some parameters #

--- a/scripts/postprocessing/bcdi_rocking_curves.py
+++ b/scripts/postprocessing/bcdi_rocking_curves.py
@@ -17,6 +17,7 @@ from scipy.interpolate import interp1d
 from scipy.ndimage.measurements import center_of_mass
 from bcdi.experiment.setup import Setup
 import bcdi.preprocessing.bcdi_utils as bu
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.utils.utilities as util
 import bcdi.utils.validation as valid
@@ -138,8 +139,7 @@ energy = 10300  # in eV, offset of 6eV at ID01
 ###################
 bad_color = "1.0"  # white
 bckg_color = "0.7"  # grey
-colormap = gu.Colormap(bad_color=bad_color)
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
 
 ########################################
 # check and initialize some parameters #

--- a/scripts/postprocessing/bcdi_strain_mean_var_rms.py
+++ b/scripts/postprocessing/bcdi_strain_mean_var_rms.py
@@ -11,7 +11,9 @@ import numpy as np
 from matplotlib import pyplot as plt
 import tkinter as tk
 from tkinter import filedialog
+
 import bcdi.postprocessing.postprocessing_utils as pu
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 
 helptext = """
@@ -36,8 +38,7 @@ debug = True  # True to see data plots
 # define colormap #
 ###################
 bad_color = "1.0"  # white background
-colormap = gu.Colormap(bad_color=bad_color)
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
 
 #############
 # load data #

--- a/scripts/preprocessing/bcdi_preprocess_BCDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_BCDI.py
@@ -16,7 +16,7 @@ from bcdi.preprocessing.preprocessing_runner import run
 from bcdi.utils.parser import add_cli_parameters, ConfigParser
 
 here = Path(__file__).parent
-CONFIG_FILE = str(here.parents[1] / "bcdi/examples/config_preprocessing.yml")
+CONFIG_FILE = str(here.parents[1] / "bcdi/examples/S11_config_preprocessing.yml")
 
 helptext = """
 Prepare experimental data for Bragg CDI phasing: crop/pad, center, mask, normalize and

--- a/scripts/preprocessing/bcdi_preprocess_CDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_CDI.py
@@ -21,6 +21,8 @@ import sys
 from scipy.io import savemat
 import tkinter as tk
 from tkinter import filedialog
+
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 from bcdi.experiment.setup import Setup
 import bcdi.utils.utilities as util
@@ -406,8 +408,7 @@ valid.valid_container(
 ###################
 # define colormap #
 ###################
-colormap = gu.Colormap()
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory().generate_cmap()
 plt.rcParams["keymap.fullscreen"] = [""]
 
 ####################

--- a/scripts/preprocessing/bcdi_read_BCDI_scan.py
+++ b/scripts/preprocessing/bcdi_read_BCDI_scan.py
@@ -16,6 +16,7 @@ import matplotlib.pyplot as plt
 from scipy.interpolate import interp1d
 from bcdi.experiment.setup import Setup
 import bcdi.preprocessing.bcdi_utils as bu
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.utils.utilities as util
 
@@ -120,8 +121,7 @@ width = None  # [50, 50]  # [vertical, horizontal], leave None for default
 # define colormap #
 ###################
 bad_color = "1.0"  # white background
-colormap = gu.Colormap(bad_color=bad_color)
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
 plt.ion()
 
 ########################################

--- a/scripts/preprocessing/bcdi_read_data_P10.py
+++ b/scripts/preprocessing/bcdi_read_data_P10.py
@@ -21,6 +21,8 @@ import matplotlib.pyplot as plt
 import os
 from scipy.io import savemat
 import sys
+
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.utils.utilities as util
 from bcdi.experiment.detector import create_detector
@@ -168,8 +170,7 @@ def main(parameters):
         bad_color = "0.7"
     else:
         bad_color = "1.0"  # white background
-    colormap = gu.Colormap(bad_color=bad_color)
-    my_cmap = colormap.cmap
+    my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
 
     #######################
     # Initialize detector #

--- a/scripts/preprocessing/bcdi_read_data_P10.py
+++ b/scripts/preprocessing/bcdi_read_data_P10.py
@@ -268,7 +268,7 @@ def main(parameters):
             h5file = h5py.File(filenames[idx], "r")
             data = h5file["entry"]["data"]["data"][:]
             data[data <= threshold] = 0
-            nbz, nby, nbx = data.shape
+            nbz, _, _ = data.shape
             for index in range(nbz):
                 counter.append(
                     data[

--- a/scripts/preprocessing/bcdi_rescale_support.py
+++ b/scripts/preprocessing/bcdi_rescale_support.py
@@ -14,6 +14,7 @@ from scipy.interpolate import RegularGridInterpolator
 import gc
 import sys
 import bcdi.postprocessing.postprocessing_utils as pu
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.algorithms.algorithms_utils as algu
 import bcdi.utils.utilities as util
@@ -257,8 +258,7 @@ def press_key(event):
 ###################
 # define colormap #
 ###################
-colormap = gu.Colormap()
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory().generate_cmap()
 plt.rcParams["keymap.fullscreen"] = [""]
 
 #################

--- a/scripts/publication/bcdi_coefficient_variation.py
+++ b/scripts/publication/bcdi_coefficient_variation.py
@@ -15,6 +15,7 @@ from tkinter import filedialog
 import matplotlib.ticker as ticker
 import bcdi.postprocessing.postprocessing_utils as pu
 from bcdi.utils import image_registration as reg
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.utils.utilities as util
 
@@ -92,8 +93,7 @@ if grey_background:
     bad_color = "0.7"
 else:
     bad_color = "1.0"  # white background
-colormap = gu.Colormap(bad_color=bad_color)
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
 
 #############
 # load data #

--- a/scripts/publication/bcdi_diffpattern_from_reconstruction.py
+++ b/scripts/publication/bcdi_diffpattern_from_reconstruction.py
@@ -18,6 +18,8 @@ import pathlib
 from scipy.ndimage.measurements import center_of_mass
 import tkinter as tk
 from tkinter import filedialog
+
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.postprocessing.postprocessing_utils as pu
 import bcdi.utils.utilities as util
@@ -186,8 +188,7 @@ if grey_background:
 else:
     bad_color = "1.0"  # white background
 
-colormap = gu.Colormap(bad_color=bad_color)
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
 
 labels = ("Qx", "Qz", "Qy")
 

--- a/scripts/publication/bcdi_plot_diffpattern_2D.py
+++ b/scripts/publication/bcdi_plot_diffpattern_2D.py
@@ -16,6 +16,8 @@ import pathlib
 import tkinter as tk
 from tkinter import filedialog
 from scipy.ndimage.measurements import center_of_mass
+
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.utils.utilities as util
 import bcdi.utils.validation as valid
@@ -138,8 +140,7 @@ if grey_background:
 else:
     bad_color = "1.0"  # white background
 
-colormap = gu.Colormap(bad_color=bad_color)
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
 
 if is_orthogonal:
     labels = ("Qx", "Qz", "Qy")

--- a/scripts/publication/bcdi_plot_strain.py
+++ b/scripts/publication/bcdi_plot_strain.py
@@ -16,6 +16,7 @@ from scipy.ndimage.measurements import center_of_mass
 import tkinter as tk
 from tkinter import filedialog
 
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.utils.utilities as util
 import bcdi.utils.validation as valid
@@ -106,8 +107,7 @@ if grey_background:
     bad_color = "0.7"
 else:
     bad_color = "1.0"  # white background
-colormap = gu.Colormap(bad_color=bad_color)
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
 
 #########################
 # check some parameters #

--- a/scripts/simulation/bcdi_domain_orientation.py
+++ b/scripts/simulation/bcdi_domain_orientation.py
@@ -16,6 +16,8 @@ import gc
 import time
 import datetime
 import sys
+
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 from bcdi.experiment.detector import create_detector
 import bcdi.utils.utilities as util
@@ -105,8 +107,7 @@ detector = create_detector(name=detector, binning=binning, roi=roi_detector)
 # define colormap #
 ###################
 bad_color = "1.0"  # white background
-colormap = gu.Colormap(bad_color=bad_color)
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
 plt.ion()
 
 ###################################

--- a/scripts/simulation/bcdi_simu_diffpattern_BCDI.py
+++ b/scripts/simulation/bcdi_simu_diffpattern_BCDI.py
@@ -17,6 +17,8 @@ from scipy.interpolate import RegularGridInterpolator
 import gc
 import os
 import sys
+
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 from bcdi.experiment.setup import Setup
 import bcdi.postprocessing.postprocessing_utils as pu
@@ -116,8 +118,7 @@ comment = ""  # should start with _
 # define colormap #
 ###################
 bad_color = "1.0"  # white background
-colormap = gu.Colormap(bad_color=bad_color)
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
 
 ################
 # define setup #

--- a/scripts/simulation/bcdi_simu_diffpattern_CDI.py
+++ b/scripts/simulation/bcdi_simu_diffpattern_CDI.py
@@ -9,6 +9,8 @@
 
 import numpy as np
 from matplotlib import pyplot as plt
+
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 from bcdi.experiment.detector import create_detector
 import bcdi.postprocessing.postprocessing_utils as pu
@@ -82,8 +84,7 @@ print("Data shape:", nbz, nby, nbx)
 # define colormap #
 ###################
 bad_color = "1.0"  # white background
-colormap = gu.Colormap(bad_color=bad_color)
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
 plt.ion()
 
 ######################

--- a/scripts/utils/bcdi_angular_avg_3Dto1D.py
+++ b/scripts/utils/bcdi_angular_avg_3Dto1D.py
@@ -11,6 +11,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 import tkinter as tk
 from tkinter import filedialog
+
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.utils.utilities as util
 import bcdi.xcca.xcca_utils as xcca
@@ -59,8 +61,7 @@ subtract_median = False  # if True, will subtract the median to the mean at each
 ###################
 # define colormap #
 ###################
-colormap = gu.Colormap()
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory().generate_cmap()
 
 ##############################
 # load reciprocal space data #

--- a/scripts/utils/bcdi_calibration_grid_SEM.py
+++ b/scripts/utils/bcdi_calibration_grid_SEM.py
@@ -133,9 +133,7 @@ file_path = filedialog.askopenfilename(
 
 _, ext = os.path.splitext(file_path)
 if ext in {".png", ".jpg", ".tif"}:
-    obj = util.image_to_ndarray(
-        filename=file_path, convert_grey=True, cmap="gray", debug=False
-    )
+    obj = util.image_to_ndarray(filename=file_path, convert_grey=True)
 else:
     obj, _ = util.load_file(file_path)
 ndim = obj.ndim

--- a/scripts/utils/bcdi_correlation_realspace.py
+++ b/scripts/utils/bcdi_correlation_realspace.py
@@ -14,6 +14,7 @@ from tkinter import filedialog
 from scipy.stats import pearsonr
 import bcdi.utils.utilities as util
 from bcdi.utils import image_registration as reg
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 
 helptext = """
@@ -26,8 +27,7 @@ threshold_correlation = 0.05
 ###################
 # define colormap #
 ###################
-colormap = gu.Colormap()
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory().generate_cmap()
 
 #############
 # load data #

--- a/scripts/utils/bcdi_crop_npz.py
+++ b/scripts/utils/bcdi_crop_npz.py
@@ -13,6 +13,7 @@ import matplotlib.pyplot as plt
 import tkinter as tk
 from tkinter import filedialog
 import bcdi.utils.utilities as util
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 
 helptext = """
@@ -41,8 +42,7 @@ comment = ""  # should start with _
 ###################
 # define colormap #
 ###################
-colormap = gu.Colormap()
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory().generate_cmap()
 
 #################
 # load the data #

--- a/scripts/utils/bcdi_fit_1D_curve.py
+++ b/scripts/utils/bcdi_fit_1D_curve.py
@@ -39,7 +39,7 @@ fit_range = [
     [0.70, 0.90],
 ]  # list of ranges for simultaneous fit [[start1, stop1],[start2, stop2],...]
 constraint_expr = [
-    "sqrt(8)/sqrt(3) * cen_1"
+    "sqrt(8)/sqrt(3) * cen_0"
 ]  # list of string constraints for the fit, leave [] otherwise
 # if provided, len(constraint_expr) should be equal to len(fit_range)-1
 # sqrt(8)/sqrt(3), ratio of 220 to 111 in FCC materials
@@ -140,22 +140,22 @@ for idx in range(nb_ranges):
     if lineshape == "gaussian":
         cen = (fit_range[idx, 0] + fit_range[idx, 1]) / 2
         sig = abs(fit_range[idx, 0] - fit_range[idx, 1]) / 16
-        fit_params.add("amp_%i" % (idx + 1), value=10, min=0.0, max=1000)
-        fit_params.add("cen_%i" % (idx + 1), value=cen, min=cen - 0.5, max=cen + 0.5)
-        fit_params.add("sig_%i" % (idx + 1), value=sig, min=sig / 32, max=sig * 4)
+        fit_params.add("amp_%i" % idx, value=10, min=0.0, max=1000)
+        fit_params.add("cen_%i" % idx, value=cen, min=cen - 0.5, max=cen + 0.5)
+        fit_params.add("sig_%i" % idx, value=sig, min=sig / 32, max=sig * 4)
     elif lineshape == "lorentzian":
         cen = (fit_range[idx, 0] + fit_range[idx, 1]) / 2
         sig = abs(fit_range[idx, 0] - fit_range[idx, 1]) / 16
-        fit_params.add("amp_%i" % (idx + 1), value=10, min=0.0, max=1000)
-        fit_params.add("cen_%i" % (idx + 1), value=cen, min=cen - 0.5, max=cen + 0.5)
-        fit_params.add("sig_%i" % (idx + 1), value=sig, min=sig / 32, max=sig * 4)
+        fit_params.add("amp_%i" % idx, value=10, min=0.0, max=1000)
+        fit_params.add("cen_%i" % idx, value=cen, min=cen - 0.5, max=cen + 0.5)
+        fit_params.add("sig_%i" % idx, value=sig, min=sig / 32, max=sig * 4)
     elif lineshape == "pseudovoigt":
         cen = (fit_range[idx, 0] + fit_range[idx, 1]) / 2
         sig = abs(fit_range[idx, 0] - fit_range[idx, 1]) / 8  # FWHM of the Pseudo Voigt
-        fit_params.add("amp_%i" % (idx + 1), value=10, min=0.0, max=1000)
-        fit_params.add("cen_%i" % (idx + 1), value=cen, min=cen - 0.5, max=cen + 0.5)
-        fit_params.add("sig_%i" % (idx + 1), value=sig, min=sig / 32, max=sig * 4)
-        fit_params.add("ratio_%i" % (idx + 1), value=0.5, min=0, max=1)
+        fit_params.add("amp_%i" % idx, value=10, min=0.0, max=1000)
+        fit_params.add("cen_%i" % idx, value=cen, min=cen - 0.5, max=cen + 0.5)
+        fit_params.add("sig_%i" % idx, value=sig, min=sig / 32, max=sig * 4)
+        fit_params.add("ratio_%i" % idx, value=0.5, min=0, max=1)
 
 # constrain values
 if len(constraint_expr) != 0:
@@ -168,7 +168,7 @@ if len(constraint_expr) != 0:
         )
         sys.exit()
     for idx in range(1, nb_ranges):
-        fit_params[constraint_var[idx - 1] + "_%i" % (idx + 1)].expr = constraint_expr[
+        fit_params[constraint_var[idx - 1] + "_%i" % idx].expr = constraint_expr[
             idx - 1
         ]
 
@@ -203,6 +203,19 @@ try:
     fig.text(
         0.15,
         0.95,
+        "cen_0 = "
+        + str("{:.5f}".format(result.params["cen_0"].value))
+        + "+/-"
+        + str("{:.5f}".format(result.params["cen_0"].stderr))
+        + "   sig_0 = "
+        + str("{:.5f}".format(result.params["sig_0"].value))
+        + "+/-"
+        + str("{:.5f}".format(result.params["sig_0"].stderr)),
+        size=12,
+    )
+    fig.text(
+        0.15,
+        0.90,
         "cen_1 = "
         + str("{:.5f}".format(result.params["cen_1"].value))
         + "+/-"
@@ -211,19 +224,6 @@ try:
         + str("{:.5f}".format(result.params["sig_1"].value))
         + "+/-"
         + str("{:.5f}".format(result.params["sig_1"].stderr)),
-        size=12,
-    )
-    fig.text(
-        0.15,
-        0.90,
-        "cen_2 = "
-        + str("{:.5f}".format(result.params["cen_2"].value))
-        + "+/-"
-        + str("{:.5f}".format(result.params["cen_2"].stderr))
-        + "   sig_2 = "
-        + str("{:.5f}".format(result.params["sig_2"].value))
-        + "+/-"
-        + str("{:.5f}".format(result.params["sig_2"].stderr)),
         size=12,
     )
 except TypeError:  # one output is None

--- a/scripts/xcca/bcdi_view_ccf_map.py
+++ b/scripts/xcca/bcdi_view_ccf_map.py
@@ -13,6 +13,8 @@ from matplotlib import pyplot as plt
 import tkinter as tk
 from tkinter import filedialog
 import sys
+
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.utils.utilities as util
 
@@ -151,8 +153,7 @@ def press_key(event):
 # define colormap #
 ###################
 bad_color = "1.0"  # white background
-colormap = gu.Colormap(bad_color=bad_color)
-my_cmap = colormap.cmap
+my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
 plt.ion()
 
 ###################################

--- a/scripts/xcca/bcdi_xcca_3D_map_polar.py
+++ b/scripts/xcca/bcdi_xcca_3D_map_polar.py
@@ -18,6 +18,8 @@ from tkinter import filedialog
 import gc
 import multiprocessing as mp
 import sys
+
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.utils.utilities as util
 import bcdi.xcca.xcca_utils as xcca
@@ -125,8 +127,7 @@ def main(calc_self, user_comment):
     # define colormap #
     ###################
     bad_color = "1.0"  # white background
-    colormap = gu.Colormap(bad_color=bad_color)
-    my_cmap = colormap.cmap
+    my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
     plt.ion()
 
     ###################################

--- a/scripts/xcca/bcdi_xcca_3D_map_polar.py
+++ b/scripts/xcca/bcdi_xcca_3D_map_polar.py
@@ -116,7 +116,7 @@ def main(calc_self, user_comment):
         raise ValueError("at least 2 values are needed for q_range")
 
     print("the CCF map will be calculated for {:d} q values: ".format(len(q_range)))
-    for idx, item in enumerate(q_range):
+    for _, item in enumerate(q_range):
         if calc_self:
             print(f"q1 = {item:.3f}  q2 = {item:.3f}")
         else:

--- a/scripts/xcca/bcdi_xcca_3D_map_rect.py
+++ b/scripts/xcca/bcdi_xcca_3D_map_rect.py
@@ -17,6 +17,8 @@ from tkinter import filedialog
 import gc
 import multiprocessing as mp
 import sys
+
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.utils.utilities as util
 import bcdi.xcca.xcca_utils as xcca
@@ -119,8 +121,7 @@ def main(calc_self, user_comment):
     # define colormap #
     ###################
     bad_color = "1.0"  # white background
-    colormap = gu.Colormap(bad_color=bad_color)
-    my_cmap = colormap.cmap
+    my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
     plt.ion()
 
     ###################################

--- a/scripts/xcca/bcdi_xcca_3D_map_rect.py
+++ b/scripts/xcca/bcdi_xcca_3D_map_rect.py
@@ -110,7 +110,7 @@ def main(calc_self, user_comment):
         raise ValueError("at least 2 values are needed for q_range")
 
     print("the CCF map will be calculated for {:d} q values: ".format(len(q_range)))
-    for idx, item in enumerate(q_range):
+    for _, item in enumerate(q_range):
         if calc_self:
             print(f"q1 = {item:.3f}  q2 = {item:.3f}")
         else:

--- a/scripts/xcca/bcdi_xcca_3D_polar.py
+++ b/scripts/xcca/bcdi_xcca_3D_polar.py
@@ -18,6 +18,8 @@ from tkinter import filedialog
 import gc
 import multiprocessing as mp
 import sys
+
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.utils.utilities as util
 import bcdi.xcca.xcca_utils as xcca
@@ -143,8 +145,7 @@ def main(user_comment):
     # define colormap #
     ###################
     bad_color = "1.0"  # white background
-    colormap = gu.Colormap(bad_color=bad_color)
-    my_cmap = colormap.cmap
+    my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
     plt.ion()
 
     ###################################

--- a/scripts/xcca/bcdi_xcca_3D_rect.py
+++ b/scripts/xcca/bcdi_xcca_3D_rect.py
@@ -17,6 +17,8 @@ from tkinter import filedialog
 import gc
 import multiprocessing as mp
 import sys
+
+from bcdi.graph.colormap import ColormapFactory
 import bcdi.graph.graph_utils as gu
 import bcdi.utils.utilities as util
 import bcdi.xcca.xcca_utils as xcca
@@ -138,8 +140,7 @@ def main(user_comment):
     # define colormap #
     ###################
     bad_color = "1.0"  # white background
-    colormap = gu.Colormap(bad_color=bad_color)
-    my_cmap = colormap.cmap
+    my_cmap = ColormapFactory(bad_color=bad_color).generate_cmap()
     plt.ion()
 
     ###################################

--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,7 @@ setup(
             "sphinxcontrib-mermaid==0.7.1",
         ],
         "dev": [
-            "black==22.1.0",
+            "black==22.3.0",
             "coverage==6.3.2",
             "doit==0.34.2",
             "mypy==0.941",

--- a/tests/graph/test_graph_utils.py
+++ b/tests/graph/test_graph_utils.py
@@ -14,6 +14,84 @@ import bcdi.graph.graph_utils as gu
 from tests.config import run_tests
 
 
+class TestLinecut(unittest.TestCase):
+    """
+    Tests on graphs_utils.linecut.
+
+    def linecut(
+        array: np.ndarray,
+        indices: List[Tuple[int, int]],
+        interp_order: int = 3,
+    ) -> np.ndarray:
+    """
+
+    def test_interp_order_wrong_type(self):
+        with self.assertRaises(TypeError):
+            gu.linecut(np.ones(3), indices=[(1, 2)], interp_order=1.2)
+
+    def test_interp_order_none(self):
+        with self.assertRaises(ValueError):
+            gu.linecut(np.ones(3), indices=[(1, 2)], interp_order=None)
+
+    def test_interp_order_null(self):
+        with self.assertRaises(ValueError):
+            gu.linecut(np.ones(3), indices=[(1, 2)], interp_order=0)
+
+    def test_1d(self):
+        array = np.arange(5)
+        expected = np.array([1.0, 2.0, 3.0])
+        output = gu.linecut(array, indices=[(1, 3)], interp_order=1)
+        self.assertTrue(np.allclose(output, expected))
+
+    def test_2d_diagonal(self):
+        array = np.asarray([np.arange(6) for _ in range(6)])
+        expected = np.array(
+            [
+                0,
+                0.71428571,
+                1.42857143,
+                2.14285714,
+                2.85714286,
+                3.57142857,
+                4.28571429,
+                5.0,
+            ]
+        )
+        output = gu.linecut(array, indices=[(0, 5), (0, 5)], interp_order=1)
+        self.assertTrue(np.allclose(output, expected))
+
+    def test_2d_horizontal(self):
+        array = np.asarray([np.arange(6) for _ in range(5)])
+        expected = np.arange(1, 5)
+        output = gu.linecut(array, indices=[(1, 1), (1, 4)], interp_order=1)
+        self.assertTrue(np.allclose(output, expected))
+
+    def test_2d_vertical(self):
+        array = np.asarray([np.ones(6) * idx for idx in range(5)])
+        expected = np.arange(1, 5)
+        output = gu.linecut(array, indices=[(1, 4), (2, 2)], interp_order=1)
+        self.assertTrue(np.allclose(output, expected))
+
+    def test_3d_diagonal(self):
+        array = np.asarray([[np.arange(6) for _ in range(6)] for _ in range(6)])
+        expected = np.array(
+            [
+                0,
+                0.55555556,
+                1.11111111,
+                1.66666667,
+                2.22222222,
+                2.77777778,
+                3.33333333,
+                3.88888889,
+                4.44444444,
+                5.0,
+            ]
+        )
+        output = gu.linecut(array, indices=[(0, 5), (0, 5), (0, 5)], interp_order=1)
+        self.assertTrue(np.allclose(output, expected))
+
+
 class TestSaveToVti(unittest.TestCase):
     """Tests on save_to_vti."""
 

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -407,8 +407,24 @@ class TestUpsample(unittest.TestCase):
         self.assertTrue(np.allclose(output, expected))
 
     def test_2d_array(self):
-        with self.assertRaises(NotImplementedError):
-            util.upsample(array=np.vstack([np.arange(5) for _ in range(6)]), factor=2)
+        array = np.asarray([np.arange(6) for _ in range(5)])
+        expected = np.asarray([np.linspace(0, 5, num=12) for _ in range(10)])
+        output = util.upsample(array=array, factor=2)
+        self.assertTrue(np.allclose(output, expected))
+
+    def test_2d_array_vertical(self):
+        array = np.asarray([np.ones(6) * idx for idx in range(5)])
+        expected = np.asarray([np.ones(12) * idx for idx in np.linspace(0, 4, num=10)])
+        output = util.upsample(array=array, factor=2)
+        self.assertTrue(np.allclose(output, expected))
+
+    def test_3d_array(self):
+        array = np.asarray([[np.arange(6) for _ in range(5)] for _ in range(4)])
+        expected = np.asarray(
+            [[np.linspace(0, 5, num=12) for _ in range(10)] for _ in range(8)]
+        )
+        output = util.upsample(array=array, factor=2)
+        self.assertTrue(np.allclose(output, expected))
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -369,11 +369,54 @@ class TestNdarrayToList(unittest.TestCase):
         self.assertTrue(out == valid)
 
 
+class TestUpsample(unittest.TestCase):
+    """
+    Tests on the function utilities.upsample.
+
+    def upsample(
+    array: Union[np.ndarray, List], factor: int = 2, interp_order: int = 1
+    ) -> np.ndarray:
+    """
+
+    def test_1d_array_factor_1_odd(self):
+        array = np.arange(9)
+        output = util.upsample(array=array, factor=1)
+        self.assertTrue(np.allclose(output, array))
+
+    def test_1d_array_factor_1_even(self):
+        array = np.arange(8)
+        output = util.upsample(array=array, factor=1)
+        self.assertTrue(np.allclose(output, array))
+
+    def test_1d_array_factor_2_odd(self):
+        array = np.arange(3)
+        expected = np.linspace(0, 2, num=6, endpoint=True)
+        output = util.upsample(array=array, factor=2)
+        self.assertTrue(np.allclose(output, expected))
+
+    def test_1d_array_factor_2_even(self):
+        array = np.arange(6)
+        expected = np.linspace(0, 5, num=12, endpoint=True)
+        output = util.upsample(array=array, factor=2)
+        self.assertTrue(np.allclose(output, expected))
+
+    def test_1d_array_complex_factor_2_even(self):
+        array = np.arange(6) * (1 + 1j)
+        expected = np.linspace(0, 5, num=12, endpoint=True) * (1 + 1j)
+        output = util.upsample(array=array, factor=2)
+        self.assertTrue(np.allclose(output, expected))
+
+    def test_2d_array(self):
+        with self.assertRaises(NotImplementedError):
+            util.upsample(array=np.vstack([np.arange(5) for _ in range(6)]), factor=2)
+
+
 if __name__ == "__main__":
     run_tests(TestInRange)
     run_tests(TestFindFile)
     run_tests(TestGaussianWindow)
     run_tests(TestUnpackArray)
+    run_tests(TestUpsample)
     run_tests(TestCreateRepr)
     run_tests(TestFormatRepr)
     run_tests(TestNdarrayToList)

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -272,37 +272,6 @@ class TestInRange(unittest.TestCase):
         self.assertTrue(util.in_range(point=(0, 0, 119), extent=self.extent))
 
 
-class TestIsFloat(unittest.TestCase):
-    """
-    Tests on the function utilities.is_float.
-
-    def is_float(string)
-    """
-
-    def test_string_float(self):
-        self.assertTrue(util.is_float("12.0"))
-
-    def test_string_int(self):
-        self.assertTrue(util.is_float("12"))
-
-    def test_string_complex(self):
-        self.assertFalse(util.is_float("12 + 1j"))
-
-    def test_string_none(self):
-        self.assertFalse(util.is_float("None"))
-
-    def test_string_not_numeric(self):
-        self.assertFalse(util.is_float("abc"))
-
-    def test_none(self):
-        with self.assertRaises(TypeError):
-            util.is_float(None)
-
-    def test_array(self):
-        with self.assertRaises(TypeError):
-            util.is_float(np.ones(3))
-
-
 class TestGaussianWindow(unittest.TestCase):
     """
     Tests on the function utilities.gaussian_window.
@@ -402,7 +371,6 @@ class TestNdarrayToList(unittest.TestCase):
 
 if __name__ == "__main__":
     run_tests(TestInRange)
-    run_tests(TestIsFloat)
     run_tests(TestFindFile)
     run_tests(TestGaussianWindow)
     run_tests(TestUnpackArray)

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -21,27 +21,27 @@ class TestIsFloat(unittest.TestCase):
     """
 
     def test_string_float(self):
-        self.assertTrue(util.is_float("12.0"))
+        self.assertTrue(valid.is_float("12.0"))
 
     def test_string_int(self):
-        self.assertTrue(util.is_float("12"))
+        self.assertTrue(valid.is_float("12"))
 
     def test_string_complex(self):
-        self.assertFalse(util.is_float("12 + 1j"))
+        self.assertFalse(valid.is_float("12 + 1j"))
 
     def test_string_none(self):
-        self.assertFalse(util.is_float("None"))
+        self.assertFalse(valid.is_float("None"))
 
     def test_string_not_numeric(self):
-        self.assertFalse(util.is_float("abc"))
+        self.assertFalse(valid.is_float("abc"))
 
     def test_none(self):
         with self.assertRaises(TypeError):
-            util.is_float(None)
+            valid.is_float(None)
 
     def test_array(self):
         with self.assertRaises(TypeError):
-            util.is_float(np.ones(3))
+            valid.is_float(np.ones(3))
 
 
 class TestValidContainer(unittest.TestCase):

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -13,6 +13,37 @@ import bcdi.utils.validation as valid
 from tests.config import run_tests
 
 
+class TestIsFloat(unittest.TestCase):
+    """
+    Tests on the function utilities.is_float.
+
+    def is_float(string)
+    """
+
+    def test_string_float(self):
+        self.assertTrue(util.is_float("12.0"))
+
+    def test_string_int(self):
+        self.assertTrue(util.is_float("12"))
+
+    def test_string_complex(self):
+        self.assertFalse(util.is_float("12 + 1j"))
+
+    def test_string_none(self):
+        self.assertFalse(util.is_float("None"))
+
+    def test_string_not_numeric(self):
+        self.assertFalse(util.is_float("abc"))
+
+    def test_none(self):
+        with self.assertRaises(TypeError):
+            util.is_float(None)
+
+    def test_array(self):
+        with self.assertRaises(TypeError):
+            util.is_float(np.ones(3))
+
+
 class TestValidContainer(unittest.TestCase):
     """
     Tests on valid_container.
@@ -812,6 +843,7 @@ class TestValidNdArray(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    run_tests(TestIsFloat)
     run_tests(TestValidContainer)
     run_tests(TestValidKwargs)
     run_tests(TestValidItem)


### PR DESCRIPTION
## Description

I added one step in post-processing, where line cuts through the reconstructed modulus are generated in Z, Y, X, and the gradient of the line cuts is fitted with a Gaussian line shape to estimate the resolution.

![linecut_amp](https://user-images.githubusercontent.com/44344327/162183767-c7d8f512-672b-4d9e-8a2b-9057d114f739.png)
![linecut_amp_fits](https://user-images.githubusercontent.com/44344327/162183772-291d83f9-6d09-449a-9d24-7ef05315b93c.png)

Fixes #195 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?

I added unit tests and ran the example dataset.

## Checklist:

- [X] I have made corresponding changes to the documentation
- [X] I have added corresponding unit tests
- [X] I have run ``doit`` and all tasks have passed