### PR TITLE
Bug: create `save_dir` before running scripts

### DIFF
--- a/bcdi/experiment/detector.py
+++ b/bcdi/experiment/detector.py
@@ -223,7 +223,7 @@ class Detector(ABC):
     @property
     def current_binning(self):
         """
-        Current binning factor of the dataset.
+        Display the current binning factor of the dataset.
 
         Tuple of three positive integers corresponding to the current binning of the
         data in the processing pipeline.

--- a/bcdi/utils/parameters.py
+++ b/bcdi/utils/parameters.py
@@ -15,6 +15,7 @@ discarded.
 import copy
 import logging
 import os
+import pathlib
 from abc import ABC, abstractmethod
 from numbers import Number, Real
 from typing import Any, Dict, List, Optional, Set, Tuple
@@ -88,8 +89,20 @@ class ConfigChecker(ABC):
         self._check_mandatory_params()
         self._configure_params()
         self._check_backend()
+        self._create_dirs()
         self._create_colormap()
         return self._checked_params
+
+    def _create_dirs(self) -> None:
+        """Check if the directories exist and create them if needed."""
+        if not isinstance(self._checked_params.get("save_dir"), list):
+            raise TypeError(
+                "save_dir should be a list, got a "
+                f"{type(self._checked_params.get('save_dir'))}"
+            )
+        for _, val in enumerate(self._checked_params["save_dir"]):
+            if val is not None:
+                pathlib.Path(val).mkdir(parents=True, exist_ok=True)
 
     def _create_roi(self) -> Optional[List[int]]:
         """

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,7 +1,7 @@
 Future:
 -------
 
-* Bug: add the method `utils.parametes.ConfigChecker._create_dirs`, which creates the
+* Bug: add the method `utils.parameters.ConfigChecker._create_dirs`, which creates the
   saving directory when the folder does not exist yet.
 
 * Bug: provide the correct binning factors to `bcdi_utils.find_bragg` by introducing a

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,6 +1,9 @@
 Future:
 -------
 
+* Bug: add the method `utils.parametes.ConfigChecker._create_dirs`, which creates the
+  saving directory when the folder does not exist yet.
+
 * Bug: provide the correct binning factors to `bcdi_utils.find_bragg` by introducing a
   new detector property `current_binning` and using it as input parameter.
 

--- a/tests/postprocessing/test_postprocessing_runner.py
+++ b/tests/postprocessing/test_postprocessing_runner.py
@@ -50,7 +50,7 @@ class TestRun(unittest.TestCase):
         expected_volume = 23232528
         with tempfile.TemporaryDirectory() as tmpdir:
             self.args = self.parser.load_arguments()
-            self.args["save_dir"] = (tmpdir,)
+            self.args["save_dir"] = [tmpdir]
             run(self.args)
             self.assertTrue(os.path.isfile(f"{tmpdir}/postprocessing_run0_S11.log"))
             with h5py.File(

--- a/tests/preprocessing/test_preprocessing_runner.py
+++ b/tests/preprocessing/test_preprocessing_runner.py
@@ -49,7 +49,7 @@ class TestRun(unittest.TestCase):
         expected_q = [-0.84164063, 2.63974482, -0.03198209]
         with tempfile.TemporaryDirectory() as tmpdir:
             self.args = self.parser.load_arguments()
-            self.args["save_dir"] = (tmpdir,)
+            self.args["save_dir"] = [tmpdir]
             run(self.args)
             self.assertTrue(os.path.isfile(f"{tmpdir}/preprocessing_run0_S11.log"))
             with h5py.File(

--- a/tests/utils/test_parameters.py
+++ b/tests/utils/test_parameters.py
@@ -6,6 +6,8 @@
 #       authors:
 #         Jerome Carnis, carnis_jerome@yahoo.fr
 import copy
+import pathlib
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -176,6 +178,12 @@ class TestConfigChecker(unittest.TestCase):
         self.checker._checked_params["grey_background"] = True
         self.checker._create_colormap()
         self.assertTrue(self.checker._checked_params["colormap"].bad_color == "0.7")
+
+    def test_create_dirs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.checker._checked_params["save_dir"] = [tmpdir]
+            self.checker._create_dirs()
+            self.assertTrue(pathlib.Path(tmpdir).is_dir())
 
     def test_check_config_scans_none(self):
         self.checker._checked_params["scans"] = None


### PR DESCRIPTION
In scripts, the logfile was created in `save_dir` if defined, but there was not check if the folder actually existed. Now it is created in ConfigChecker.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have made corresponding changes to the documentation
- [X] I have added corresponding unit tests
- [X] I have run ``doit`` and all tasks have passed
