### PR TITLE
Bug: fix binning value of first axis in `find_bragg`

### DIFF
--- a/bcdi/experiment/detector.py
+++ b/bcdi/experiment/detector.py
@@ -182,7 +182,9 @@ class Detector(ABC):
         self.saturation_threshold = None
 
         # property used to track the binning factor throughout data processing
-        self.current_binning = [1, 1, 1]
+        # the starting point is preprocessing_binning, which is the state of the data
+        # when loaded
+        self.current_binning = list(self.preprocessing_binning)
 
     @property
     def binning(self):

--- a/bcdi/experiment/detector.py
+++ b/bcdi/experiment/detector.py
@@ -181,6 +181,9 @@ class Detector(ABC):
         # initialize the threshold for saturation, can be overriden in child classes
         self.saturation_threshold = None
 
+        # property used to track the binning factor throughout data processing
+        self.current_binning = [1, 1, 1]
+
     @property
     def binning(self):
         """
@@ -214,6 +217,28 @@ class Detector(ABC):
         if not isinstance(beamline, str):
             raise TypeError("beamline should be a string")
         return self._counter_table.get(beamline)
+
+    @property
+    def current_binning(self):
+        """
+        Current binning factor of the dataset.
+
+        Tuple of three positive integers corresponding to the current binning of the
+        data in the processing pipeline.
+        """
+        return self._current_binning
+
+    @current_binning.setter
+    def current_binning(self, value):
+        valid.valid_container(
+            value,
+            container_types=list,
+            length=3,
+            item_types=int,
+            min_excluded=0,
+            name="Detector.current_binning",
+        )
+        self._current_binning = value
 
     @property
     def datadir(self):

--- a/bcdi/experiment/detector.py
+++ b/bcdi/experiment/detector.py
@@ -978,7 +978,7 @@ class Merlin(Detector):
 
 
 class MerlinSixS(Detector):
-    """Implementation of the Merlin detector for SixS"""
+    """Implementation of the Merlin detector for SixS."""
 
     def __init__(self, name, **kwargs):
         super().__init__(name=name, **kwargs)

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -15,6 +15,7 @@ except ModuleNotFoundError:
 import logging
 import pathlib
 from numbers import Real
+from operator import mul
 from typing import Any, Dict, List, Optional, Tuple, Union, no_type_check
 
 import matplotlib.pyplot as plt
@@ -622,7 +623,7 @@ def center_fft(
 def find_bragg(
     data: np.ndarray,
     roi: Optional[Tuple[int, int, int, int]] = None,
-    binning: Optional[Tuple[int, ...]] = None,
+    binning: Optional[Union[Tuple[int, ...], List[int]]] = None,
     **kwargs,
 ) -> Dict[str, Tuple[int, int, int]]:
     """
@@ -1185,6 +1186,14 @@ def load_bcdi_data(
         )
         rawmask[np.nonzero(rawmask)] = 1
 
+    # update the current binning factor
+    setup.detector.current_binning = list(
+        map(
+            mul,
+            setup.detector.current_binning,
+            (1, setup.detector.binning[1], setup.detector.binning[2]),
+        )
+    )
     ################################################
     # pad the data to the shape defined by the ROI #
     ################################################
@@ -1323,6 +1332,13 @@ def reload_bcdi_data(
             debugging=debugging,
         )
         mask[np.nonzero(mask)] = 1
+        setup.detector.current_binning = list(
+            map(
+                mul,
+                setup.detector.current_binning,
+                (1, setup.detector.binning[1], setup.detector.binning[2]),
+            )
+        )
 
     return data, mask, frames_logical, monitor
 

--- a/bcdi/preprocessing/process_scan.py
+++ b/bcdi/preprocessing/process_scan.py
@@ -22,6 +22,7 @@ import logging
 import os
 import tkinter as tk
 from logging import Logger
+from operator import mul
 from pathlib import Path
 from tkinter import filedialog
 from typing import Any, Dict, List, Optional, Tuple
@@ -381,11 +382,7 @@ def process_scan(
             ] = []  # we assume that crop/pad/centering was already performed
 
             # bin data and mask if needed
-            if (
-                (setup.detector.binning[0] != 1)
-                or (setup.detector.binning[1] != 1)
-                or (setup.detector.binning[2] != 1)
-            ):
+            if any(val != 1 for val in setup.detector.binning):
                 logger.info(
                     f"Binning the reloaded orthogonal data by {setup.detector.binning}"
                 )
@@ -403,6 +400,10 @@ def process_scan(
                     cmap=prm["colormap"].cmap,
                     logger=logger,
                 )
+                setup.detector.current_binning = list(
+                    map(mul, setup.detector.current_binning, setup.detector.binning)
+                )
+
                 mask[np.nonzero(mask)] = 1
                 if len(q_values) != 0:
                     qx = q_values[0]
@@ -475,7 +476,7 @@ def process_scan(
             peaks = bu.find_bragg(
                 data=data,
                 roi=setup.detector.roi,
-                binning=setup.detector.binning,
+                binning=setup.detector.current_binning,
                 logger=logger,
             )
             bragg_peaks.update(peaks)
@@ -967,9 +968,9 @@ def process_scan(
         plt.disconnect(cid)
         plt.close(fig)
 
-        #############################################
-        # define mask
-        #############################################
+        ###############
+        # define mask #
+        ###############
         width = 0
         max_colorbar = 5
         flag_aliens = False
@@ -1188,6 +1189,13 @@ def process_scan(
             logger=logger,
         )
         mask[np.nonzero(mask)] = 1
+        setup.detector.current_binning = list(
+            map(
+                mul,
+                setup.detector.current_binning,
+                (setup.detector.binning[0], 1, 1),
+            )
+        )
         if not prm["use_rawdata"] and len(q_values) != 0:
             numz = len(qx)
             qx = qx[
@@ -1195,6 +1203,21 @@ def process_scan(
             ]  # along Z
             del numz
     logger.info(f"Data size after binning the stacking dimension: {data.shape}")
+    expected_binning = list(
+        map(
+            mul,
+            setup.detector.preprocessing_binning,
+            setup.detector.binning,
+        )
+    )
+    if any(
+        val1 != val2
+        for val1, val2 in zip(setup.detector.current_binning, expected_binning)
+    ):
+        raise ValueError(
+            f"Mismatch in binning, current_binning = {setup.detector.current_binning}, "
+            f"expected binning = {expected_binning}"
+        )
 
     ##################################################################
     # final check of the shape to comply with FFT shape requirements #

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,6 +1,9 @@
 Future:
 -------
 
+* Bug: provide the correct binning factors to `bcdi_utils.find_bragg` by introducing a
+  new detector property `current_binning` and using it as input parameter.
+
 * Calculate the Bragg peak position for the three methods "max", "com" and "max_com"
   and plot the results to compare their efficiency. The type of `centering_method` is
   changed to `dict` in order to provide different methods for direct and reciprocal


### PR DESCRIPTION
## Description

The first axis was considered as binned in `bcdi_utils.find_bragg`, but the data was not always binned accordingly beforehand, depending on the preprocessing pipeline. This is fixed by introducing a property tracking the current binning factor, which is provided as input to `find_bragg` instead of the user-defined binning.

Fixes #285 

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have made corresponding changes to the documentation
- [X] I have run ``doit`` and all tasks have passed
