### PR TITLE
FEAT: Add option to skip unwrapping

### DIFF
--- a/bcdi/examples/S11_config_postprocessing.yml
+++ b/bcdi/examples/S11_config_postprocessing.yml
@@ -1,10 +1,10 @@
 scans: 11  # scan number or list of scan numbers
-root_folder: "C:/Users/Jerome/Documents/data/CXIDB-I182/CH4760/"
+root_folder: "C:/Users/carnisj/Documents/data/CXIDB-I182/CH4760/"
 # folder of the experiment, where all scans are stored
-save_dir: "C:/Users/Jerome/Documents/data/CXIDB-I182/CH4760/test/"
+save_dir: "C:/Users/carnisj/Documents/data/CXIDB-I182/CH4760/test/"
 # images will be saved here, leave it to None otherwise (default to data directory's
 # parent). Provide a single path or a list of paths for multiple scans.
-data_dir: "C:/Users/Jerome/Documents/data/CXIDB-I182/CH4760/S11/"
+data_dir: "C:/Users/carnisj/Documents/data/CXIDB-I182/CH4760/S11/"
 # leave None to use the beamline default, or provide the full path to the data. Provide
 # a list of paths for multiple scans.
 sample_name: "S"
@@ -72,6 +72,9 @@ save_frame: "crystal"  # 'crystal', 'laboratory' or 'lab_flat_sample'
 # (which is done in the crystal frame along ref_axis_q)
 isosurface_strain: 0.3  # threshold use for removing the outer layer
 # (strain is undefined at the exact surface voxel)
+skip_unwrap: False
+# If 'skip_unwrap', it will not unwrap the phase. It can be used when there is a defect
+# and phase unwrapping does not work well.
 strain_method: "default"  # 'default' or 'defect'.
 # If 'defect', will offset the phase in a loop and keep the smallest
 # magnitude value for the strain.

--- a/bcdi/postprocessing/postprocessing_runner.py
+++ b/bcdi/postprocessing/postprocessing_runner.py
@@ -95,6 +95,7 @@ def run(prm: Dict[str, Any]) -> None:
             "save": True,
             "save_rawdata": False,
             "save_support": False,
+            "skip_unwrap": False,
             "sort_method": "variance/mean",
             "strain_method": "default",
             "strain_range": 0.002,

--- a/bcdi/postprocessing/postprocessing_utils.py
+++ b/bcdi/postprocessing/postprocessing_utils.py
@@ -2255,7 +2255,7 @@ def unwrap(
     # 0 is a valid entry for ma.masked_array
     phase_wrapped: np.ndarray = ma.masked_array(np.angle(obj), mask=unwrap_support)
 
-    plot_title = "applying support threshold only" if skip_unwrap else "unwrapping"
+    plot_title = "applying support threshold\n" if skip_unwrap else "unwrapping"
     if debugging and ndim == 3:
         gu.multislices_plot(
             phase_wrapped.data,
@@ -2276,7 +2276,7 @@ def unwrap(
         gu.multislices_plot(
             phase_unwrapped,
             plot_colorbar=True,
-            title=f"Before {plot_title}",
+            title=f"After {plot_title}",
             reciprocal_space=reciprocal_space,
             is_orthogonal=is_orthogonal,
             cmap=kwargs.get("cmap", "turbo"),

--- a/bcdi/postprocessing/postprocessing_utils.py
+++ b/bcdi/postprocessing/postprocessing_utils.py
@@ -2209,7 +2209,9 @@ def tukey_window(shape, alpha=np.array([0.5, 0.5, 0.5])):
     return tukey3
 
 
-def unwrap(obj, support_threshold, seed=0, debugging=True, **kwargs):
+def unwrap(
+    obj, support_threshold, seed=0, skip_unwrap: bool = False, debugging=True, **kwargs
+):
     """
     Unwrap the phase of a complex object.
 
@@ -2220,6 +2222,8 @@ def unwrap(obj, support_threshold, seed=0, debugging=True, **kwargs):
     :param support_threshold: relative threshold used to define a support from abs(obj)
     :param seed: int, random seed. Use always the same value if you want a
      deterministic behavior.
+    :param skip_unwrap: True to apply only the support_threshold to the phase but skip
+     the unwrapping part.
     :param debugging: set to True to see plots
     :param kwargs:
 
@@ -2247,28 +2251,32 @@ def unwrap(obj, support_threshold, seed=0, debugging=True, **kwargs):
 
     ndim = obj.ndim
     unwrap_support = np.ones(obj.shape, dtype=int)
-    unwrap_support[
-        abs(obj) > support_threshold * abs(obj).max()
-    ] = 0  # 0 is a valid entry for ma.masked_array
-    phase_wrapped = ma.masked_array(np.angle(obj), mask=unwrap_support)
+    unwrap_support[abs(obj) > support_threshold * abs(obj).max()] = 0
+    # 0 is a valid entry for ma.masked_array
+    phase_wrapped: np.ndarray = ma.masked_array(np.angle(obj), mask=unwrap_support)
 
+    plot_title = "applying support threshold only" if skip_unwrap else "unwrapping"
     if debugging and ndim == 3:
         gu.multislices_plot(
             phase_wrapped.data,
             plot_colorbar=True,
-            title="Object before unwrapping",
+            title=f"Before {plot_title}",
             reciprocal_space=reciprocal_space,
             is_orthogonal=is_orthogonal,
             cmap=kwargs.get("cmap", "turbo"),
         )
 
-    phase_unwrapped = unwrap_phase(phase_wrapped, wrap_around=False, seed=seed).data
+    if skip_unwrap:
+        phase_unwrapped = phase_wrapped
+    else:
+        phase_unwrapped = unwrap_phase(phase_wrapped, wrap_around=False, seed=seed).data
+
     phase_unwrapped[np.nonzero(unwrap_support)] = 0
     if debugging and ndim == 3:
         gu.multislices_plot(
             phase_unwrapped,
             plot_colorbar=True,
-            title="Object after unwrapping",
+            title=f"Before {plot_title}",
             reciprocal_space=reciprocal_space,
             is_orthogonal=is_orthogonal,
             cmap=kwargs.get("cmap", "turbo"),

--- a/bcdi/postprocessing/process_scan.py
+++ b/bcdi/postprocessing/process_scan.py
@@ -284,37 +284,36 @@ def process_scan(
     ################
     # unwrap phase #
     ################
-    if prm["skip_unwrap"]:
-        phase = np.angle(avg_obj)
-    else:
-        phase, extent_phase = pu.unwrap(
-            avg_obj,
-            support_threshold=prm["threshold_unwrap_refraction"],
-            debugging=prm["debug"],
+    phase, extent_phase = pu.unwrap(
+        avg_obj,
+        support_threshold=prm["threshold_unwrap_refraction"],
+        skip_unwrap=prm["skip_unwrap"],
+        debugging=prm["debug"],
+        reciprocal_space=False,
+        is_orthogonal=prm["is_orthogonal"],
+        cmap=prm["colormap"].cmap,
+    )
+
+    logger.info(
+        "Extent of the phase over an extended support (ceil(phase range)) ~ "
+        f"{int(extent_phase)} (rad)",
+    )
+    if not prm["skip_unwrap"]:
+        phase = util.wrap(
+            phase, start_angle=-extent_phase / 2, range_angle=extent_phase
+        )
+    if prm["debug"]:
+        gu.multislices_plot(
+            phase,
+            width_z=2 * zrange,
+            width_y=2 * yrange,
+            width_x=2 * xrange,
+            plot_colorbar=True,
+            title="Phase after unwrap + wrap",
             reciprocal_space=False,
             is_orthogonal=prm["is_orthogonal"],
             cmap=prm["colormap"].cmap,
         )
-
-        logger.info(
-            "Extent of the phase over an extended support (ceil(phase range)) ~ "
-            f"{int(extent_phase)} (rad)",
-        )
-        phase = util.wrap(
-            phase, start_angle=-extent_phase / 2, range_angle=extent_phase
-        )
-        if prm["debug"]:
-            gu.multislices_plot(
-                phase,
-                width_z=2 * zrange,
-                width_y=2 * yrange,
-                width_x=2 * xrange,
-                plot_colorbar=True,
-                title="Phase after unwrap + wrap",
-                reciprocal_space=False,
-                is_orthogonal=prm["is_orthogonal"],
-                cmap=prm["colormap"].cmap,
-            )
 
     #############################################
     # phase ramp removal before phase filtering #
@@ -704,18 +703,21 @@ def process_scan(
     ####################
     # Phase unwrapping #
     ####################
-    if prm["skip_unwrap"]:
-        phase = np.angle(obj_ortho)
-    else:
-        logger.info("Phase unwrapping")
-        phase, extent_phase = pu.unwrap(
-            obj_ortho,
-            support_threshold=prm["threshold_unwrap_refraction"],
-            debugging=True,
-            reciprocal_space=False,
-            is_orthogonal=True,
-            cmap=prm["colormap"].cmap,
-        )
+    log_text = (
+        "Applying support threshold to the phase"
+        if prm["skip_unwrap"]
+        else "Phase unwrapping"
+    )
+    logger.info(log_text)
+    phase, extent_phase = pu.unwrap(
+        obj_ortho,
+        support_threshold=prm["threshold_unwrap_refraction"],
+        skip_unwrap=prm["skip_unwrap"],
+        debugging=True,
+        reciprocal_space=False,
+        is_orthogonal=True,
+        cmap=prm["colormap"].cmap,
+    )
     amp = abs(obj_ortho)
     del obj_ortho
     gc.collect()

--- a/bcdi/utils/parameters.py
+++ b/bcdi/utils/parameters.py
@@ -400,6 +400,7 @@ def valid_param(key: str, value: Any) -> Tuple[Any, bool]:
         "save_to_mat",
         "save_to_npz",
         "save_to_vti",
+        "skip_unwrap",
         "simulation",
         "use_rawdata",
     }:

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,6 +1,10 @@
 Future:
 -------
 
+* Add option to skip unwrapping: add the boolean parameter `skip_unwrap` to the
+  postprocessing. This can be useful when there are defects in the crystal and phase
+  unwrapping does not work well.
+
 * Bug: provide the correct number of motor positions to xrayutilities Qconv for the SIXS
   beamline (beta needs to be duplicated because it is also below the detector circles.)
 

--- a/scripts/postprocessing/bcdi_strain.py
+++ b/scripts/postprocessing/bcdi_strain.py
@@ -144,6 +144,9 @@ Usage:
     :param isosurface_strain: e.g. 0.2
      threshold use for removing the outer layer (the strain is undefined at the exact
      surface voxel)
+    :param skip_unwrap: e.g. False
+     If 'skip_unwrap', it will not unwrap the phase. It can be used when there is a
+     defect and phase unwrapping does not work well.
     :param strain_method: e.g. "default"
      how to calculate the strain, available options:
 


### PR DESCRIPTION
Add a parameter `skip_unwrap` to the config files, so that the user can skip phase unwrapping. This can be useful when there are defects in the crystal and phase unwrapping does not work well.

- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?

I ran the example dataset without phase unwrapping, results as expected.

## Checklist:

- [X] I have run ``doit`` and all tasks have passed
