### PR TITLE
Add version function

### DIFF
--- a/bcdi/__init__.py
+++ b/bcdi/__init__.py
@@ -8,22 +8,26 @@
 """The main bcdi package, which contains the whole framework."""
 __version__ = "0.2.7"
 
+from subprocess import PIPE, Popen
 
-def get_git_version():
+
+def get_git_version() -> str:
     """
-    Get the full version name with git hash, e.g. "2020.1-65-g958b7254-dirty"
+    Get the full version name with git hash, e.g. "2020.1-65-g958b7254-dirty".
+
     Only works if the current directory is part of the git repository.
+
     :return: the version name
     """
-    from subprocess import Popen, PIPE
-
     try:
         p = Popen(
             ["git", "describe", "--tags", "--dirty", "--always"],
             stdout=PIPE,
             stderr=PIPE,
         )
-        return p.stdout.readlines()[0].strip().decode("UTF-8")
+        if p.stdout is not None:
+            return p.stdout.readlines()[0].strip().decode("UTF-8")
+        raise IndexError
     except IndexError:
         # in distributed & installed versions this is replaced by a string
         __git_version_static__ = "git_version_placeholder"

--- a/bcdi/__init__.py
+++ b/bcdi/__init__.py
@@ -24,7 +24,7 @@ def get_git_version():
             stderr=PIPE,
         )
         return p.stdout.readlines()[0].strip().decode("UTF-8")
-    except:
+    except IndexError:
         # in distributed & installed versions this is replaced by a string
         __git_version_static__ = "git_version_placeholder"
         if "placeholder" in __git_version_static__:

--- a/bcdi/__init__.py
+++ b/bcdi/__init__.py
@@ -7,3 +7,22 @@
 #         Jerome Carnis, carnis_jerome@yahoo.fr
 """The main bcdi package, which contains the whole framework."""
 __version__ = "0.2.7"
+
+
+def get_git_version():
+    """
+    Get the full version name with git hash, e.g. "2020.1-65-g958b7254-dirty"
+    Only works if the current directory is part of the git repository.
+    :return: the version name
+    """
+    from subprocess import Popen, PIPE
+    try:
+        p = Popen(['git', 'describe', '--tags', '--dirty', '--always'],
+                  stdout=PIPE, stderr=PIPE)
+        return p.stdout.readlines()[0].strip().decode("UTF-8")
+    except:
+        # in distributed & installed versions this is replaced by a string
+        __git_version_static__ = "git_version_placeholder"
+        if "placeholder" in __git_version_static__:
+            return __version__
+        return __git_version_static__

--- a/bcdi/__init__.py
+++ b/bcdi/__init__.py
@@ -16,9 +16,13 @@ def get_git_version():
     :return: the version name
     """
     from subprocess import Popen, PIPE
+
     try:
-        p = Popen(['git', 'describe', '--tags', '--dirty', '--always'],
-                  stdout=PIPE, stderr=PIPE)
+        p = Popen(
+            ["git", "describe", "--tags", "--dirty", "--always"],
+            stdout=PIPE,
+            stderr=PIPE,
+        )
         return p.stdout.readlines()[0].strip().decode("UTF-8")
     except:
         # in distributed & installed versions this is replaced by a string


### PR DESCRIPTION
I added the version function that may work to get the commit hash saved in the version.

It works for me on my personal laptop but not on slurm ...

You should try it 

I don't know how to want to use it, maybe : 

```python
version = "0.2.7"


def get_git_version():
    """
    Get the full version name with git hash, e.g. "2020.1-65-g958b7254-dirty"
    Only works if the current directory is part of the git repository.
    :return: the version name
    """
    from subprocess import Popen, PIPE
    try:
        p = Popen(['git', 'describe', '--tags', '--dirty', '--always'],
                  stdout=PIPE, stderr=PIPE)
        return p.stdout.readlines()[0].strip().decode("UTF-8")
    except:
        # in distributed & installed versions this is replaced by a string
        __git_version_static__ = "git_version_placeholder"
        if "placeholder" in __git_version_static__:
            return version
        return __git_version_static__


__version__ = get_git_version()
```