### PR TITLE
remove deprecated `fix_size` parameter

### DIFF
--- a/bcdi/examples/S11_config_preprocessing.yml
+++ b/bcdi/examples/S11_config_preprocessing.yml
@@ -32,9 +32,6 @@ background_plot: "0.5"  # in level of grey in [0,1], 0 being dark.
 centering_method: "max_com"  # method used to determine the location of the Bragg peak.
 # 'max', 'com' (center of mass), or 'max_com' (max along the first axis, center of mass
 # in the detector plane). It will be overridden if 'bragg_peak' is provided.
-fix_size: None  # crop the array to predefined size considering the full detector,
-# leave None otherwise [zstart, zstop, ystart, ystop, xstart, xstop].
-# ROI will be defaulted to []
 center_fft: "skip"
 # 'crop_sym_ZYX','crop_asym_ZYX','pad_asym_Z_crop_sym_YX', 'pad_sym_Z_crop_asym_YX',
 # 'pad_sym_Z', 'pad_asym_Z', 'pad_sym_ZYX','pad_asym_ZYX' or 'skip'

--- a/bcdi/preprocessing/preprocessing_runner.py
+++ b/bcdi/preprocessing/preprocessing_runner.py
@@ -58,7 +58,6 @@ def run(prm: Dict[str, Any]) -> None:
                 "dirbeam_detector_angles": None,
                 "energy": None,
                 "fill_value_mask": 0,
-                "fix_size": None,
                 "flag_interact": True,
                 "flatfield_file": None,
                 "frames_pattern": None,

--- a/bcdi/preprocessing/process_scan.py
+++ b/bcdi/preprocessing/process_scan.py
@@ -377,9 +377,6 @@ def process_scan(
             monitor = []  # we assume that normalization was already performed
             prm["center_fft"] = "skip"
             # we assume that crop/pad/centering was already performed
-            prm[
-                "fix_size"
-            ] = []  # we assume that crop/pad/centering was already performed
 
             # bin data and mask if needed
             if any(val != 1 for val in setup.detector.binning):
@@ -734,7 +731,6 @@ def process_scan(
         fft_option=prm["center_fft"],
         pad_size=prm["pad_size"],
         fix_bragg=prm["bragg_peak"],
-        fix_size=prm["fix_size"],
         q_values=q_values,
         logger=logger,
     )

--- a/bcdi/utils/parameters.py
+++ b/bcdi/utils/parameters.py
@@ -300,13 +300,6 @@ class PreprocessingChecker(ConfigChecker):
             self._checked_params["multiprocessing"] = False
 
         self._checked_params["roi_detector"] = self._create_roi()
-        if self._checked_params["fix_size"]:
-            logger.info('"fix_size" parameter provided, roi_detector will be set to []')
-            logger.info(
-                "'fix_size' parameter provided, defaulting 'center_fft' to 'skip'"
-            )
-            self._checked_params["roi_detector"] = []
-            self._checked_params["center_fft"] = "skip"
 
         if self._checked_params["photon_filter"] == "loading":
             self._checked_params["loading_threshold"] = self._checked_params[
@@ -730,15 +723,6 @@ def valid_param(key: str, value: Any) -> Tuple[Any, bool]:
         allowed = {0, 1}
         if value not in allowed:
             raise ParameterError(key, value, allowed)
-    elif key == "fix_size":
-        valid.valid_container(
-            value,
-            container_types=(tuple, list),
-            length=6,
-            item_types=int,
-            allow_none=True,
-            name=key,
-        )
     elif key == "fix_voxel":
         valid.valid_item(
             value, allowed_types=Real, min_excluded=0, allow_none=True, name=key

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,6 +1,9 @@
 Future:
 -------
 
+* Remove the deprecated parameter 'fix_size'. THe same functionality can be obtained by
+ using the set of parameters `roi_detector`, `center_roi_x` and `center_roi_y`.
+
 * Previously the functionalities regarding Bragg peak finding, rocking curve fitting and
  plotting were located in tightly binded functions. A class PeakFinder is implemented to
  gather these functionalities and manage its own state properly.

--- a/scripts/preprocessing/bcdi_preprocess.py
+++ b/scripts/preprocessing/bcdi_preprocess.py
@@ -94,10 +94,6 @@ Usage:
      Method used to determine the location of the Bragg peak. 'max', 'com'
      (center of mass), or 'max_com' (max along the first axis, center of mass in the
      detector plane). It will be overridden if 'bragg_peak' is provided.
-    :param fix_size: e.g. [0, 256, 10, 240, 50, 350]
-     crop the array to that predefined size considering the full detector.
-     [zstart, zstop, ystart, ystop, xstart, xstop], ROI will be defaulted to [] if
-     fix_size is provided. Leave None otherwise
     :param center_fft: e.g. "skip"
      how to crop/pad/center the data, available options: 'crop_sym_ZYX','crop_asym_ZYX',
      'pad_asym_Z_crop_sym_YX', 'pad_sym_Z_crop_asym_YX', 'pad_sym_Z', 'pad_asym_Z',

--- a/tests/utils/test_parameters.py
+++ b/tests/utils/test_parameters.py
@@ -239,14 +239,6 @@ class TestPreprocessingChecker(unittest.TestCase):
         out = self.checker.check_config()
         self.assertEqual(out["center_fft"], "skip")
 
-    def test_check_config_fix_size(self):
-        self.checker._checked_params["fix_size"] = [2, 127, 25, 326, 56, 95]
-        self.checker._checked_params["center_fft"] = "crop_sym_ZYX"
-        self.checker._checked_params["roi_detector"] = [2, 326, 5, 956]
-        out = self.checker.check_config()
-        self.assertEqual(out["center_fft"], "skip")
-        self.assertTrue(len(out["roi_detector"]) == 0)
-
     def test_check_config_photon_filter_loading(self):
         self.checker._checked_params["photon_filter"] = "loading"
         out = self.checker.check_config()


### PR DESCRIPTION
## Description

The functionality provided by the parameter 'fix_size' can be obtained using the more recent set of parameters `roi_detector`, `center_roi_x` and `center_roi_y`. It is decided to remote it.

Fixes #296 

## Type of change

- [X] Refactor

## Checklist:

- [X] I have made corresponding changes to the documentation
- [X] I have run ``doit`` and all tasks have passed
