### PR TITLE
fix typo error in logger usage

### DIFF
--- a/bcdi/postprocessing/postprocessing_utils.py
+++ b/bcdi/postprocessing/postprocessing_utils.py
@@ -1745,7 +1745,7 @@ def remove_ramp(
             plt.title("centered np.log10(abs(my_fft).sum(axis=0))")
             plt.pause(0.1)
 
-        logger(f"COM after subpixel shift: {center_of_mass(abs(my_fft) ** 4)}")
+        logger.info(f"COM after subpixel shift: {center_of_mass(abs(my_fft) ** 4)}")
         myobj = fftshift(ifftn(ifftshift(my_fft)))
         del my_fft
         gc.collect()


### PR DESCRIPTION
# Fix typo in postprocessing_utils.py

## Description

typo caused error in the BCDI_strain.py script

## Test
The script now runs
