### PR TITLE
Bug: force centering by center of mass after interpolation

### DIFF
--- a/bcdi/postprocessing/analysis.py
+++ b/bcdi/postprocessing/analysis.py
@@ -165,11 +165,20 @@ class Analysis(ABC):
         if average_counter > 1:
             self.logger.info(f"Average performed over {average_counter} arrays")
 
-    def center_object_based_on_modulus(self):
-        """Center the object based on one of the methods 'max', 'com' and 'max_com'."""
-        self.data = pu.center_object(
-            method=self.parameters["centering_method"]["direct_space"], obj=self.data
+    def center_object_based_on_modulus(self, **kwargs):
+        """
+        Center the object based on one of the methods 'max', 'com' and 'max_com'.
+
+        :param kwargs:
+
+         - 'centering_method': centering method name among 'max', 'com' and 'max_com'
+
+        """
+        method = (
+            kwargs.get("centering_method")
+            or self.parameters["centering_method"]["direct_space"]
         )
+        self.data = pu.center_object(method=method, obj=self.data)
 
     def crop_pad_data(self, value: Tuple[int, ...]) -> None:
         self.data = util.crop_pad(

--- a/bcdi/postprocessing/process_scan.py
+++ b/bcdi/postprocessing/process_scan.py
@@ -254,7 +254,7 @@ def process_scan(
     # center the object (centering based on the modulus) #
     ######################################################
     logger.info("Centering the crystal")
-    analysis.center_object_based_on_modulus()
+    analysis.center_object_based_on_modulus(centering_method="com")
 
     ####################
     # Phase unwrapping #

--- a/bcdi/postprocessing/process_scan.py
+++ b/bcdi/postprocessing/process_scan.py
@@ -175,7 +175,7 @@ def process_scan(
 
     if prm["apodize"]:
         phase_manipulator.apodize()
-        comment.concatenate("_apodize_" + prm["apodization_window"])
+        comment.concatenate("apodize_" + prm["apodization_window"])
 
     np.savez_compressed(
         setup.detector.savedir + "S" + str(scan_nb) + "_avg_obj_prtf" + comment.text,


### PR DESCRIPTION
#306 introduced a reproducibility issue by replacing the centering method (center of mass) in postprocessing after interpolation with the value of the parameter 'centering_method'. This is fixed by this pull request.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have made corresponding changes to the documentation
- [ ] I have run ``doit`` and all tasks have passed
