### PR TITLE
Refactor postprocessing_utils.find_datarange

### DIFF
--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -1443,9 +1443,9 @@ class LoaderID01BLISS(Loader):
             raise ValueError("'sample_name' parameter required")
 
         key_path = (
-            f"{sample_name}_"
-            if sample_name
-            else "" + str(scan_number) + ".1/measurement/"
+            (f"{sample_name}_" if sample_name else "")
+            + str(scan_number)
+            + ".1/measurement/"
         )
         if setup.detector_name == "Maxipix":
             try:
@@ -1518,9 +1518,9 @@ class LoaderID01BLISS(Loader):
 
         # load positioners
         positioners = file[
-            f"{sample_name}_"
-            if sample_name
-            else "" + str(scan_number) + ".1/instrument/positioners"
+            (f"{sample_name}_" if sample_name else "")
+            + str(scan_number)
+            + ".1/instrument/positioners"
         ]
         if not setup.custom_scan:
             try:
@@ -1570,9 +1570,9 @@ class LoaderID01BLISS(Loader):
 
         # load positioners
         positioners = file[
-            f"{setup.detector.sample_name}_"
-            if setup.detector.sample_name
-            else "" + str(scan_number) + ".1/measurement"
+            (f"{setup.detector.sample_name}_" if setup.detector.sample_name else "")
+            + str(scan_number)
+            + ".1/measurement"
         ]
         try:
             device_values = util.cast(positioners[device_name][()], target_type=float)

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -883,13 +883,13 @@ class Setup:
         # check parameters
         if self.direct_beam is None:
             self.logger.info(
-               f"'direct_beam' is {self.direct_beam}, can't correct detector angles"
+                f"'direct_beam' is {self.direct_beam}, can't correct detector angles."
             )
             return
         if self.dirbeam_detector_angles is None:
             self.logger.info(
                 f"'dirbeam_detector_angles' is {self.dirbeam_detector_angles}, "
-                "can't correct detector angles"
+                "can't correct detector angles."
             )
             return
         if any(

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -881,12 +881,17 @@ class Setup:
         :param verbose: True to self.logger.info more comments
         """
         # check parameters
-        if self.direct_beam is None or self.dirbeam_detector_angles is None:
+        if self.direct_beam is None:
             self.logger.info(
-                "direct beam position not defined, can't correct detector angles"
+               f"'direct_beam' is {self.direct_beam}, can't correct detector angles"
             )
             return
-
+        if self.dirbeam_detector_angles is None:
+            self.logger.info(
+                f"'dirbeam_detector_angles' is {self.dirbeam_detector_angles}, "
+                "can't correct detector angles"
+            )
+            return
         if any(
             val is None
             for val in {self.inplane_angle, self.outofplane_angle, self.distance}

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -987,7 +987,7 @@ class Setup:
 
         return ver_direct, hor_direct
 
-    def create_logfile(self, scan_number, root_folder, filename):
+    def create_logfile(self, scan_number: int, root_folder: str, filename: str) -> None:
         """
         Create the logfile, which can be a log/spec file or the data itself.
 
@@ -998,12 +998,11 @@ class Setup:
          specfile/.fio file
         :param filename: the file name to load, or the absolute path of
          'alias_dict.txt' for SIXS
-        :return: logfile
         """
-        if self.custom_scan:
-            logfile = None
-        else:
-            logfile = self.loader.create_logfile(
+        self.logfile = (
+            None
+            if self.custom_scan
+            else self.loader.create_logfile(
                 datadir=self.detector.datadir,
                 name=self.beamline.name,
                 scan_number=scan_number,
@@ -1011,9 +1010,7 @@ class Setup:
                 filename=filename,
                 template_imagefile=self.detector.template_imagefile,
             )
-        self.logfile = logfile
-
-        return logfile
+        )
 
     def detector_frame(
         self,

--- a/bcdi/postprocessing/postprocessing_utils.py
+++ b/bcdi/postprocessing/postprocessing_utils.py
@@ -11,6 +11,7 @@ import gc
 import logging
 from math import pi
 from numbers import Number, Real
+from typing import List, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -22,7 +23,6 @@ from scipy.ndimage.measurements import center_of_mass
 from scipy.signal import convolve
 from scipy.stats import multivariate_normal, norm
 from skimage.restoration import unwrap_phase
-from typing import List, Tuple, Union
 
 from ..graph import graph_utils as gu
 from ..utils import utilities as util
@@ -785,7 +785,7 @@ def find_datarange(
     processing. The range can be larger than the initial data size, which then will need
     to be padded.
 
-    :param array: a numpy array
+    :param array: a non-empty numpy array
     :param plot_margin: user-defined margin to add on each side of the thresholded array
     :param amplitude_threshold: threshold used to define a support from the amplitude
     :param keep_size: set to True in order to keep the dataset full size

--- a/bcdi/postprocessing/process_scan.py
+++ b/bcdi/postprocessing/process_scan.py
@@ -1076,7 +1076,7 @@ def process_scan(
     phase[bulk == 0] = np.nan
 
     # plot the slice at the maximum phase
-    gu.combined_plots(
+    fig = gu.combined_plots(
         (phase[piz, :, :], phase[:, piy, :], phase[:, :, pix]),
         tuple_sum_frames=False,
         tuple_sum_axis=0,
@@ -1095,6 +1095,17 @@ def process_scan(
         is_orthogonal=True,
         reciprocal_space=False,
     )
+    plt.pause(0.1)
+    if prm["save"]:
+        fig.savefig(
+            setup.detector.savedir
+            + "S"
+            + str(scan_nb)
+            + "_phase_at_max"
+            + comment
+            + ".png"
+        )
+    plt.close(fig)
 
     # bulk support
     fig, _, _ = gu.multislices_plot(
@@ -1119,6 +1130,7 @@ def process_scan(
         fig.savefig(
             setup.detector.savedir + "S" + str(scan_nb) + "_bulk" + comment + ".png"
         )
+    plt.close(fig)
 
     # amplitude
     fig, _, _ = gu.multislices_plot(

--- a/bcdi/postprocessing/process_scan.py
+++ b/bcdi/postprocessing/process_scan.py
@@ -187,13 +187,10 @@ def process_scan(
     ###########################################################################
     # define range for orthogonalization and plotting - speed up calculations #
     ###########################################################################
-    zrange, yrange, xrange = pu.find_datarange(
+    numz, numy, numx = pu.find_datarange(
         array=obj, amplitude_threshold=0.05, keep_size=prm["keep_size"]
     )
 
-    numz = zrange * 2
-    numy = yrange * 2
-    numx = xrange * 2
     logger.info(
         "Data shape used for orthogonalization and plotting: "
         f"({numz}, {numy}, {numx})"
@@ -210,7 +207,7 @@ def process_scan(
         sorted_obj = pu.sort_reconstruction(
             file_path=file_path,
             amplitude_threshold=prm["isosurface_strain"],
-            data_range=(zrange, yrange, xrange),
+            data_range=(numz, numy, numx),
             sort_method=prm["sort_method"],
         )
     else:
@@ -245,8 +242,8 @@ def process_scan(
 
         # use the range of interest defined above
         obj = util.crop_pad(
-            obj,
-            [2 * zrange, 2 * yrange, 2 * xrange],
+            array=obj,
+            output_shape=(numz, numy, numx),
             debugging=False,
             cmap=prm["colormap"].cmap,
         )
@@ -301,9 +298,9 @@ def process_scan(
     if prm["debug"]:
         gu.multislices_plot(
             phase,
-            width_z=2 * zrange,
-            width_y=2 * yrange,
-            width_x=2 * xrange,
+            width_z=numz,
+            width_y=numy,
+            width_x=numx,
             plot_colorbar=True,
             title="Phase after unwrap + wrap",
             reciprocal_space=False,
@@ -330,9 +327,9 @@ def process_scan(
     if prm["debug"]:
         gu.multislices_plot(
             phase,
-            width_z=2 * zrange,
-            width_y=2 * yrange,
-            width_x=2 * xrange,
+            width_z=numz,
+            width_y=numy,
+            width_x=numx,
             plot_colorbar=True,
             title="Phase after ramp removal",
             reciprocal_space=False,
@@ -584,9 +581,9 @@ def process_scan(
             )
             gu.multislices_plot(
                 phase,
-                width_z=2 * zrange,
-                width_y=2 * yrange,
-                width_x=2 * xrange,
+                width_z=numz,
+                width_y=numy,
+                width_x=numx,
                 sum_frames=False,
                 plot_colorbar=True,
                 reciprocal_space=False,
@@ -779,9 +776,9 @@ def process_scan(
 
             gu.multislices_plot(
                 np.multiply(phase_correction, bulk),
-                width_z=2 * zrange,
-                width_y=2 * yrange,
-                width_x=2 * xrange,
+                width_z=numz,
+                width_y=numy,
+                width_x=numx,
                 sum_frames=False,
                 plot_colorbar=True,
                 vmin=0,
@@ -802,9 +799,9 @@ def process_scan(
 
             gu.multislices_plot(
                 np.multiply(amp_correction, bulk),
-                width_z=2 * zrange,
-                width_y=2 * yrange,
-                width_x=2 * xrange,
+                width_z=numz,
+                width_y=numy,
+                width_x=numx,
                 sum_frames=False,
                 plot_colorbar=True,
                 vmin=1,

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -739,6 +739,7 @@ def find_bragg(
     plt.pause(0.1)
     if savedir is not None:
         fig.savefig(savedir + "centering_method.png")
+    plt.close(fig)
     return {
         "max": tuple(position_max),
         "com": tuple(position_com),

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,3 +1,11 @@
+Future:
+-------
+
+* Add unit tests to postprocessing_utils.find_datarange and make it dimension-agnostic.
+
+* Fix a bug with data path formatting in ID01BLISS loader (missing parentheses when
+  creating the data path in the h5 file).
+
 Version 0.2.8:
 --------------
 

--- a/scripts/graph/bcdi_scan_analysis.py
+++ b/scripts/graph/bcdi_scan_analysis.py
@@ -130,7 +130,7 @@ def onclick(click_event):
         motor_text = figure.text(
             0.70,
             0.75,
-            motor_name + " = {:.2f}".format(motor_positions[index_peak]),
+            motor_name + f" = {motor_positions[index_peak]:.2f}",
             size=10,
         )
         max_text.remove()
@@ -138,9 +138,7 @@ def onclick(click_event):
             0.70,
             0.70,
             "ROI max at line = "
-            + "{:.0f}".format(
-                data[index_peak, sum_roi[0] : sum_roi[1], sum_roi[2] : sum_roi[3]].max()
-            ),
+            f"{data[index_peak, sum_roi[0]:sum_roi[1], sum_roi[2]:sum_roi[3]].max():d}",
             size=10,
         )
         plt.draw()
@@ -199,12 +197,10 @@ def onselect(click, release):
         0.70,
         0.80,
         "unbinned ROI [y0 y1 x0 x1]\n"
-        "[{:d}, {:d}, {:d}, {:d}]".format(
-            sum_roi[0] * binning[0],
-            sum_roi[1] * binning[0],
-            sum_roi[2] * binning[1],
-            sum_roi[3] * binning[1],
-        ),
+        f"[{sum_roi[0] * binning[0]:d}, "
+        f"{sum_roi[1] * binning[0]:d}, "
+        f"{sum_roi[2] * binning[1]:d}, "
+        f"{sum_roi[3] * binning[1]:d}]",
         size=10,
     )
     max_text.remove()
@@ -212,9 +208,7 @@ def onselect(click, release):
         0.70,
         0.70,
         "ROI max at line = "
-        + "{:.0f}".format(
-            data[index_peak, sum_roi[0] : sum_roi[1], sum_roi[2] : sum_roi[3]].max()
-        ),
+        + f"{data[index_peak, sum_roi[0]:sum_roi[1], sum_roi[2]:sum_roi[3]].max():d}",
         size=10,
     )
     plt.draw()
@@ -262,7 +256,7 @@ setup = Setup(
 )
 
 if setup.beamline == "P10":
-    specfile_name = sample_name + "_{:05d}".format(scan)
+    specfile_name = sample_name + f"_{scan:05d}"
     homedir = root_folder + specfile_name + "/"
     setup.detector.datadir = homedir + "e4m/"
     template_imagefile = specfile_name + template_imagefile
@@ -390,15 +384,13 @@ roi_text = figure.text(
     size=10,
 )
 motor_text = figure.text(
-    0.70, 0.75, motor_name + " = {:.2f}".format(motor_positions[index_peak]), size=10
+    0.70, 0.75, f"{motor_name} = {motor_positions[index_peak]:.2f}", size=10
 )
 max_text = figure.text(
     0.70,
     0.70,
     "ROI max at line = "
-    + "{:.0f}".format(
-        data[index_peak, sum_roi[0] : sum_roi[1], sum_roi[2] : sum_roi[3]].max()
-    ),
+    + f"{data[index_peak, sum_roi[0]:sum_roi[1], sum_roi[2]:sum_roi[3]].max():d}",
     size=10,
 )
 plt.tight_layout()

--- a/scripts/graph/bcdi_scan_analysis.py
+++ b/scripts/graph/bcdi_scan_analysis.py
@@ -375,12 +375,10 @@ roi_text = figure.text(
     0.70,
     0.80,
     "unbinned ROI [y0 y1 x0 x1]\n"
-    "[{:d}, {:d}, {:d}, {:d}]".format(
-        sum_roi[0] * binning[0],
-        sum_roi[1] * binning[0],
-        sum_roi[2] * binning[1],
-        sum_roi[3] * binning[1],
-    ),
+    f"[{sum_roi[0] * binning[0]:d}, "
+    f"{sum_roi[1] * binning[0]:d}, "
+    f"{sum_roi[2] * binning[1]:d}, "
+    f"{sum_roi[3] * binning[1]:d}]",
     size=10,
 )
 motor_text = figure.text(

--- a/scripts/graph/bcdi_scan_analysis.py
+++ b/scripts/graph/bcdi_scan_analysis.py
@@ -280,9 +280,7 @@ if savedir == "":
 setup.detector.savedir = savedir
 print("savedir: ", savedir)
 
-logfile = setup.create_logfile(
-    scan_number=scan, root_folder=root_folder, filename=specfile_name
-)
+setup.create_logfile(scan_number=scan, root_folder=root_folder, filename=specfile_name)
 
 #########################
 # check some parameters #

--- a/scripts/graph/bcdi_view_mesh.py
+++ b/scripts/graph/bcdi_view_mesh.py
@@ -111,20 +111,16 @@ def onclick(click_event):
             motor_text = figure.text(
                 0.40,
                 0.95,
-                fast_motor
-                + " = {:.2f}, ".format(click_event.xdata)
-                + slow_motor
-                + " = {:.2f}".format(click_event.ydata),
+                f"{fast_motor} = {click_event.xdata:.2f}, "
+                f"{slow_motor} = {click_event.ydata:.2f}",
                 size=12,
             )
         else:
             motor_text = figure.text(
                 0.40,
                 0.95,
-                fast_motor
-                + " = {:.2f}, ".format(click_event.ydata)
-                + slow_motor
-                + " = {:.2f}".format(click_event.xdata),
+                f"{fast_motor} = {click_event.ydata:.2f}, "
+                f"{slow_motor} = {click_event.xdata:.2f}",
                 size=12,
             )
         plt.draw()
@@ -273,7 +269,7 @@ crop_roi = crop_roi or (0, setup.detector.nb_pixel_y, 0, setup.detector.nb_pixel
 setup.detector.roi = crop_roi
 
 if setup.beamline == "P10":
-    specfile_name = sample_name + "_{:05d}".format(scan)
+    specfile_name = sample_name + f"_{scan:05d}"
     homedir = root_folder + specfile_name + "/"
     setup.detector.datadir = homedir + "e4m/"
     template_imagefile = specfile_name + template_imagefile

--- a/scripts/graph/bcdi_view_mesh.py
+++ b/scripts/graph/bcdi_view_mesh.py
@@ -291,9 +291,7 @@ if savedir == "":
 setup.detector.savedir = savedir
 print("savedir: ", savedir)
 
-logfile = setup.create_logfile(
-    scan_number=scan, root_folder=root_folder, filename=specfile_name
-)
+setup.create_logfile(scan_number=scan, root_folder=root_folder, filename=specfile_name)
 
 #########################
 # check some parameters #

--- a/scripts/postprocessing/bcdi_correct_angles_detector.py
+++ b/scripts/postprocessing/bcdi_correct_angles_detector.py
@@ -254,7 +254,7 @@ interp_fwhm = (
     * (tilt_values.max() - tilt_values.min())
     / (interp_points - 1)
 )
-print("FWHM by interpolation", str("{:.3f}".format(interp_fwhm)), "deg")
+print(f"FWHM by interpolation {interp_fwhm:.3f} deg")
 
 fig, (ax0, ax1) = plt.subplots(2, 1, sharex="col", figsize=(10, 5))
 ax0.plot(tilt_values, rocking_curve, ".")

--- a/scripts/postprocessing/bcdi_correct_angles_detector.py
+++ b/scripts/postprocessing/bcdi_correct_angles_detector.py
@@ -165,7 +165,7 @@ setup.init_paths(
     data_dir=data_dir,
 )
 
-logfile = setup.create_logfile(
+setup.create_logfile(
     scan_number=scan, root_folder=root_folder, filename=setup.detector.specfile
 )
 

--- a/scripts/postprocessing/bcdi_polarplot.py
+++ b/scripts/postprocessing/bcdi_polarplot.py
@@ -339,7 +339,7 @@ setup.detector.savedir = homedir
 if not reconstructed_data:  # load reciprocal space data
     flatfield = util.load_flatfield(flatfield_file)
     hotpix_array = util.load_hotpixels(hotpixels_file)
-    logfile = setup.create_logfile(
+    setup.create_logfile(
         scan_number=scan, root_folder=root_folder, filename=specfile_name
     )
 

--- a/scripts/postprocessing/bcdi_polarplot.py
+++ b/scripts/postprocessing/bcdi_polarplot.py
@@ -477,16 +477,12 @@ else:  # load a reconstructed real space object
         obj = amp
         newvoxelsize = voxel_size[0]  # nm
     print(
-        "Original voxel sizes (nm):",
-        str("{:.2f}".format(voxel_size[0])),
-        str("{:.2f}".format(voxel_size[1])),
-        str("{:.2f}".format(voxel_size[2])),
+        "Original voxel sizes (nm): "
+        f"{voxel_size[0]:.2f}, {voxel_size[1]:.2f}, {voxel_size[2]:.2f}"
     )
     print(
-        "Output voxel sizes (nm):",
-        str("{:.2f}".format(newvoxelsize)),
-        str("{:.2f}".format(newvoxelsize)),
-        str("{:.2f}".format(newvoxelsize)),
+        "Output voxel sizes (nm): "
+        f"{newvoxelsize:.2f}, {newvoxelsize:.2f}, {newvoxelsize:.2f}"
     )
 
     ########################################################################
@@ -524,7 +520,7 @@ else:  # load a reconstructed real space object
             ).transpose()
         )
         obj = obj.reshape((nz, ny, nx)).astype(amp.dtype)
-        print("voxel size after upsampling (nm)", newvoxelsize / upsampling_ratio)
+        print(f"voxel size after upsampling (nm) {newvoxelsize / upsampling_ratio}")
 
         if debug:
             gu.multislices_plot(
@@ -578,14 +574,7 @@ else:  # load a reconstructed real space object
     dqx = 2 * np.pi / (newvoxelsize / upsampling_ratio * 10 * nz)  # qx downstream
     dqy = 2 * np.pi / (newvoxelsize / upsampling_ratio * 10 * nx)  # qy outboard
     dqz = 2 * np.pi / (newvoxelsize / upsampling_ratio * 10 * ny)  # qz vertical up
-    print(
-        "dqx",
-        str("{:.5f}".format(dqx)),
-        "dqy",
-        str("{:.5f}".format(dqy)),
-        "dqz",
-        str("{:.5f}".format(dqz)),
-    )
+    print(f"dqx {dqx:.5f}, dqy {dqy:.5f}, dqz {dqz:.5f}")
     qx = np.arange(-nz // 2, nz // 2) * dqx
     qy = np.arange(-nx // 2, nx // 2) * dqy
     qz = np.arange(-ny // 2, ny // 2) * dqz
@@ -617,13 +606,7 @@ else:
         0,
         0,
     )  # data is centered because it is the FFT of the object
-print(
-    "Center of mass [qx, qy, qz]: [",
-    str("{:.5f}".format(qxCOM)),
-    str("{:.5f}".format(qyCOM)),
-    str("{:.5f}".format(qzCOM)),
-    "]",
-)
+print(f"Center of mass [qx, qy, qz]: [{qxCOM:.5f}, {qyCOM:.5f}, {qzCOM:.5f}]")
 
 ###############################################################
 # create a 3D array of distances in q from the center of mass #

--- a/scripts/postprocessing/bcdi_prtf_BCDI.py
+++ b/scripts/postprocessing/bcdi_prtf_BCDI.py
@@ -281,7 +281,7 @@ if simulation:
         root_folder,
     ) * 3
 
-logfile = setup.create_logfile(
+setup.create_logfile(
     scan_number=scan, root_folder=root_folder, filename=setup.detector.specfile
 )
 

--- a/scripts/postprocessing/bcdi_prtf_BCDI_2D.py
+++ b/scripts/postprocessing/bcdi_prtf_BCDI_2D.py
@@ -179,7 +179,7 @@ setup.init_paths(
     template_imagefile=template_imagefile,
 )
 
-logfile = setup.create_logfile(
+setup.create_logfile(
     scan_number=scan, root_folder=root_folder, filename=setup.detector.specfile
 )
 

--- a/scripts/postprocessing/bcdi_rocking_curves.py
+++ b/scripts/postprocessing/bcdi_rocking_curves.py
@@ -230,7 +230,7 @@ for scan_idx, scan_nb in enumerate(scans, start=1):
     # override the saving directory, we want to save results at the same place
     setup.detector.savedir = save_dir
 
-    logfile = setup.create_logfile(
+    setup.create_logfile(
         scan_number=scan_nb, root_folder=root_folder, filename=setup.detector.specfile
     )
 

--- a/scripts/postprocessing/bcdi_rocking_curves.py
+++ b/scripts/postprocessing/bcdi_rocking_curves.py
@@ -402,7 +402,7 @@ for fig_idx in range(nb_fig):
     for idx in range(min(49, len(scans) - scan_counter)):
         axis = plt.subplot(nb_rows, nb_columns, idx + 1)
         axis.imshow(np.log10(check_roi[scan_counter]))
-        axis.set_title("S{:d}".format(scans[scan_counter]))
+        axis.set_title(f"S{scans[scan_counter]}")
         scan_counter = scan_counter + 1
     plt.tight_layout()
     plt.pause(0.1)

--- a/scripts/preprocessing/bcdi_read_BCDI_scan.py
+++ b/scripts/preprocessing/bcdi_read_BCDI_scan.py
@@ -177,7 +177,7 @@ setup.init_paths(
     data_dir=data_dir,
 )
 
-logfile = setup.create_logfile(
+setup.create_logfile(
     scan_number=scan, root_folder=root_folder, filename=setup.detector.specfile
 )
 

--- a/tests/postprocessing/test_postprocessing_utils.py
+++ b/tests/postprocessing/test_postprocessing_utils.py
@@ -37,11 +37,11 @@ class TestFindDataRange(unittest.TestCase):
         output = pu.find_datarange(
             array, self.plot_margin, self.amplitude_threshold, keep_size=True
         )
-        self.assertTrue(output == array.shape)
+        self.assertTrue(output == list(array.shape))
 
     def test_no_margin_even_shape_full_array(self):
         array = generate_binary_array((10, 10, 8), nonzero_slice=np.s_[3:10, 1:10, 0:2])
-        expected = (10, 10, 8)
+        expected = [10, 10, 8]
         output = pu.find_datarange(
             array, plot_margin=0, amplitude_threshold=self.amplitude_threshold
         )
@@ -49,7 +49,7 @@ class TestFindDataRange(unittest.TestCase):
 
     def test_no_margin_even_shape(self):
         array = generate_binary_array((10, 10, 10), nonzero_slice=np.s_[3:9, 1:6, 0:2])
-        expected = (8, 8, 10)
+        expected = [8, 8, 10]
         output = pu.find_datarange(
             array, plot_margin=0, amplitude_threshold=self.amplitude_threshold
         )
@@ -57,7 +57,7 @@ class TestFindDataRange(unittest.TestCase):
 
     def test_no_margin_odd_shape_full_array(self):
         array = generate_binary_array((10, 11, 9), nonzero_slice=np.s_[3:10, 1:11, 0:2])
-        expected = (10, 11, 9)
+        expected = [10, 11, 9]
         output = pu.find_datarange(
             array, plot_margin=0, amplitude_threshold=self.amplitude_threshold
         )
@@ -65,7 +65,7 @@ class TestFindDataRange(unittest.TestCase):
 
     def test_no_margin_odd_shape(self):
         array = generate_binary_array((10, 11, 1), nonzero_slice=np.s_[3:5, 6:8, :])
-        expected = (4, 5, 1)
+        expected = [4, 5, 1]
         output = pu.find_datarange(
             array, plot_margin=0, amplitude_threshold=self.amplitude_threshold
         )
@@ -78,13 +78,41 @@ class TestFindDataRange(unittest.TestCase):
 
     def test_margin_odd_shape(self):
         array = generate_binary_array((10, 11, 1), nonzero_slice=np.s_[3:5, 6:8, :])
-        expected = (8, 9, 5)
+        expected = [8, 9, 5]
         output = pu.find_datarange(
             array,
             plot_margin=self.plot_margin,
             amplitude_threshold=self.amplitude_threshold,
         )
         self.assertTrue(output == expected)
+
+    def test_margin_2d(self):
+        array = generate_binary_array((10, 11), nonzero_slice=np.s_[3:5, 6:8:])
+        expected = [8, 9]
+        output = pu.find_datarange(
+            array,
+            plot_margin=self.plot_margin,
+            amplitude_threshold=self.amplitude_threshold,
+        )
+        self.assertTrue(output == expected)
+
+    def test_margin_1d(self):
+        array = generate_binary_array((11,), nonzero_slice=np.s_[6:8:])
+        expected = [9]
+        output = pu.find_datarange(
+            array,
+            plot_margin=self.plot_margin,
+            amplitude_threshold=self.amplitude_threshold,
+        )
+        self.assertTrue(output == expected)
+
+    def test_margin_0d(self):
+        with self.assertRaises(ValueError):
+            pu.find_datarange(
+                np.empty(0),
+                plot_margin=self.plot_margin,
+                amplitude_threshold=self.amplitude_threshold,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/postprocessing/test_postprocessing_utils.py
+++ b/tests/postprocessing/test_postprocessing_utils.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+
+# BCDI: tools for pre(post)-processing Bragg coherent X-ray diffraction imaging data
+#   (c) 07/2017-06/2019 : CNRS UMR 7344 IM2NP
+#   (c) 07/2019-05/2021 : DESY PHOTON SCIENCE
+#       authors:
+#         Jerome Carnis, carnis_jerome@yahoo.fr
+import os.path
+import tempfile
+import unittest
+from functools import reduce
+from pathlib import Path
+from typing import Dict, Optional
+
+import numpy as np
+
+import bcdi.postprocessing.postprocessing_utils as pu
+from tests.config import run_tests
+
+
+def generate_binary_array(array_shape, nonzero_slice):
+    """"""
+    array = np.zeros(array_shape)
+    array[nonzero_slice] = 1
+    return array
+
+
+class TestFindDataRange(unittest.TestCase):
+    """Tests on the function postprocessing_utils.find_datarange."""
+
+    def setUp(self) -> None:
+        self.plot_margin = 2
+        self.amplitude_threshold = 0.25
+
+    def test_keep_size(self):
+        array = generate_binary_array((10, 10, 10), nonzero_slice=np.s_[3:9, 1:6, 0:2])
+        output = pu.find_datarange(
+            array, self.plot_margin, self.amplitude_threshold, keep_size=True
+        )
+        self.assertTrue(output == array.shape)
+
+    def test_no_margin_even_shape_full_array(self):
+        array = generate_binary_array((10, 10, 8), nonzero_slice=np.s_[3:10, 1:10, 0:2])
+        expected = (10, 10, 8)
+        output = pu.find_datarange(
+            array, plot_margin=0, amplitude_threshold=self.amplitude_threshold
+        )
+        self.assertTrue(output == expected)
+
+    def test_no_margin_even_shape(self):
+        array = generate_binary_array((10, 10, 10), nonzero_slice=np.s_[3:9, 1:6, 0:2])
+        expected = (8, 8, 10)
+        output = pu.find_datarange(
+            array, plot_margin=0, amplitude_threshold=self.amplitude_threshold
+        )
+        self.assertTrue(output == expected)
+
+    def test_no_margin_odd_shape_full_array(self):
+        array = generate_binary_array((10, 11, 9), nonzero_slice=np.s_[3:10, 1:11, 0:2])
+        expected = (10, 11, 9)
+        output = pu.find_datarange(
+            array, plot_margin=0, amplitude_threshold=self.amplitude_threshold
+        )
+        self.assertTrue(output == expected)
+
+    def test_no_margin_odd_shape(self):
+        array = generate_binary_array((10, 11, 1), nonzero_slice=np.s_[3:5, 6:8, :])
+        expected = (4, 5, 1)
+        output = pu.find_datarange(
+            array, plot_margin=0, amplitude_threshold=self.amplitude_threshold
+        )
+        self.assertTrue(output == expected)
+
+    def test_below_threshold(self):
+        array = generate_binary_array((3, 3, 3), nonzero_slice=np.s_[:, :, :])
+        with self.assertRaises(pu.ModulusBelowThreshold):
+            pu.find_datarange(array, plot_margin=0, amplitude_threshold=2)
+
+    def test_margin_odd_shape(self):
+        array = generate_binary_array((10, 11, 1), nonzero_slice=np.s_[3:5, 6:8, :])
+        expected = (8, 9, 5)
+        output = pu.find_datarange(
+            array,
+            plot_margin=self.plot_margin,
+            amplitude_threshold=self.amplitude_threshold,
+        )
+        self.assertTrue(output == expected)
+
+
+if __name__ == "__main__":
+    run_tests(TestFindDataRange)

--- a/tests/postprocessing/test_postprocessing_utils.py
+++ b/tests/postprocessing/test_postprocessing_utils.py
@@ -86,7 +86,7 @@ class TestFindDataRange(unittest.TestCase):
         )
         self.assertTrue(output == expected)
 
-    def test_margin_2d(self):
+    def test_2d_array(self):
         array = generate_binary_array((10, 11), nonzero_slice=np.s_[3:5, 6:8:])
         expected = [8, 9]
         output = pu.find_datarange(
@@ -96,7 +96,7 @@ class TestFindDataRange(unittest.TestCase):
         )
         self.assertTrue(output == expected)
 
-    def test_margin_1d(self):
+    def test_1d_array(self):
         array = generate_binary_array((11,), nonzero_slice=np.s_[6:8:])
         expected = [9]
         output = pu.find_datarange(
@@ -106,7 +106,7 @@ class TestFindDataRange(unittest.TestCase):
         )
         self.assertTrue(output == expected)
 
-    def test_margin_0d(self):
+    def test_empty_array(self):
         with self.assertRaises(ValueError):
             pu.find_datarange(
                 np.empty(0),


### PR DESCRIPTION
Add unit tests to `postprocessing_utils.find_datarange` and make it dimension-agnostic.

Fix a bug with data path formatting in ID01BLISS loader (missing parentheses).

Do not return the logfile anymore in `setup.create_logfile` (as it should be in a setter).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor

## Checklist:

- [X] I have made corresponding changes to the documentation
- [X] I have added corresponding unit tests
- [X] I have run ``doit`` and all tasks have passed
