### PR TITLE
Allow `sample_name` to be an empty string.

### DIFF
--- a/bcdi/experiment/detector.py
+++ b/bcdi/experiment/detector.py
@@ -438,6 +438,7 @@ class Detector(ABC):
         valid.valid_container(
             value,
             container_types=str,
+            allow_none=True,
             name="Detector.sample_name",
         )
         self._sample_name = value

--- a/bcdi/experiment/detector.py
+++ b/bcdi/experiment/detector.py
@@ -438,8 +438,6 @@ class Detector(ABC):
         valid.valid_container(
             value,
             container_types=str,
-            min_length=1,
-            allow_none=True,
             name="Detector.sample_name",
         )
         self._sample_name = value

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -1442,7 +1442,11 @@ class LoaderID01BLISS(Loader):
         if sample_name is None:
             raise ValueError("'sample_name' parameter required")
 
-        key_path = sample_name + "_" + str(scan_number) + ".1/measurement/"
+        key_path = (
+            f"{sample_name}_"
+            if sample_name
+            else "" + str(scan_number) + ".1/measurement/"
+        )
         if setup.detector_name == "Maxipix":
             try:
                 raw_data = file[key_path + "mpx1x4"]
@@ -1514,7 +1518,9 @@ class LoaderID01BLISS(Loader):
 
         # load positioners
         positioners = file[
-            sample_name + "_" + str(scan_number) + ".1/instrument/positioners"
+            f"{sample_name}_"
+            if sample_name
+            else "" + str(scan_number) + ".1/instrument/positioners"
         ]
         if not setup.custom_scan:
             try:
@@ -1564,7 +1570,9 @@ class LoaderID01BLISS(Loader):
 
         # load positioners
         positioners = file[
-            setup.detector.sample_name + "_" + str(scan_number) + ".1/measurement"
+            f"{setup.detector.sample_name}_"
+            if setup.detector.sample_name
+            else "" + str(scan_number) + ".1/measurement"
         ]
         try:
             device_values = util.cast(positioners[device_name][()], target_type=float)

--- a/bcdi/utils/parameters.py
+++ b/bcdi/utils/parameters.py
@@ -935,10 +935,15 @@ def valid_param(key: str, value: Any) -> Tuple[Any, bool]:
             name=key,
         )
     elif key == "sample_name":
+        if value is None:
+            value = ""
         if isinstance(value, str):
             value = (value,)
         valid.valid_container(
-            value, container_types=(tuple, list), item_types=str, min_length=1, name=key
+            value,
+            container_types=(tuple, list),
+            item_types=str,
+            name=key,
         )
     elif key == "sample_offsets":
         valid.valid_container(

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,6 +1,9 @@
 Future:
 -------
 
+* Bug: allow `sample_name` to be an empty string, in order to match the data internal
+  path in ID01BLISS h5 files.
+
 * Bug: override  `centering_method` in PreprocessingChecker when the Bragg peak position
   is provided (the new setting becomes "user" for reciprocal space).
 

--- a/tests/experiment/test_detector.py
+++ b/tests/experiment/test_detector.py
@@ -261,8 +261,8 @@ class TestDetector(fake_filesystem_unittest.TestCase):
             Maxipix(name="Maxipix", sample_name=777)
 
     def test_sample_name_wrong_length(self):
-        with self.assertRaises(ValueError):
-            Maxipix(name="Maxipix", sample_name="")
+        det = Maxipix(name="Maxipix", sample_name="")
+        self.assertEqual(det.sample_name, "")
 
     def test_sample_name_None(self):
         det = Maxipix(name="Maxipix", sample_name=None)


### PR DESCRIPTION
Allow `sample_name` to be an empty string, in order to match the data internal path in ID01BLISS h5 files.

E.g., the positioners could be located at "X.1/instrument/positioners", X being the scan number. In that case, there is no sample name in front of the scan number.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- [X] I have made corresponding changes to the documentation
- [X] I have run ``doit`` and all tasks have passed
