### PR TITLE
Bug: provide the correct number of motor positions to xrayutilities Qconv for SIXS

### DIFF
--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -2235,7 +2235,7 @@ class BeamlineSIXS(Beamline):
         return util.bin_parameters(
             binning=setup.detector.binning[0],
             nb_frames=nb_frames,
-            params=[beta, mu, gamma, delta, energy],
+            params=[beta, mu, beta, gamma, delta, energy],
         )
 
     def transformation_matrix(

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,8 +1,8 @@
 Future:
 -------
 
-* Bug: provide the correct number of motor position to xrayutilities Qconv for SIXS
-  (beta needs to be duplicated because it is also below the detector circles.)
+* Bug: provide the correct number of motor positions to xrayutilities Qconv for the SIXS
+  beamline (beta needs to be duplicated because it is also below the detector circles.)
 
 * Modify the saturation threshold of the Eiger2M detector from 1e6 to 1e7 photons.
 

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,6 +1,9 @@
 Future:
 -------
 
+* Bug: provide the correct number of motor position to xrayutilities Qconv for SIXS
+  (beta needs to be duplicated because it is also below the detector circles.)
+
 * Modify the saturation threshold of the Eiger2M detector from 1e6 to 1e7 photons.
 
 * The log file will be created in `save_dir` if this parameter is defined, otherwise


### PR DESCRIPTION
## Description

One needs to return twice beta in BeamlineSIXS.process_positions because beta is also below the detector circles, as correctly
defined in xrayutilities Qconv object.

Fixes #267 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Test with a dataset from SIXS, the script runs correctly.

## Checklist:

- [X] I have run ``doit`` and all tasks have passed
