### PR TITLE
change the name of the field name for the phase in the .vti output

### DIFF
--- a/bcdi/postprocessing/analysis.py
+++ b/bcdi/postprocessing/analysis.py
@@ -725,7 +725,7 @@ class InterpolatedCrystal:
             tuple_fieldnames=(
                 "amp",
                 "bulk",
-                self.parameters["phase_fieldname"],
+                "phase",
                 "strain",
             ),
             amplitude_threshold=0.01,


### PR DESCRIPTION
The phase is saved in the h5 and pz files with the field name "phase", but it is called "disp" in the vti file.
Here, I just changed the name of the field name to get "phase" as a field name.