### PR TITLE
Add plot to check qualitatively the centering method

### DIFF
--- a/bcdi/postprocessing/process_scan.py
+++ b/bcdi/postprocessing/process_scan.py
@@ -509,6 +509,7 @@ def process_scan(
                 data=data,
                 roi=setup.detector.roi,
                 binning=None,
+                savedir=setup.detector.savedir,
                 logger=logger,
             )
             logger.info(

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -624,7 +624,7 @@ def find_bragg(
     data: np.ndarray,
     roi: Optional[Tuple[int, int, int, int]] = None,
     binning: Optional[Union[Tuple[int, ...], List[int]]] = None,
-    debug: bool = False,
+    savedir: Optional[str] = None,
     **kwargs,
 ) -> Dict[str, Tuple[int, int, int]]:
     """
@@ -638,7 +638,7 @@ def find_bragg(
      from the full sized detector.
     :param binning: tuple of integers of length data.ndim, binning applied to the data
      in each dimension.
-    :param debug: True to plot the detected peaks onto the projected data.
+    :param savedir: path to the saving directory
     :param kwargs:
 
      - 'logger': an optional logger
@@ -708,36 +708,37 @@ def find_bragg(
         position_max_com[-1] = position_max_com[-1] + roi[2]
         position_max_com[-2] = position_max_com[-2] + roi[0]
 
-    if debug:
-        plt.ion()
-        methods = {
-            "max": (position_max, "k"),
-            "com": (position_com, "g"),
-            "max_com": (position_max_com, "b"),
-        }
-        indices = {0: [2, 1], 1: [2, 0], 2: [1, 0]}
-        fig, axes, plots = gu.multislices_plot(
-            data,
-            sum_frames=True,
-            scale="log",
-            plot_colorbar=True,
-            vmin=0,
-            vmax=6,
-            title="data",
-        )
-        for ax, ind in indices.items():
-            for method, values in methods.items():
-                axes[ax].scatter(
-                    values[0][ind[0]],
-                    values[0][ind[1]],
-                    color=values[1],
-                    marker="1",
-                    alpha=0.7,
-                    linewidth=2,
-                    label=method,
-                )
-            axes[ax].legend()
-        plt.pause(0.1)
+    plt.ion()
+    methods = {
+        "max": (position_max, "k"),
+        "com": (position_com, "g"),
+        "max_com": (position_max_com, "b"),
+    }
+    indices = {0: [2, 1], 1: [2, 0], 2: [1, 0]}
+    fig, axes, plots = gu.multislices_plot(
+        data,
+        sum_frames=True,
+        scale="log",
+        plot_colorbar=True,
+        vmin=0,
+        vmax=6,
+        title="data",
+    )
+    for ax, ind in indices.items():
+        for method, values in methods.items():
+            axes[ax].scatter(
+                values[0][ind[0]],
+                values[0][ind[1]],
+                color=values[1],
+                marker="1",
+                alpha=0.7,
+                linewidth=2,
+                label=method,
+            )
+        axes[ax].legend()
+    plt.pause(0.1)
+    if savedir is not None:
+        fig.savefig(savedir + "peaks.png")
     return {
         "max": tuple(position_max),
         "com": tuple(position_com),
@@ -1536,7 +1537,7 @@ def show_rocking_curve(
                 color=colors[idx],
                 marker="1",
                 alpha=0.7,
-                linewidth=1,
+                linewidth=2,
                 label=f"{key}={peak}",
             )
             idx += 1

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -624,6 +624,7 @@ def find_bragg(
     data: np.ndarray,
     roi: Optional[Tuple[int, int, int, int]] = None,
     binning: Optional[Union[Tuple[int, ...], List[int]]] = None,
+    debug: bool = False,
     **kwargs,
 ) -> Dict[str, Tuple[int, int, int]]:
     """
@@ -637,6 +638,7 @@ def find_bragg(
      from the full sized detector.
     :param binning: tuple of integers of length data.ndim, binning applied to the data
      in each dimension.
+    :param debug: True to plot the detected peaks onto the projected data.
     :param kwargs:
 
      - 'logger': an optional logger
@@ -706,6 +708,36 @@ def find_bragg(
         position_max_com[-1] = position_max_com[-1] + roi[2]
         position_max_com[-2] = position_max_com[-2] + roi[0]
 
+    if debug:
+        plt.ion()
+        methods = {
+            "max": (position_max, "k"),
+            "com": (position_com, "g"),
+            "max_com": (position_max_com, "b"),
+        }
+        indices = {0: [2, 1], 1: [2, 0], 2: [1, 0]}
+        fig, axes, plots = gu.multislices_plot(
+            data,
+            sum_frames=True,
+            scale="log",
+            plot_colorbar=True,
+            vmin=0,
+            vmax=6,
+            title="data",
+        )
+        for ax, ind in indices.items():
+            for method, values in methods.items():
+                axes[ax].scatter(
+                    values[0][ind[0]],
+                    values[0][ind[1]],
+                    color=values[1],
+                    marker="1",
+                    alpha=0.7,
+                    linewidth=2,
+                    label=method,
+                )
+            axes[ax].legend()
+        plt.pause(0.1)
     return {
         "max": tuple(position_max),
         "com": tuple(position_com),
@@ -1488,7 +1520,7 @@ def show_rocking_curve(
         vmin=0,
         vmax=5,
     )
-    colors = ["r", "g", "b", "k"]
+    colors = ["k", "g", "b", "r"]
     idx = 0
     for key, peak in peaks.items():
         if peak is not None:

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -738,7 +738,7 @@ def find_bragg(
         axes[ax].legend()
     plt.pause(0.1)
     if savedir is not None:
-        fig.savefig(savedir + "peaks.png")
+        fig.savefig(savedir + "centering_method.png")
     return {
         "max": tuple(position_max),
         "com": tuple(position_com),

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -715,7 +715,7 @@ def find_bragg(
         "max_com": (position_max_com, "b"),
     }
     indices = {0: [2, 1], 1: [2, 0], 2: [1, 0]}
-    fig, axes, plots = gu.multislices_plot(
+    fig, axes, _ = gu.multislices_plot(
         data,
         sum_frames=True,
         scale="log",

--- a/bcdi/preprocessing/process_scan.py
+++ b/bcdi/preprocessing/process_scan.py
@@ -481,6 +481,7 @@ def process_scan(
                 data=data,
                 roi=setup.detector.roi,
                 binning=setup.detector.current_binning,
+                savedir=setup.detector.savedir,
                 logger=logger,
             )
             bragg_peaks.update(peaks)

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,6 +1,9 @@
 Future:
 -------
 
+* Add plot in `bcdi_utils.find_bragg` to check qualitatively the configured centering
+  method. Save it automatically with the title 'centering_method.png'.
+
 * Refactor: move all methods related to linecuts in a dedicated module and class.
   Improve the robustness of linecuts fits in postprocessing, by allowing each fit to
   have a different length.


### PR DESCRIPTION
In the presence of hotpixels, some centering methods are not performing well (typically, those based on the center of mass). A plot of the peak position determined by each of the methods 'max', 'com' and 'max_com' is now saved automatically to help checking the validity of the parameter setting for `centering_method`.

Fix #288 

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] I have made corresponding changes to the documentation
- [X] I have run ``doit`` and all tasks have passed

![peaks](https://user-images.githubusercontent.com/44344327/181937537-d7635b9c-9302-4e12-a671-44606cfd8c54.png)

