### PR TITLE
Was using monitor even if "skip"

### DIFF
--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -1219,7 +1219,7 @@ def reload_bcdi_data(
     # check and load kwargs
     valid.valid_kwargs(
         kwargs=kwargs,
-        allowed_kwargs={"logger", "photon_threshold"},
+        allowed_kwargs={"logger", "photon_threshold", "logfile"},
         name="kwargs",
     )
     photon_threshold = kwargs.get("photon_threshold", 0)
@@ -1230,8 +1230,6 @@ def reload_bcdi_data(
         name="photon_threshold",
     )
 
-    normalize_method = "monitor" if normalize else "skip"
-
     nbz, nby, nbx = data.shape
     frames_logical = np.ones(nbz)
 
@@ -1241,7 +1239,7 @@ def reload_bcdi_data(
     data[data < 0] = 0
 
     # normalize by the incident X-ray beam intensity
-    if normalize_method == "skip":
+    if normalize == "skip":
         logger.info("Skip intensity normalization")
         monitor = []
     else:  # use the default monitor of the beamline
@@ -1250,7 +1248,7 @@ def reload_bcdi_data(
             setup=setup,
         )
 
-        logger.info(f"Intensity normalization using {normalize_method}")
+        logger.info(f"Intensity normalization using {normalize}")
         data, monitor = loader.normalize_dataset(
             array=data,
             monitor=monitor,

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -1202,7 +1202,8 @@ def reload_bcdi_data(
     :param mask: the 3D mask array
     :param scan_number: the scan number to load
     :param setup: an instance of the class Setup
-    :param normalize: set to True to normalize by the default monitor of the beamline
+    :param normalize: set to "monitor" to normalize by the default monitor of
+     the beamline, otherwise set to "skip"
     :param debugging:  set to True to see plots
     :parama kwargs:
 
@@ -1219,7 +1220,7 @@ def reload_bcdi_data(
     # check and load kwargs
     valid.valid_kwargs(
         kwargs=kwargs,
-        allowed_kwargs={"logger", "photon_threshold", "logfile"},
+        allowed_kwargs={"logger", "photon_threshold"},
         name="kwargs",
     )
     photon_threshold = kwargs.get("photon_threshold", 0)

--- a/bcdi/preprocessing/process_scan.py
+++ b/bcdi/preprocessing/process_scan.py
@@ -282,7 +282,7 @@ def process_scan(
         template_imagefile=prm["template_imagefile"][scan_idx],
     )
 
-    logfile = setup.create_logfile(
+    setup.create_logfile(
         scan_number=scan_nb,
         root_folder=prm["root_folder"],
         filename=setup.detector.specfile,

--- a/bcdi/preprocessing/process_scan.py
+++ b/bcdi/preprocessing/process_scan.py
@@ -416,7 +416,6 @@ def process_scan(
                     del numz, numy, numx
         else:  # the data is in the detector frame
             data, mask, frames_logical, monitor = bu.reload_bcdi_data(
-                logfile=logfile,
                 scan_number=scan_nb,
                 data=data,
                 mask=mask,


### PR DESCRIPTION
There was a pb with how the argument was loaded. It is a string and not a boolean, so the monitor would always be used.