### PR TITLE
Implement multiprocessing for the preprocessing

### DIFF
--- a/bcdi/examples/S11_config_preprocessing.yml
+++ b/bcdi/examples/S11_config_preprocessing.yml
@@ -21,6 +21,9 @@ backend: "Qt5Agg"
 # parameters used in masking #
 ##############################
 flag_interact: True  # True to interact with plots, False to close it automatically
+mask: None  # path to a file containing a 3D mask array of the same size as data would
+# have during interactive masking (binned & cropped/padded). It will be used to mask the
+# data if flag_interact is False, or as an initial mask if flag_interact is True.
 background_plot: "0.5"  # in level of grey in [0,1], 0 being dark.
 # For visual comfort during masking
 #########################################################

--- a/bcdi/graph/graph_utils.py
+++ b/bcdi/graph/graph_utils.py
@@ -8,6 +8,7 @@
 """Functions related to visualization."""
 
 from lmfit import minimize, Parameters
+import logging
 import numpy as np
 from numbers import Real
 from mpl_toolkits.axes_grid1 import make_axes_locatable
@@ -33,6 +34,7 @@ from bcdi.utils import utilities as util
 from bcdi.utils import validation as valid
 
 default_cmap = ColormapFactory(colormap="turbo").cmap
+module_logger = logging.getLogger(__name__)
 
 
 def close_event(event):
@@ -2392,6 +2394,7 @@ def save_to_vti(
     tuple_fieldnames,
     origin=(0, 0, 0),
     amplitude_threshold=0.01,
+    **kwargs,
 ):
     """
     Save arrays defined by their name in a single vti file.
@@ -2410,11 +2413,16 @@ def save_to_vti(
     :param origin: tuple of points for vtk SetOrigin()
     :param amplitude_threshold: lower threshold for saving the reconstruction
      modulus (save memory space)
+    :param kwargs:
+
+     - 'logger': an optional logger
+
     :return: nothing
     """
     import vtk
     from vtk.util import numpy_support
 
+    logger = kwargs.get("logger", module_logger)
     #########################
     # check some parameters #
     #########################
@@ -2465,7 +2473,7 @@ def save_to_vti(
         ] = 0  # theshold low amplitude values in order to save disk space
         is_amp = True
     except ValueError:
-        print('"amp" not in fieldnames, will save arrays without thresholding')
+        logger.info('"amp" not in fieldnames, will save arrays without thresholding')
         index_first = 0
         first_array = tuple_array[0]
         is_amp = False

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -93,7 +93,7 @@ def center_fft(
     # check and load kwargs
     valid.valid_kwargs(
         kwargs=kwargs,
-        allowed_kwargs={"fix_bragg", "fix_size", "pad_size", "q_values"},
+        allowed_kwargs={"fix_bragg", "fix_size", "logger", "pad_size", "q_values"},
         name="kwargs",
     )
     fix_bragg = kwargs.get("fix_bragg")
@@ -746,7 +746,7 @@ def grid_bcdi_labframe(
     # check and load kwargs
     valid.valid_kwargs(
         kwargs=kwargs,
-        allowed_kwargs={"cmap", "fill_value", "reference_axis"},
+        allowed_kwargs={"cmap", "fill_value", "logger", "reference_axis"},
         name="kwargs",
     )
     cmap = kwargs.get("cmap", "turbo")
@@ -1114,7 +1114,7 @@ def load_bcdi_data(
     # check and load kwargs
     valid.valid_kwargs(
         kwargs=kwargs,
-        allowed_kwargs={"photon_threshold", "frames_pattern"},
+        allowed_kwargs={"photon_threshold", "frames_pattern", "logger"},
         name="kwargs",
     )
     photon_threshold = kwargs.get("photon_threshold", 0)
@@ -1218,7 +1218,7 @@ def reload_bcdi_data(
     # check and load kwargs
     valid.valid_kwargs(
         kwargs=kwargs,
-        allowed_kwargs={"photon_threshold"},
+        allowed_kwargs={"logger", "photon_threshold"},
         name="kwargs",
     )
     photon_threshold = kwargs.get("photon_threshold", 0)

--- a/bcdi/preprocessing/preprocessing_runner.py
+++ b/bcdi/preprocessing/preprocessing_runner.py
@@ -110,7 +110,7 @@ def run(prm: Dict[str, Any]) -> None:
     # start looping over scans #
     ############################
     nb_scans = len(prm["scans"])
-    if ["multiprocessing"]:
+    if prm["multiprocessing"]:
         mp.freeze_support()
         pool = mp.Pool(
             processes=min(mp.cpu_count(), nb_scans)

--- a/bcdi/preprocessing/preprocessing_runner.py
+++ b/bcdi/preprocessing/preprocessing_runner.py
@@ -110,7 +110,7 @@ def run(prm: Dict[str, Any]) -> None:
     # start looping over scans #
     ############################
     nb_scans = len(prm["scans"])
-    if False:  # prm["multiprocessing"]:
+    if ["multiprocessing"]:
         mp.freeze_support()
         pool = mp.Pool(
             processes=min(mp.cpu_count(), nb_scans)

--- a/bcdi/preprocessing/preprocessing_runner.py
+++ b/bcdi/preprocessing/preprocessing_runner.py
@@ -110,7 +110,7 @@ def run(prm: Dict[str, Any]) -> None:
     # start looping over scans #
     ############################
     nb_scans = len(prm["scans"])
-    if prm["multiprocessing"]:
+    if False:  # prm["multiprocessing"]:
         mp.freeze_support()
         pool = mp.Pool(
             processes=min(mp.cpu_count(), nb_scans)

--- a/bcdi/preprocessing/process_scan.py
+++ b/bcdi/preprocessing/process_scan.py
@@ -837,8 +837,9 @@ def process_scan(
     ########################################################
     # load an optional mask from the config and combine it #
     ########################################################
-    if prm.get("mask") is not None:
-        config_mask, _ = util.load_file(prm.get("mask"))
+    mask_file = prm.get("mask")
+    if isinstance(mask_file, str):
+        config_mask, _ = util.load_file(mask_file)
         valid.valid_ndarray(config_mask, shape=data.shape)
         config_mask[np.nonzero(config_mask)] = 1
         mask = np.multiply(mask, config_mask.astype(mask.dtype))

--- a/bcdi/preprocessing/process_scan.py
+++ b/bcdi/preprocessing/process_scan.py
@@ -37,6 +37,7 @@ import bcdi.preprocessing.bcdi_utils as bu
 from bcdi.utils.constants import AXIS_TO_ARRAY
 from bcdi.utils.snippets_logging import FILE_FORMATTER
 import bcdi.utils.utilities as util
+import bcdi.utils.validation as valid
 
 logger = logging.getLogger(__name__)
 
@@ -830,6 +831,15 @@ def process_scan(
                 tuple_fieldnames="int",
                 origin=(qx0, qz0, qy0),
             )
+
+    ########################################################
+    # load an optional mask from the config and combine it #
+    ########################################################
+    if prm.get("mask") is not None:
+        config_mask = util.load_file(prm.get("mask"))
+        valid.valid_ndarray(config_mask, shape=data.shape)
+        config_mask[np.nonzero(config_mask)] = 1
+        mask = np.multiply(mask, config_mask.astype(mask.dtype))
 
     if prm["flag_interact"]:
         plt.ioff()

--- a/bcdi/preprocessing/process_scan.py
+++ b/bcdi/preprocessing/process_scan.py
@@ -266,6 +266,7 @@ def process_scan(
         binning=prm["phasing_binning"],
         preprocessing_binning=prm["preprocessing_binning"],
         linearity_func=prm["linearity_func"],
+        logger=logger,
     )
 
     # initialize the paths
@@ -384,12 +385,14 @@ def process_scan(
                     binning=setup.detector.binning,
                     debugging=False,
                     cmap=prm["colormap"].cmap,
+                    logger=logger,
                 )
                 mask = util.bin_data(
                     mask,
                     binning=setup.detector.binning,
                     debugging=False,
                     cmap=prm["colormap"].cmap,
+                    logger=logger,
                 )
                 mask[np.nonzero(mask)] = 1
                 if len(q_values) != 0:
@@ -420,6 +423,7 @@ def process_scan(
                 debugging=prm["debug"],
                 normalize=prm["normalize_flux"],
                 photon_threshold=prm["loading_threshold"],
+                logger=logger,
             )
 
     else:  # new masking process
@@ -439,6 +443,7 @@ def process_scan(
             normalize=prm["normalize_flux"],
             debugging=prm["debug"],
             photon_threshold=prm["loading_threshold"],
+            logger=logger,
         )
 
     nz, ny, nx = np.shape(data)
@@ -463,6 +468,7 @@ def process_scan(
                 peak_method="maxcom",
                 roi=setup.detector.roi,
                 binning=setup.detector.binning,
+                logger=logger,
             )
 
         if prm["bragg_peak"] is None:
@@ -478,6 +484,7 @@ def process_scan(
             roi_center=roi_center,
             tilt_values=setup.incident_angles,
             savedir=setup.detector.savedir,
+            logger=logger,
         )
         setup.correct_detector_angles(bragg_peak_position=prm["bragg_peak"])
         prm["outofplane_angle"] = setup.outofplane_angle
@@ -606,6 +613,7 @@ def process_scan(
                     hxrd=hxrd,
                     debugging=prm["debug"],
                     cmap=prm["colormap"].cmap,
+                    logger=logger,
                 )
             else:  # 'linearization'
                 # for q values, the frame used is
@@ -622,6 +630,7 @@ def process_scan(
                     debugging=prm["debug"],
                     fill_value=(0, prm["fill_value_mask"]),
                     cmap=prm["colormap"].cmap,
+                    logger=logger,
                 )
                 prm["transformation_matrix"] = transfer_matrix
             nz, ny, nx = data.shape
@@ -690,6 +699,7 @@ def process_scan(
         fix_bragg=prm["bragg_peak"],
         fix_size=prm["fix_size"],
         q_values=q_values,
+        logger=logger,
     )
 
     starting_frame = [
@@ -832,6 +842,7 @@ def process_scan(
                 tuple_array=data,
                 tuple_fieldnames="int",
                 origin=(qx0, qz0, qy0),
+                logger=logger,
             )
 
     ########################################################
@@ -1162,12 +1173,14 @@ def process_scan(
             (setup.detector.binning[0], 1, 1),
             debugging=False,
             cmap=prm["colormap"].cmap,
+            logger=logger,
         )
         mask = util.bin_data(
             mask,
             (setup.detector.binning[0], 1, 1),
             debugging=False,
             cmap=prm["colormap"].cmap,
+            logger=logger,
         )
         mask[np.nonzero(mask)] = 1
         if not prm["use_rawdata"] and len(q_values) != 0:
@@ -1191,12 +1204,14 @@ def process_scan(
         output_shape=final_shape,
         crop_center=crop_center,
         cmap=prm["colormap"].cmap,
+        logger=logger,
     )
     mask = util.crop_pad(
         mask,
         output_shape=final_shape,
         crop_center=crop_center,
         cmap=prm["colormap"].cmap,
+        logger=logger,
     )
     logger.info(f"Data size after considering FFT shape requirements: {data.shape}")
     nz, ny, nx = data.shape

--- a/bcdi/preprocessing/process_scan.py
+++ b/bcdi/preprocessing/process_scan.py
@@ -1023,14 +1023,12 @@ def process_scan(
     mask[np.nonzero(mask)] = 1
     data[mask == 1] = 0
 
-    ########################################################
-    # save the projected mask as hotpixels for later reuse #
-    ########################################################
-    hotpixels = mask.sum(axis=0)
-    hotpixels[np.nonzero(hotpixels)] = 1
+    #############################################
+    # save the interactive mask for later reuse #
+    #############################################
     np.savez_compressed(
-        setup.detector.savedir + f"S{scan_nb}_hotpixels",
-        hotpixels=hotpixels.astype(int),
+        setup.detector.savedir + f"S{scan_nb}_interactive_mask",
+        hotpixels=mask.astype(int),
     )
 
     ###############################################

--- a/bcdi/utils/parameters.py
+++ b/bcdi/utils/parameters.py
@@ -664,6 +664,10 @@ def valid_param(key: str, value: Any) -> Tuple[Any, bool]:
             allow_none=True,
             name=key,
         )
+    elif key == "mask":
+        valid.valid_container(value, container_types=str, allow_none=True, name=key)
+        if value is not None and not os.path.isfile(value):
+            raise ValueError(f"The file '{value}' does not exist")
     elif key == "median_filter":
         allowed = {"median", "interp_isolated", "mask_isolated", "skip"}
         if value not in allowed:

--- a/bcdi/utils/parameters.py
+++ b/bcdi/utils/parameters.py
@@ -300,6 +300,11 @@ class PreprocessingChecker(ConfigChecker):
                 "non-interactive backend 'agg' not compatible with the "
                 "interactive masking GUI"
             )
+        if (
+            self._checked_params["flag_interact"]
+            or self._checked_params["reload_previous"]
+        ):
+            self._checked_params["multiprocessing"] = False
 
 
 class PostprocessingChecker(ConfigChecker):

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -111,10 +111,12 @@ def bin_data(array, binning, debugging=False, **kwargs):
     :param kwargs:
 
      - 'cmap': str, name of the colormap
+     - 'logger': an optional logger
 
     :return: the binned array
     """
     cmap = kwargs.get("cmap", "turbo")
+    logger = kwargs.get("logger", module_logger)
     valid.valid_ndarray(arrays=array, ndim=(1, 2, 3))
     ndim = array.ndim
     if isinstance(binning, int):
@@ -154,8 +156,8 @@ def bin_data(array, binning, debugging=False, **kwargs):
         raise ValueError("Array should be 1D, 2D, or 3D")
 
     if debugging:
-        print("array shape after cropping but before binning:", array.shape)
-        print("array shape after binning:", newarray.shape)
+        logger.info(f"array shape after cropping but before binning: {array.shape}")
+        logger.info(f"array shape after binning: {newarray.shape}")
         gu.combined_plots(
             tuple_array=(array, newarray),
             tuple_sum_frames=False,
@@ -280,9 +282,11 @@ def crop_pad(
     :param kwargs:
 
      - 'cmap': str, name of the colormap
+     - 'logger': an optional logger
 
     :return: myobj cropped or padded with zeros
     """
+    logger = kwargs.get("logger", module_logger)
     valid.valid_ndarray(arrays=array, ndim=3)
     valid.valid_container(
         output_shape,
@@ -305,7 +309,7 @@ def crop_pad(
         raise ValueError("crop_center should be a list or tuple of three indices")
 
     if debugging:
-        print(f"array shape before crop/pad = {array.shape}")
+        logger.info(f"array shape before crop/pad = {array.shape}")
         gu.multislices_plot(
             abs(array),
             sum_frames=True,
@@ -354,7 +358,7 @@ def crop_pad(
         ]
 
     if debugging:
-        print(f"array shape after crop/pad = {newobj.shape}")
+        logger.info(f"array shape after crop/pad = {newobj.shape}")
         gu.multislices_plot(
             abs(newobj),
             sum_frames=True,

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -1181,7 +1181,9 @@ def load_background(background_file):
     return background
 
 
-def load_file(file_path, fieldname=None):
+def load_file(
+    file_path: str, fieldname: Optional[str] = None
+) -> Tuple[np.ndarray, str]:
     """
     Load a file.
 

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,8 +1,17 @@
 Future:
 -------
 
-* Implement logging in ``bcdi_preprocessing_BCDI.py``. For each scan, a separate log
-  file is created and saved in `save_dir` along with processing results.
+* Use multiprocessing for the analysis of several scans in `bcdi_preprocessing_BCDI.py`.
+  In this case, `flag_interact` has to be False, and an optional mask can be loaded to
+  be applied on the data. The use case is when one runs once the preprocessing manually
+  and creates such a mask (it is saved automatically after the interactive masking as
+  `interactive_mask.npz`), and afterwards wants to apply it to a series of scans
+  measured in the same geometry. For each scan, a separate log file is created and
+  saved in `save_dir` along with processing results.
+
+* A parameter `mask` was added to the config file for preprocessing. The loaded mask
+  will be combined with the one generated automatically and used independently of
+  `flag_interact`.
 
 * Use multiprocessing for the analysis of several scans in ``bcdi_strain.py``. The
   use-case is when there is a series of scans measured with the same geometry and only

--- a/scripts/preprocessing/bcdi_preprocess_BCDI.py
+++ b/scripts/preprocessing/bcdi_preprocess_BCDI.py
@@ -72,6 +72,10 @@ Usage:
 
     :param flag_interact: e.g. True
      True to interact with plots, False to close it automatically
+    :param mask: e.g. "path_to/mask.npz"
+     path to a file containing a 3D mask array of the same shape as the data would have
+     during interactive masking (binned & cropped/padded). It will be used to mask the
+     data if flag_interact is False, or as an initial mask if flag_interact is True.
     :param background_plot: e.g. "0.5"
      background color for the GUI in level of grey in [0,1], 0 being dark. For visual
      comfort during interactive masking.


### PR DESCRIPTION
Add the option to preprocess multiple scans using multiprocessing. In this case, `flag_interact` has to be False, and an optional mask can be loaded to be applied on the data. The use case is when one runs once the preprocessing manually and creates such a mask (it is saved automatically after the interactive masking as `interactive_mask.npz`), and afterwards wants to apply it to a series of scans measured in the same geometry.

The parameter `mask` was therefore added to the config files. The loaded mask will be used independently of `flag_interact`.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- 
## How has this been tested?

Test with two scans, with and without mask.

## Checklist:

- [X] I have made corresponding changes to the documentation
- [X] I have run ``doit`` and all tasks have passed
