### PR TITLE
Bug: override  `centering_method` when the Bragg peak position is provided

### DIFF
--- a/bcdi/examples/S11_config_preprocessing.yml
+++ b/bcdi/examples/S11_config_preprocessing.yml
@@ -31,8 +31,7 @@ background_plot: "0.5"  # in level of grey in [0,1], 0 being dark.
 #########################################################
 centering_method: "max_com"  # method used to determine the location of the Bragg peak.
 # 'max', 'com' (center of mass), or 'max_com' (max along the first axis, center of mass
-# in the detector plane). It will be overridden by 'fix_bragg' if the latter is not
-# empty.
+# in the detector plane). It will be overridden if 'bragg_peak' is provided.
 fix_size: None  # crop the array to predefined size considering the full detector,
 # leave None otherwise [zstart, zstop, ystart, ystop, xstart, xstop].
 # ROI will be defaulted to []

--- a/bcdi/utils/parameters.py
+++ b/bcdi/utils/parameters.py
@@ -388,6 +388,8 @@ class PreprocessingChecker(ConfigChecker):
             or self._checked_params["reload_previous"]
         ):
             self._checked_params["multiprocessing"] = False
+        if self._checked_params["bragg_peak"] is not None:
+            self._checked_params["centering_method"]["reciprocal_space"] = "user"
 
 
 class PostprocessingChecker(ConfigChecker):
@@ -593,7 +595,7 @@ def valid_param(key: str, value: Any) -> Tuple[Any, bool]:
             raise ParameterError(key, value, allowed)
     elif key == "centering_method":
         allowed_keys = {"direct_space", "reciprocal_space"}
-        allowed_values = {"com", "max", "max_com", "skip"}
+        allowed_values = {"com", "max", "max_com", "skip", "user"}
         if isinstance(value, dict):
             if any(
                 subkey not in allowed_keys or val not in allowed_values

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,6 +1,9 @@
 Future:
 -------
 
+* Bug: override  `centering_method` in PreprocessingChecker when the Bragg peak position
+  is provided (the new setting becomes "user" for reciprocal space).
+
 * Bug: add the method `utils.parameters.ConfigChecker._create_dirs`, which creates the
   saving directory when the folder does not exist yet.
 

--- a/scripts/preprocessing/bcdi_preprocess.py
+++ b/scripts/preprocessing/bcdi_preprocess.py
@@ -93,7 +93,7 @@ Usage:
     :param centering_method: e.g. "max"
      Method used to determine the location of the Bragg peak. 'max', 'com'
      (center of mass), or 'max_com' (max along the first axis, center of mass in the
-     detector plane). It will be overridden by 'fix_bragg' if the latter is not empty.
+     detector plane). It will be overridden if 'bragg_peak' is provided.
     :param fix_size: e.g. [0, 256, 10, 240, 50, 350]
      crop the array to that predefined size considering the full detector.
      [zstart, zstop, ystart, ystop, xstart, xstop], ROI will be defaulted to [] if

--- a/tests/utils/test_parameters.py
+++ b/tests/utils/test_parameters.py
@@ -214,6 +214,18 @@ class TestPreprocessingChecker(unittest.TestCase):
                 reason=f"cannot load backend {self.checker._checked_params['backend']}"
             )
 
+    def test_bragg_peak_not_provided(self):
+        self.checker._checked_params["bragg_peak"] = None
+        out = self.checker.check_config()
+        self.assertEqual(
+            out["centering_method"], self.checker.initial_params["centering_method"]
+        )
+
+    def test_bragg_peak_provided(self):
+        self.checker._checked_params["bragg_peak"] = [100, 252, 321]
+        out = self.checker.check_config()
+        self.assertEqual(out["centering_method"]["reciprocal_space"], "user")
+
     def test_check_config(self):
         out = self.checker.check_config()
         self.assertEqual(out["scans"], (11,))


### PR DESCRIPTION
When the Bragg peak position is provided, the setting of `centering_method` is now overriden in the ConfigChecker instance.

Fixes # 288

- [X] Bug fix (non-breaking change which fixes an issue)

- [X] I have made corresponding changes to the documentation
- [X] I have added corresponding unit tests
- [X] I have run ``doit`` and all tasks have passed
