### PR TITLE
Move the correction of detector angles before the calculation of q_bragg

### DIFF
--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,6 +1,10 @@
 Future:
 -------
 
+* Move the calculation of corrected detector angles before the calculation of `q_lab`
+  in `postprocessing.process_scan`. Previously it was using the values from the beamline
+  log file, resulting in a small discrepancy.
+
 * Add a placeholder "-f" command line parameter to host the automatically generated
  parameter in Jupyter notebooks (path of the kernel json file).
 

--- a/tests/postprocessing/test_postprocessing_runner.py
+++ b/tests/postprocessing/test_postprocessing_runner.py
@@ -46,8 +46,8 @@ class TestRun(unittest.TestCase):
             )
 
     def test_run(self):
-        expected_q_com = [0, 2.77555, 0]
-        expected_volume = 23217408
+        expected_q_com = [0, 2.770848, 0]
+        expected_volume = 23232528
         with tempfile.TemporaryDirectory() as tmpdir:
             self.args = self.parser.load_arguments()
             self.args["save_dir"] = (tmpdir,)


### PR DESCRIPTION
The correction of detector angles has been moved before the calculation of q_bragg, so that the latter uses the corrected values.

Fixes #282 

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- [X] I have made corresponding changes to the documentation
- [X] I have added corresponding unit tests
- [X ] I have run ``doit`` and all tasks have passed
