### PR TITLE
Add more OOP in preproccessing

### DIFF
--- a/bcdi/experiment/detector.py
+++ b/bcdi/experiment/detector.py
@@ -400,7 +400,7 @@ class Detector(ABC):
     @roi.setter
     def roi(self, value):
         if not value:  # None or empty list/tuple
-            value = [0, self.nb_pixel_y, 0, self.nb_pixel_x]
+            value = [0, self.unbinned_pixel_number[0], 0, self.unbinned_pixel_number[1]]
         valid.valid_container(
             value,
             container_types=(tuple, list, np.ndarray),

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -146,7 +146,7 @@ def check_empty_frames(data, mask=None, monitor=None, frames_logical=None, **kwa
             raise ValueError("monitor be a 1D array of length data.shae[0]")
 
     if frames_logical is None:
-        frames_logical = np.ones(data.shape[0])
+        frames_logical = np.ones(data.shape[0], dtype=int)
     valid.valid_1d_array(
         frames_logical,
         allowed_types=Integral,
@@ -162,6 +162,9 @@ def check_empty_frames(data, mask=None, monitor=None, frames_logical=None, **kwa
         logger.info("Empty frame detected, cropping the data")
 
     # update frames_logical
+    if len(frames_logical) != len(is_intensity):
+        raise ValueError(f"len(frames_logical)={len(frames_logical)} "
+                         f"but len(is_intensity)={len(is_intensity)}")
     frames_logical = np.multiply(frames_logical, is_intensity)
 
     # remove empty frames from the data and update the mask and the monitor

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -163,8 +163,10 @@ def check_empty_frames(data, mask=None, monitor=None, frames_logical=None, **kwa
 
     # update frames_logical
     if len(frames_logical) != len(is_intensity):
-        raise ValueError(f"len(frames_logical)={len(frames_logical)} "
-                         f"but len(is_intensity)={len(is_intensity)}")
+        raise ValueError(
+            f"len(frames_logical)={len(frames_logical)} "
+            f"but len(is_intensity)={len(is_intensity)}"
+        )
     frames_logical = np.multiply(frames_logical, is_intensity)
 
     # remove empty frames from the data and update the mask and the monitor

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -657,7 +657,7 @@ class Setup:
 
         Frame convention: (z downstream, y vertical up, x outboard). The unit is 1/A.
 
-        :return: a tuple of three vectors components.
+        :return: npdarray of three vectors components.
         """
         q_laboratory = (self.exit_wavevector - self.incident_wavevector) * 1e-10
         if np.isclose(np.linalg.norm(q_laboratory), 0, atol=1e-15):

--- a/bcdi/graph/graph_utils.py
+++ b/bcdi/graph/graph_utils.py
@@ -1501,6 +1501,9 @@ def multislices_plot(
     ):
         raise ValueError("vmin should be strictly smaller than vmax")
 
+    if slice_position is not None:
+        sum_frames = False
+
     if not sum_frames:
         slice_position = slice_position or (int(nbz // 2), int(nby // 2), int(nbx // 2))
         valid.valid_container(

--- a/bcdi/postprocessing/analysis.py
+++ b/bcdi/postprocessing/analysis.py
@@ -5,7 +5,7 @@
 #   (c) 07/2019-05/2021 : DESY PHOTON SCIENCE
 #       authors:
 #         Jerome Carnis, carnis_jerome@yahoo.fr
-"""Implementation of the analysis classes."""
+"""Implementation of postprocessing analysis classes."""
 
 import logging
 import os

--- a/bcdi/postprocessing/postprocessing_utils.py
+++ b/bcdi/postprocessing/postprocessing_utils.py
@@ -713,64 +713,6 @@ def find_bulk(
     return support
 
 
-def find_crop_center(array_shape, crop_shape, pivot):
-    """
-    Find the position of the center of the cropping window.
-
-    It finds the closest voxel to pivot which allows to crop an array of array_shape to
-    crop_shape.
-
-    :param array_shape: initial shape of the array
-    :type array_shape: tuple
-    :param crop_shape: final shape of the array
-    :type crop_shape: tuple
-    :param pivot: position on which the final region of interest dhould be centered
-     (center of mass of the Bragg peak)
-    :type pivot: tuple
-    :return: the voxel position closest to pivot which allows cropping to the defined
-     shape.
-    """
-    valid.valid_container(
-        array_shape,
-        container_types=(tuple, list, np.ndarray),
-        min_length=1,
-        item_types=int,
-        name="array_shape",
-    )
-    ndim = len(array_shape)
-    valid.valid_container(
-        crop_shape,
-        container_types=(tuple, list, np.ndarray),
-        length=ndim,
-        item_types=int,
-        name="crop_shape",
-    )
-    valid.valid_container(
-        pivot,
-        container_types=(tuple, list, np.ndarray),
-        length=ndim,
-        item_types=int,
-        name="pivot",
-    )
-    crop_center = np.empty(ndim)
-    for idx, _ in enumerate(range(ndim)):
-        if max(0, pivot[idx] - crop_shape[idx] // 2) == 0:
-            # not enough range on this side of the com
-            crop_center[idx] = crop_shape[idx] // 2
-        else:
-            if (
-                min(array_shape[idx], pivot[idx] + crop_shape[idx] // 2)
-                == array_shape[idx]
-            ):
-                # not enough range on this side of the com
-                crop_center[idx] = array_shape[idx] - crop_shape[idx] // 2
-            else:
-                crop_center[idx] = pivot[idx]
-
-    crop_center = list(map(int, crop_center))
-    return crop_center
-
-
 def find_datarange(
     array: np.ndarray,
     plot_margin: Union[int, List[int]] = 10,

--- a/bcdi/preprocessing/analysis.py
+++ b/bcdi/preprocessing/analysis.py
@@ -19,6 +19,7 @@ import numpy as np
 import scipy.signal  # for medfilt2d
 import xrayutilities as xu
 from matplotlib import pyplot as plt
+from matplotlib.axes import Axes
 from matplotlib.backend_bases import KeyEvent, MouseEvent
 from matplotlib.figure import Figure
 from matplotlib.text import Text
@@ -60,6 +61,10 @@ class InteractiveMasker:
         self.width: int = 5
         self.max_colorbar: int = 5
         self.fig_mask: Optional[Figure] = None
+        self.ax0: Optional[Axes] = None
+        self.ax1: Optional[Axes] = None
+        self.ax2: Optional[Axes] = None
+        self.ax3: Optional[Axes] = None
         self.info_text: Optional[Text] = None
         self.frame_index: Optional[List[int]] = None
 
@@ -874,7 +879,7 @@ class DetectorFrameAnalysis(Analysis):
         self.q_bragg = self.setup.q_laboratory
 
     def interpolate_data(self) -> None:
-        super().interpolate_data()
+        self.logger("No interpolation performed for the analysis in detector frame")
 
 
 class LinearizationAnalysis(Analysis):
@@ -938,7 +943,7 @@ class OrthogonalFrameAnalysis(Analysis):
         self.calculate_q_bragg_orthogonal()
 
     def interpolate_data(self) -> None:
-        super().interpolate_data()
+        self.logger("Reloaded data is already interpolated in an orthogonal frame.")
 
 
 class XrayUtilitiesAnalysis(Analysis):

--- a/bcdi/preprocessing/analysis.py
+++ b/bcdi/preprocessing/analysis.py
@@ -18,10 +18,10 @@ import h5py
 import numpy as np
 import scipy.signal  # for medfilt2d
 import xrayutilities as xu
+from matplotlib import pyplot as plt
 from matplotlib.backend_bases import KeyEvent, MouseEvent
 from matplotlib.figure import Figure
 from matplotlib.text import Text
-from matplotlib import pyplot as plt
 from scipy.io import savemat
 from scipy.ndimage.measurements import center_of_mass
 

--- a/bcdi/preprocessing/analysis.py
+++ b/bcdi/preprocessing/analysis.py
@@ -489,6 +489,7 @@ class Analysis(ABC):
                 tilt_values=None,
                 logger=self.logger,
                 plot_fit=False,
+                frames_pattern=self.parameters["frames_pattern"],
             )
             self.q_bragg = np.array(
                 [
@@ -663,6 +664,7 @@ class Analysis(ABC):
             peak_method=self.parameters["centering_method"]["reciprocal_space"],
             tilt_values=self.setup.tilt_angles,
             savedir=self.setup.detector.savedir,
+            frames_pattern=self.parameters.get("frames_pattern"),
             logger=self.logger,
             plot_fit=True,
         )

--- a/bcdi/preprocessing/analysis.py
+++ b/bcdi/preprocessing/analysis.py
@@ -1,0 +1,329 @@
+# -*- coding: utf-8 -*-
+
+# BCDI: tools for pre(post)-processing Bragg coherent X-ray diffraction imaging data
+#   (c) 07/2017-06/2019 : CNRS UMR 7344 IM2NP
+#   (c) 07/2019-05/2021 : DESY PHOTON SCIENCE
+#       authors:
+#         Jerome Carnis, carnis_jerome@yahoo.fr
+"""Implementation of preprocessing analysis classes."""
+
+import logging
+from operator import mul
+import os
+import tkinter as tk
+from abc import ABC, abstractmethod
+from functools import reduce
+from tkinter import filedialog
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import h5py
+import numpy as np
+import yaml
+from matplotlib import pyplot as plt
+
+import bcdi.graph.graph_utils as gu
+import bcdi.graph.linecut as linecut
+import bcdi.preprocessing.bcdi_utils as bu
+import bcdi.utils.image_registration as reg
+import bcdi.utils.utilities as util
+import bcdi.utils.validation as valid
+from bcdi.experiment.setup import Setup
+from bcdi.utils.constants import AXIS_TO_ARRAY
+from bcdi.utils.text import Comment
+
+module_logger = logging.getLogger(__name__)
+
+
+class Analysis(ABC):
+    """Base class for the pre-processing analysis workflow."""
+
+    def __init__(
+        self,
+        scan_index: int,
+        parameters: Dict[str, Any],
+        setup: Setup,
+        **kwargs,
+    ) -> None:
+        self.scan_index = scan_index
+        self.parameters = parameters
+        self.setup = setup
+        self.logger = kwargs.get("logger", module_logger)
+
+        self.data_loader = create_data_loader(
+            scan_index=self.scan_index,
+            parameters=self.parameters,
+            setup=self.setup,
+            logger=self.logger,
+        )
+        self.comment = self.initialize_comment()
+        if parameters["normalize_flux"]:
+            self.comment.concatenate("norm")
+
+    @property
+    def scan_nb(self) -> int:
+        return self.parameters["scans"][self.scan_index]
+
+    def initialize_comment(self) -> Comment:
+        return Comment(self.parameters.get("comment", ""))
+
+
+class DetectorFrameAnalysis(Analysis):
+    """Analysis worklow in the detector frame."""
+
+
+class LinearizationAnalysis(Analysis):
+    def __init__(
+        self,
+        scan_index: int,
+        parameters: Dict[str, Any],
+        setup: Setup,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            scan_index=scan_index, parameters=parameters, setup=setup, **kwargs
+        )
+        # load the goniometer positions needed in the calculation
+        # of the transformation matrix
+        self.setup.read_logfile(scan_number=self.scan_nb)
+        self.comment.concatenate("ortho_lin")
+
+
+class XrayUtilitiesAnalysis(Analysis):
+    def __init__(
+        self,
+        scan_index: int,
+        parameters: Dict[str, Any],
+        setup: Setup,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            scan_index=scan_index, parameters=parameters, setup=setup, **kwargs
+        )
+        self.comment.concatenate("ortho_xrutils")
+
+
+def define_analysis_type(use_rawdata: bool, interpolation_method: str) -> str:
+    """Define the correct analysis type depending on the parameters."""
+    if use_rawdata:
+        return "detector_frame"
+    return interpolation_method
+
+
+def create_analysis(
+    scan_index: int,
+    parameters: Dict[str, Any],
+    setup: Setup,
+    **kwargs,
+) -> Analysis:
+    """Create the correct analysis class depending on the parameters."""
+    name = define_analysis_type(
+        use_rawdata=parameters["use_rawdata"],
+        interpolation_method=parameters["interpolation_method"],
+    )
+    if name == "detector_frame":
+        return DetectorFrameAnalysis(
+            scan_index=scan_index,
+            parameters=parameters,
+            setup=setup,
+            **kwargs,
+        )
+    if name == "linearization":
+        return LinearizationAnalysis(
+            scan_index=scan_index,
+            parameters=parameters,
+            setup=setup,
+            **kwargs,
+        )
+    if name == "orthogonal":
+        return XrayUtilitiesAnalysis(
+            scan_index=scan_index,
+            parameters=parameters,
+            setup=setup,
+            **kwargs,
+        )
+    raise ValueError(f"Analysis {name} not supported")
+
+
+class PreprocessingLoader(ABC):
+    def __init__(
+        self, scan_index: int, parameters: Dict[str, Any], setup: "Setup", **kwargs
+    ) -> None:
+        self.scan_index = scan_index
+        self.parameters = parameters
+        self.setup = setup
+        self.logger = kwargs.get("logger", module_logger)
+
+        self.q_values: Optional[List[np.ndarray]] = None
+
+    @property
+    def scan_nb(self) -> int:
+        return self.parameters["scans"][self.scan_index]
+
+    @abstractmethod
+    def load_dataset(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        raise NotImplementedError
+
+    def reload(self) -> Tuple[np.ndarray, np.ndarray]:
+        file_path = filedialog.askopenfilename(
+            initialdir=self.setup.detector.scandir,
+            title="Select data file",
+            filetypes=[("NPZ", "*.npz")],
+        )
+        data = np.load(file_path)
+        npz_key = data.files
+        data = data[npz_key[0]]
+        _, ny, nx = np.shape(data)
+
+        # check that the ROI is correctly defined
+        self.setup.detector.roi = self.parameters["roi_detector"] or [0, ny, 0, nx]
+        self.logger.info(f"Detector ROI: {self.setup.detector.roi}")
+        # update savedir to save the data in the same directory as the reloaded data
+        if not self.parameters["save_dir"]:
+            self.setup.detector.savedir = os.path.dirname(file_path) + "/"
+            self.logger.info(f"Updated saving directory: {self.setup.detector.savedir}")
+
+        file_path = filedialog.askopenfilename(
+            initialdir=os.path.dirname(file_path) + "/",
+            title="Select mask file",
+            filetypes=[("NPZ", "*.npz")],
+        )
+        mask = np.load(file_path)
+        npz_key = mask.files
+        mask = mask[npz_key[0]]
+        return data, mask
+
+
+class FirstDataLoading(PreprocessingLoader):
+    """Load a dataset for the first time, de facto in the detector frame."""
+
+    def load_dataset(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        return bu.load_bcdi_data(
+            scan_number=self.scan_nb,
+            setup=self.setup,
+            frames_pattern=self.parameters["frames_pattern"],
+            bin_during_loading=self.parameters["bin_during_loading"],
+            flatfield=util.load_flatfield(self.parameters["flatfield_file"]),
+            hotpixels=util.load_hotpixels(self.parameters["hotpixels_file"]),
+            background=util.load_background(self.parameters["background_file"]),
+            normalize=self.parameters["normalize_flux"],
+            debugging=self.parameters["debug"],
+            photon_threshold=self.parameters["loading_threshold"],
+            logger=self.logger,
+        )
+
+
+class ReloadingDetectorFrame(PreprocessingLoader):
+    """Reload a dataset which is still in the detector frame."""
+
+    def load_dataset(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        data, mask = self.reload()
+        return bu.reload_bcdi_data(
+            data=data,
+            mask=mask,
+            scan_number=self.scan_nb,
+            setup=self.setup,
+            normalize=self.parameters["normalize_flux"],
+            debugging=self.parameters["debug"],
+            photon_threshold=self.parameters["loading_threshold"],
+            logger=self.logger,
+        )
+
+
+class ReloadingOrthogonal(PreprocessingLoader):
+    """Reload a dataset already interpolated in an orthogonal frame."""
+
+    def load_dataset(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        data, mask = self.reload()
+        q_values = self.load_q_values()
+
+        self.parameters["normalize_flux"] = "skip"
+        # we assume that normalization was already performed
+        monitor = []  # we assume that normalization was already performed
+        self.parameters["center_fft"] = "skip"
+        # we assume that crop/pad/centering was already performed
+
+        # bin data and mask if needed
+        if any(val != 1 for val in self.setup.detector.binning):
+            self.logger.info(
+                f"Binning the reloaded orthogonal data by {self.setup.detector.binning}"
+            )
+            data = util.bin_data(
+                data,
+                binning=self.setup.detector.binning,
+                debugging=False,
+                cmap=self.parameters["colormap"].cmap,
+                logger=self.logger,
+            )
+            mask = util.bin_data(
+                mask,
+                binning=self.setup.detector.binning,
+                debugging=False,
+                cmap=self.parameters["colormap"].cmap,
+                logger=self.logger,
+            )
+            self.setup.detector.current_binning = list(
+                map(
+                    mul,
+                    self.setup.detector.current_binning,
+                    self.setup.detector.binning,
+                )
+            )
+            mask[np.nonzero(mask)] = 1
+
+            if q_values is not None:
+                qx = q_values[0]
+                qz = q_values[1]
+                qy = q_values[2]
+                numz, numy, numx = len(qx), len(qz), len(qy)
+                qx = qx[
+                    : numz
+                    - (
+                        numz % self.setup.detector.binning[0]
+                    ) : self.setup.detector.binning[0]
+                ]  # along z downstream
+                qz = qz[
+                    : numy
+                    - (
+                        numy % self.setup.detector.binning[1]
+                    ) : self.setup.detector.binning[1]
+                ]  # along y vertical
+                qy = qy[
+                    : numx
+                    - (
+                        numx % self.setup.detector.binning[2]
+                    ) : self.setup.detector.binning[2]
+                ]  # along x outboard
+                self.q_values = [qx, qz, qy]
+        return data, mask, np.ones(data.shape[0]), monitor
+
+    def load_q_values(self) -> Optional[List[np.ndarray]]:
+        try:
+            file_path = filedialog.askopenfilename(
+                initialdir=self.setup.detector.savedir,
+                title="Select q values",
+                filetypes=[("NPZ", "*.npz")],
+            )
+            reload_qvalues = np.load(file_path)
+            return [
+                reload_qvalues["qx"],
+                reload_qvalues["qz"],
+                reload_qvalues["qy"],
+            ]
+        except FileNotFoundError:
+            return None
+
+
+def create_data_loader(
+    scan_index: int, parameters: Dict[str, Any], setup: "Setup", **kwargs
+) -> PreprocessingLoader:
+    if parameters["reload_previous"]:
+        if parameters["reload_orthogonal"]:
+            return ReloadingOrthogonal(
+                scan_index=scan_index, parameters=parameters, setup=setup, **kwargs
+            )
+        return ReloadingDetectorFrame(
+            scan_index=scan_index, parameters=parameters, setup=setup, **kwargs
+        )
+    return FirstDataLoading(
+        scan_index=scan_index, parameters=parameters, setup=setup, **kwargs
+    )

--- a/bcdi/preprocessing/analysis.py
+++ b/bcdi/preprocessing/analysis.py
@@ -1022,20 +1022,7 @@ class XrayUtilitiesAnalysis(Analysis):
             * self.setup.detector.binning[2]
         )
         # number of pixels after taking into account the roi and binning
-        nch1 = (self.setup.detector.roi[1] - self.setup.detector.roi[0]) // (
-            self.setup.detector.preprocessing_binning[1]
-            * self.setup.detector.binning[1]
-        ) + (self.setup.detector.roi[1] - self.setup.detector.roi[0]) % (
-            self.setup.detector.preprocessing_binning[1]
-            * self.setup.detector.binning[1]
-        )
-        nch2 = (self.setup.detector.roi[3] - self.setup.detector.roi[2]) // (
-            self.setup.detector.preprocessing_binning[2]
-            * self.setup.detector.binning[2]
-        ) + (self.setup.detector.roi[3] - self.setup.detector.roi[2]) % (
-            self.setup.detector.preprocessing_binning[2]
-            * self.setup.detector.binning[2]
-        )
+        nch1, nch2 = self.data.shape[1:]
         # detector init_area method, pixel sizes are the binned ones
         hxrd.Ang2Q.init_area(
             self.setup.detector_ver_xrutil,

--- a/bcdi/preprocessing/analysis.py
+++ b/bcdi/preprocessing/analysis.py
@@ -8,19 +8,19 @@
 """Implementation of preprocessing analysis classes."""
 
 import logging
-from operator import mul
 import os
 from abc import ABC, abstractmethod
+from operator import mul
 from tkinter import filedialog
 from typing import Any, Dict, List, Optional, Tuple
 
 import h5py
 import numpy as np
+import scipy.signal  # for medfilt2d
+import xrayutilities as xu
+from matplotlib import pyplot as plt
 from scipy.io import savemat
 from scipy.ndimage.measurements import center_of_mass
-import scipy.signal  # for medfilt2d
-from matplotlib import pyplot as plt
-import xrayutilities as xu
 
 import bcdi.graph.graph_utils as gu
 import bcdi.preprocessing.bcdi_utils as bu

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -345,7 +345,7 @@ class PeakFinder:
             tilt_values if tilt_values is not None else np.arange(len(rocking_curve))
         )
         if self.frames_pattern is not None:
-            x_axis = x_axis[self.frames_pattern > 0]
+            x_axis = x_axis[self.frames_pattern == 1]
         if len(x_axis) != len(rocking_curve):
             self.logger.warning(
                 "tilt_values and rocking curve don't have the same length (hint: did "

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -16,7 +16,7 @@ import logging
 import pathlib
 from numbers import Real
 from operator import mul
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -28,6 +28,9 @@ from bcdi.experiment import loader
 from bcdi.graph import graph_utils as gu
 from bcdi.utils import utilities as util
 from bcdi.utils import validation as valid
+
+if TYPE_CHECKING:
+    from bcdi.experiment.setup import Setup
 
 module_logger = logging.getLogger(__name__)
 
@@ -1354,16 +1357,16 @@ def grid_bcdi_xrayutil(
 
 
 def load_bcdi_data(
-    scan_number,
-    setup,
-    bin_during_loading=False,
-    flatfield=None,
-    hotpixels=None,
-    background=None,
-    normalize="skip",
-    debugging=False,
+    scan_number: int,
+    setup: "Setup",
+    bin_during_loading: bool = False,
+    flatfield: Optional[np.ndarray] = None,
+    hotpixels: Optional[np.ndarray] = None,
+    background: Optional[np.ndarray] = None,
+    normalize: str = "skip",
+    debugging: bool = False,
     **kwargs,
-):
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """
     Load Bragg CDI data, apply optional threshold, normalization and binning.
 
@@ -1478,14 +1481,14 @@ def load_bcdi_data(
 
 
 def reload_bcdi_data(
-    data,
-    mask,
-    scan_number,
-    setup,
-    normalize=False,
-    debugging=False,
+    data: np.ndarray,
+    mask: np.ndarray,
+    scan_number: int,
+    setup: "Setup",
+    normalize: bool = False,
+    debugging: bool = False,
     **kwargs,
-):
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """
     Reload BCDI data, apply optional threshold, normalization and binning.
 
@@ -1533,7 +1536,7 @@ def reload_bcdi_data(
     # normalize by the incident X-ray beam intensity
     if normalize == "skip":
         logger.info("Skip intensity normalization")
-        monitor = []
+        monitor = np.ones(nbz)
     else:  # use the default monitor of the beamline
         monitor = setup.loader.read_monitor(
             scan_number=scan_number,

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -463,7 +463,7 @@ def center_fft(
     pad_size = kwargs.get("pad_size", [])
     q_values = kwargs.get("q_values", [])
 
-    if q_values:  # len(q_values) != 0
+    if q_values is not None:
         qx = q_values[0]  # axis=0, z downstream, qx in reciprocal space
         qz = q_values[1]  # axis=1, y vertical, qz in reciprocal space
         qy = q_values[2]  # axis=2, x outboard, qy in reciprocal space
@@ -550,7 +550,7 @@ def center_fft(
         if (iz0 + nz1 // 2) < nbz:  # if nbz, the last frame is used
             frames_logical[iz0 + nz1 // 2 :] = 0
 
-        if len(q_values) != 0:
+        if q_values is not None:
             qx = qx[iz0 - nz1 // 2 : iz0 + nz1 // 2]
             qy = qy[ix0 - nx1 // 2 : ix0 + nx1 // 2]
             qz = qz[iy0 - ny1 // 2 : iy0 + ny1 // 2]
@@ -620,7 +620,7 @@ def center_fft(
         temp_frames[pad_width[0] : pad_width[0] + nbz] = frames_logical
         frames_logical = temp_frames
 
-        if len(q_values) != 0:
+        if q_values is not None:
             dqx = qx[1] - qx[0]
             qx0 = qx[0] - pad_width[0] * dqx
             qx = qx0 + np.arange(pad_size[0]) * dqx
@@ -672,7 +672,7 @@ def center_fft(
         temp_frames[pad_width[0] : pad_width[0] + nbz] = frames_logical
         frames_logical = temp_frames
 
-        if len(q_values) != 0:
+        if q_values is not None:
             dqx = qx[1] - qx[0]
             qx0 = qx[0] - pad_width[0] * dqx
             qx = qx0 + np.arange(pad_size[0]) * dqx
@@ -710,7 +710,7 @@ def center_fft(
         temp_frames[pad_width[0] : pad_width[0] + nbz] = frames_logical
         frames_logical = temp_frames
 
-        if len(q_values) != 0:
+        if q_values is not None:
             dqx = qx[1] - qx[0]
             qx0 = qx[0] - pad_width[0] * dqx
             qx = qx0 + np.arange(nz1) * dqx
@@ -753,7 +753,7 @@ def center_fft(
         temp_frames[pad_width[0] : pad_width[0] + nbz] = frames_logical
         frames_logical = temp_frames
 
-        if len(q_values) != 0:
+        if q_values is not None:
             dqx = qx[1] - qx[0]
             qx0 = qx[0] - pad_width[0] * dqx
             qx = qx0 + np.arange(nz1) * dqx
@@ -792,7 +792,7 @@ def center_fft(
         temp_frames[pad_width[0] : pad_width[0] + nbz] = frames_logical
         frames_logical = temp_frames
 
-        if len(q_values) != 0:
+        if q_values is not None:
             dqx = qx[1] - qx[0]
             qx0 = qx[0] - pad_width[0] * dqx
             qx = qx0 + np.arange(pad_size[0]) * dqx
@@ -822,7 +822,7 @@ def center_fft(
         temp_frames[pad_width[0] : pad_width[0] + nbz] = frames_logical
         frames_logical = temp_frames
 
-        if len(q_values) != 0:
+        if q_values is not None:
             dqx = qx[1] - qx[0]
             qx0 = qx[0] - pad_width[0] * dqx
             qx = qx0 + np.arange(nz1) * dqx
@@ -870,7 +870,7 @@ def center_fft(
         temp_frames[pad_width[0] : pad_width[0] + nbz] = frames_logical
         frames_logical = temp_frames
 
-        if len(q_values) != 0:
+        if q_values is not None:
             dqx = qx[1] - qx[0]
             dqy = qy[1] - qy[0]
             dqz = qz[1] - qz[0]
@@ -908,7 +908,7 @@ def center_fft(
         temp_frames[pad_width[0] : pad_width[0] + nbz] = frames_logical
         frames_logical = temp_frames
 
-        if len(q_values) != 0:
+        if q_values is not None:
             dqx = qx[1] - qx[0]
             dqy = qy[1] - qy[0]
             dqz = qz[1] - qz[0]
@@ -925,7 +925,7 @@ def center_fft(
     else:
         raise ValueError("Incorrect value for 'fft_option'")
 
-    if len(q_values) != 0:
+    if q_values is not None:
         q_values = list(q_values)
         q_values[0] = qx
         q_values[1] = qz

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -48,7 +48,9 @@ class PeakFinder:
      full detector
     :param peak_method: peak searching method, among "max", "com", "max_com".
     :param kwargs:
-     - "logger": an optional logger
+     - 'logger': an optional logger
+     - 'frames_pattern' = list of int, of length the size of the original dataset along
+      the rocking curve dimension. 0 if a frame was skipped, 1 otherwise
 
     """
 
@@ -70,6 +72,7 @@ class PeakFinder:
         )
         self.binning = [1, 1, 1] if binning is None else binning
         self.peak_method = peak_method
+        self.frames_pattern: Optional[List[int]] = kwargs.get("frames_pattern")
         self.logger: logging.Logger = kwargs.get("logger", module_logger)
 
         self._peaks = self.find_peak()
@@ -341,6 +344,8 @@ class PeakFinder:
         x_axis = (
             tilt_values if tilt_values is not None else np.arange(len(rocking_curve))
         )
+        if self.frames_pattern is not None:
+            x_axis = x_axis[self.frames_pattern > 0]
         if len(x_axis) != len(rocking_curve):
             self.logger.warning(
                 "tilt_values and rocking curve don't have the same length (hint: did "
@@ -971,15 +976,19 @@ def find_bragg(
     :param plot_fit: if True, will plot results and fit the rocking curve
     :param kwargs:
      - "logger": an optional logger
+     - 'frames_pattern' = list of int, of length the size of the original dataset along
+      the rocking curve dimension. 0 if a frame was skipped, 1 otherwise
 
     :return: the metadata with the results of the peak search and the fit.
     """
     logger: logging.Logger = kwargs.get("logger", module_logger)
+    frames_pattern: Optional[List[int]] = kwargs.get("frames_pattern")
     peakfinder = PeakFinder(
         array=array,
         region_of_interest=region_of_interest,
         binning=binning,
         peak_method=peak_method,
+        frames_pattern=frames_pattern,
         logger=logger,
     )
 

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -50,7 +50,7 @@ class PeakFinder:
     :param kwargs:
      - 'logger': an optional logger
      - 'frames_pattern' = list of int, of length the size of the original dataset along
-      the rocking curve dimension. 0 if a frame was skipped, 1 otherwise
+       the rocking curve dimension. 0 if a frame was skipped, 1 otherwise
 
     """
 
@@ -977,7 +977,7 @@ def find_bragg(
     :param kwargs:
      - "logger": an optional logger
      - 'frames_pattern' = list of int, of length the size of the original dataset along
-      the rocking curve dimension. 0 if a frame was skipped, 1 otherwise
+       the rocking curve dimension. 0 if a frame was skipped, 1 otherwise
 
     :return: the metadata with the results of the peak search and the fit.
     """
@@ -1521,7 +1521,7 @@ def reload_bcdi_data(
     :parama kwargs:
 
      - 'frames_pattern' = list of int, of length the size of the original dataset along
-      the rocking curve dimension. 0 if a frame was skipped, 1 otherwise
+       the rocking curve dimension. 0 if a frame was skipped, 1 otherwise
      - 'photon_threshold' = float, photon threshold to apply before binning
      - 'logger': an optional logger
 

--- a/bcdi/preprocessing/process_scan.py
+++ b/bcdi/preprocessing/process_scan.py
@@ -269,7 +269,7 @@ def process_scan(
         analysis.save_to_vti(
             filename=os.path.join(
                 setup.detector.savedir,
-                f"S{scan_nb}_ortho_int" + comment + ".vti",
+                f"S{scan_nb}_ortho_int" + comment.text + ".vti",
             )
         )
 
@@ -305,6 +305,8 @@ def process_scan(
         )
 
         interactive_mask.refine_mask()  # (remove remaining hotpixels, ...)
+        if interactive_mask.mask is None:
+            raise ValueError("mask is undefined")
         analysis.mask = np.copy(interactive_mask.mask)
         del interactive_mask
 

--- a/bcdi/preprocessing/process_scan.py
+++ b/bcdi/preprocessing/process_scan.py
@@ -400,7 +400,7 @@ def process_scan(
         filename=setup.detector.savedir + f"S{scan_nb}_maskpynx" + comment.text
     )
     analysis.save_results_as_h5(
-        filename=f"{setup.detector.savedir}S{scan_nb}_preprocessing{comment}.h5"
+        filename=f"{setup.detector.savedir}S{scan_nb}_preprocessing{comment.text}.h5"
     )
 
     ############################

--- a/bcdi/preprocessing/process_scan.py
+++ b/bcdi/preprocessing/process_scan.py
@@ -11,8 +11,6 @@ Workflow for BCDI data preprocessing of a single scan, before phase retrieval.
 The detector is expected to be on a goniometer.
 """
 
-import gc
-
 try:
     import hdf5plugin  # for P10, should be imported before h5py or PyTables
 except ModuleNotFoundError:
@@ -22,27 +20,15 @@ import logging
 import os
 import tkinter as tk
 from logging import Logger
-from operator import mul
 from pathlib import Path
-from tkinter import filedialog
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
-import h5py
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
-import scipy.signal  # for medfilt2d
-import xrayutilities as xu
-from scipy.io import savemat
-from scipy.ndimage.measurements import center_of_mass
 
-import bcdi.graph.graph_utils as gu
-import bcdi.postprocessing.postprocessing_utils as pu
-import bcdi.preprocessing.bcdi_utils as bu
-import bcdi.utils.utilities as util
-import bcdi.utils.validation as valid
+from bcdi.preprocessing.analysis import create_analysis
 from bcdi.experiment.setup import Setup
-from bcdi.utils.constants import AXIS_TO_ARRAY
 from bcdi.utils.snippets_logging import FILE_FORMATTER
 
 logger = logging.getLogger(__name__)
@@ -63,151 +49,9 @@ def process_scan(
     :param prm: the parsed parameters
     """
 
-    def on_click(event):
-        """
-        Interact with a plot, return the position of clicked pixel.
-
-        If flag_pause==1 or if the mouse is out of plot axes, it will not register
-        the click.
-
-        :param event: mouse click event
-        """
-        nonlocal xy, flag_pause, previous_axis
-
-        if not event.inaxes:
-            return
-        if not flag_pause:
-
-            if (previous_axis == event.inaxes) or (
-                previous_axis is None
-            ):  # collect points
-                _x, _y = int(np.rint(event.xdata)), int(np.rint(event.ydata))
-                xy.append([_x, _y])
-                if previous_axis is None:
-                    previous_axis = event.inaxes
-            else:  # the click is not in the same subplot, restart collecting points
-                print(
-                    "Select mask polygon vertices within "
-                    "the same subplot: restart masking..."
-                )
-                xy = []
-                previous_axis = None
-
-    def press_key(event):
-        """
-        Interact with a plot for masking parasitic intensity or detector gaps.
-
-        :param event: button press event
-        """
-        nonlocal original_data, original_mask, updated_mask, data, mask, frame_index
-        nonlocal flag_aliens, flag_mask, flag_pause, xy, fig_mask, max_colorbar
-        nonlocal ax0, ax1, ax2, ax3, previous_axis, info_text, my_cmap, width
-
-        try:
-            if event.inaxes == ax0:
-                dim = 0
-                inaxes = True
-            elif event.inaxes == ax1:
-                dim = 1
-                inaxes = True
-            elif event.inaxes == ax2:
-                dim = 2
-                inaxes = True
-            else:
-                dim = -1
-                inaxes = False
-
-            if inaxes:
-                if flag_aliens:
-                    (
-                        data,
-                        mask,
-                        width,
-                        max_colorbar,
-                        frame_index,
-                        stop_masking,
-                    ) = gu.update_aliens_combined(
-                        key=event.key,
-                        pix=int(np.rint(event.xdata)),
-                        piy=int(np.rint(event.ydata)),
-                        original_data=original_data,
-                        original_mask=original_mask,
-                        updated_data=data,
-                        updated_mask=mask,
-                        axes=(ax0, ax1, ax2, ax3),
-                        width=width,
-                        dim=dim,
-                        frame_index=frame_index,
-                        vmin=0,
-                        vmax=max_colorbar,
-                        cmap=my_cmap,
-                        invert_yaxis=not prm["use_rawdata"],
-                    )
-                elif flag_mask:
-                    if previous_axis == ax0:
-                        click_dim = 0
-                        x, y = np.meshgrid(np.arange(nx), np.arange(ny))
-                        points = np.stack((x.flatten(), y.flatten()), axis=0).T
-                    elif previous_axis == ax1:
-                        click_dim = 1
-                        x, y = np.meshgrid(np.arange(nx), np.arange(nz))
-                        points = np.stack((x.flatten(), y.flatten()), axis=0).T
-                    elif previous_axis == ax2:
-                        click_dim = 2
-                        x, y = np.meshgrid(np.arange(ny), np.arange(nz))
-                        points = np.stack((x.flatten(), y.flatten()), axis=0).T
-                    else:
-                        click_dim = None
-                        points = None
-
-                    (
-                        data,
-                        updated_mask,
-                        flag_pause,
-                        xy,
-                        width,
-                        max_colorbar,
-                        click_dim,
-                        stop_masking,
-                        info_text,
-                    ) = gu.update_mask_combined(
-                        key=event.key,
-                        pix=int(np.rint(event.xdata)),
-                        piy=int(np.rint(event.ydata)),
-                        original_data=original_data,
-                        original_mask=mask,
-                        updated_data=data,
-                        updated_mask=updated_mask,
-                        axes=(ax0, ax1, ax2, ax3),
-                        flag_pause=flag_pause,
-                        points=points,
-                        xy=xy,
-                        width=width,
-                        dim=dim,
-                        click_dim=click_dim,
-                        info_text=info_text,
-                        vmin=0,
-                        vmax=max_colorbar,
-                        cmap=my_cmap,
-                        invert_yaxis=not prm["use_rawdata"],
-                    )
-                    if click_dim is None:
-                        previous_axis = None
-                else:
-                    stop_masking = False
-
-                if stop_masking:
-                    plt.close("all")
-
-        except AttributeError:  # mouse pointer out of axes
-            pass
-
     ####################################################
     # Initialize parameters for the callback functions #
     ####################################################
-    flag_mask = False
-    flag_aliens = False
-    my_cmap = prm["colormap"].cmap
     plt.rcParams["keymap.fullscreen"] = [""]
     plt.rcParams["keymap.quit"] = [
         "ctrl+w",
@@ -240,7 +84,6 @@ def process_scan(
         logger.propagate = True
 
     prm["sample"] = f"{prm['sample_name']}+{scan_nb}"
-    comment = prm["comment"]  # re-initialize comment
     tmp_str = f"Scan {scan_idx + 1}/{len(prm['scans'])}: S{scan_nb}"
     from datetime import datetime
 
@@ -279,7 +122,9 @@ def process_scan(
         logger=logger,
     )
 
-    # initialize the paths
+    ########################################
+    # Initialize the paths and the logfile #
+    ########################################
     setup.init_paths(
         sample_name=prm["sample_name"][scan_idx],
         scan_number=scan_nb,
@@ -310,150 +155,20 @@ def process_scan(
         f"{setup.detector.params}"
     )
 
-    if not prm["use_rawdata"]:
-        comment += "_ortho"
-        if prm["interpolation_method"] == "linearization":
-            comment += "_lin"
-            # load the goniometer positions needed in the calculation
-            # of the transformation matrix
-            setup.read_logfile(scan_number=scan_nb)
-        else:  # 'xrayutilities'
-            comment += "_xrutil"
-    if prm["normalize_flux"]:
-        comment = comment + "_norm"
+    ######################
+    # start the analysis #
+    ######################
+    logger.info("###############\nProcessing data\n###############")
+
+    analysis = create_analysis(
+        scan_index=scan_idx, parameters=prm, setup=setup, logger=logger
+    )
+    comment = analysis.comment
 
     #############
     # Load data #
     #############
-    if prm["reload_previous"]:  # resume previous masking
-        logger.info("Resuming previous masking")
-        file_path = filedialog.askopenfilename(
-            initialdir=setup.detector.scandir,
-            title="Select data file",
-            filetypes=[("NPZ", "*.npz")],
-        )
-        data = np.load(file_path)
-        npz_key = data.files
-        data = data[npz_key[0]]
-        nz, ny, nx = np.shape(data)
-
-        # check that the ROI is correctly defined
-        setup.detector.roi = prm["roi_detector"] or [0, ny, 0, nx]
-        logger.info(f"Detector ROI: {setup.detector.roi}")
-        # update savedir to save the data in the same directory as the reloaded data
-        if not prm["save_dir"]:
-            setup.detector.savedir = os.path.dirname(file_path) + "/"
-            logger.info(f"Updated saving directory: {setup.detector.savedir}")
-
-        file_path = filedialog.askopenfilename(
-            initialdir=os.path.dirname(file_path) + "/",
-            title="Select mask file",
-            filetypes=[("NPZ", "*.npz")],
-        )
-        mask = np.load(file_path)
-        npz_key = mask.files
-        mask = mask[npz_key[0]]
-
-        if prm["reload_orthogonal"]:
-            # the data is gridded in the orthonormal laboratory frame
-            prm["use_rawdata"] = False
-            try:
-                file_path = filedialog.askopenfilename(
-                    initialdir=setup.detector.savedir,
-                    title="Select q values",
-                    filetypes=[("NPZ", "*.npz")],
-                )
-                reload_qvalues = np.load(file_path)
-                q_values = [
-                    reload_qvalues["qx"],
-                    reload_qvalues["qz"],
-                    reload_qvalues["qy"],
-                ]
-            except FileNotFoundError:
-                q_values = []
-
-            prm["normalize_flux"] = "skip"
-            # we assume that normalization was already performed
-            monitor = []  # we assume that normalization was already performed
-            prm["center_fft"] = "skip"
-            # we assume that crop/pad/centering was already performed
-
-            # bin data and mask if needed
-            if any(val != 1 for val in setup.detector.binning):
-                logger.info(
-                    f"Binning the reloaded orthogonal data by {setup.detector.binning}"
-                )
-                data = util.bin_data(
-                    data,
-                    binning=setup.detector.binning,
-                    debugging=False,
-                    cmap=prm["colormap"].cmap,
-                    logger=logger,
-                )
-                mask = util.bin_data(
-                    mask,
-                    binning=setup.detector.binning,
-                    debugging=False,
-                    cmap=prm["colormap"].cmap,
-                    logger=logger,
-                )
-                setup.detector.current_binning = list(
-                    map(mul, setup.detector.current_binning, setup.detector.binning)
-                )
-
-                mask[np.nonzero(mask)] = 1
-                if len(q_values) != 0:
-                    qx = q_values[0]
-                    qz = q_values[1]
-                    qy = q_values[2]
-                    numz, numy, numx = len(qx), len(qz), len(qy)
-                    qx = qx[
-                        : numz
-                        - (numz % setup.detector.binning[0]) : setup.detector.binning[0]
-                    ]  # along z downstream
-                    qz = qz[
-                        : numy
-                        - (numy % setup.detector.binning[1]) : setup.detector.binning[1]
-                    ]  # along y vertical
-                    qy = qy[
-                        : numx
-                        - (numx % setup.detector.binning[2]) : setup.detector.binning[2]
-                    ]  # along x outboard
-                    del numz, numy, numx
-        else:  # the data is in the detector frame
-            data, mask, frames_logical, monitor = bu.reload_bcdi_data(
-                data=data,
-                mask=mask,
-                scan_number=scan_nb,
-                setup=setup,
-                normalize=prm["normalize_flux"],
-                debugging=prm["debug"],
-                photon_threshold=prm["loading_threshold"],
-                logger=logger,
-            )
-
-    else:  # new masking process
-        prm["reload_orthogonal"] = False  # the data is in the detector plane
-        flatfield = util.load_flatfield(prm["flatfield_file"])
-        hotpix_array = util.load_hotpixels(prm["hotpixels_file"])
-        background = util.load_background(prm["background_file"])
-
-        data, mask, frames_logical, monitor = bu.load_bcdi_data(
-            scan_number=scan_nb,
-            setup=setup,
-            frames_pattern=prm["frames_pattern"],
-            bin_during_loading=prm["bin_during_loading"],
-            flatfield=flatfield,
-            hotpixels=hotpix_array,
-            background=background,
-            normalize=prm["normalize_flux"],
-            debugging=prm["debug"],
-            photon_threshold=prm["loading_threshold"],
-            logger=logger,
-        )
-
-    nz, ny, nx = np.shape(data)
-    logger.info(f"Input data shape: {np.shape(data)}")
+    logger.info(f"Input data shape: {np.shape(analysis.data)}")
 
     binning_comment = (
         f"_{setup.detector.preprocessing_binning[0] * setup.detector.binning[0]}"
@@ -464,949 +179,235 @@ def process_scan(
     ##############################################################
     # correct detector angles and save values for postprocessing #
     ##############################################################
-    metadata = None
-    if (
-        not prm["outofplane_angle"]
-        and not prm["inplane_angle"]
-        and prm["rocking_angle"] != "energy"
-    ):
-        # corrected detector angles not provided
-        metadata = bu.find_bragg(
-            array=data,
-            binning=setup.detector.current_binning,
-            roi=setup.detector.roi,
-            peak_method=prm["centering_method"]["reciprocal_space"],
-            tilt_values=setup.tilt_angles,
-            savedir=setup.detector.savedir,
-            logger=logger,
-            plot_fit=True,
+    if analysis.detector_angles_correction_needed:
+        logger.info("Trying to correct detector angles using the direct beam")
+
+        analysis.retrieve_bragg_peak()
+
+        analysis.update_detector_angles(bragg_peak_position=prm["bragg_peak"])
+        analysis.update_parameters(
+            {
+                "inplane_angle": setup.inplane_angle,
+                "outofplane_angle": setup.outofplane_angle,
+            }
         )
-        prm["bragg_peak"] = metadata["bragg_peak"]
-        setup.correct_detector_angles(bragg_peak_position=prm["bragg_peak"])
-        prm["outofplane_angle"] = setup.outofplane_angle
-        prm["inplane_angle"] = setup.inplane_angle
 
     ##############################################################
     # optional interpolation of the data onto an orthogonal grid #
     ##############################################################
-    if not prm["reload_orthogonal"]:
-        if prm["save_rawdata"]:
-            np.savez_compressed(
-                setup.detector.savedir + f"S{scan_nb}" + "_data_before_masking_stack",
-                data=data,
-            )
-            if prm["save_to_mat"]:
-                # save to .mat, the new order is x y z
-                # (outboard, vertical up, downstream)
-                savemat(
-                    setup.detector.savedir
-                    + "S"
-                    + str(scan_nb)
-                    + "_data_before_masking_stack.mat",
-                    {"data": np.moveaxis(data, [0, 1, 2], [-1, -2, -3])},
-                )
+    if analysis.is_raw_data_available and prm["save_rawdata"]:
+        analysis.save_data(
+            filename=setup.detector.savedir
+            + f"S{scan_nb}"
+            + "_data_before_masking_stack",
+        )
 
-        if prm["use_rawdata"]:
-            q_values = []
-            qnorm = np.linalg.norm(setup.q_laboratory)  # (1/A)
-            q_bragg = setup.q_laboratory
-            # binning along axis 0 is done after masking
-            data[np.nonzero(mask)] = 0
-        else:
-            tmp_data = np.copy(data)
-            # do not modify the raw data before the interpolation
-            tmp_data[mask == 1] = 0
-            fig, _, _ = gu.multislices_plot(
-                tmp_data,
-                sum_frames=True,
-                scale="log",
-                plot_colorbar=True,
-                vmin=0,
-                title="Data before gridding\n",
-                is_orthogonal=False,
-                reciprocal_space=True,
-                cmap=prm["colormap"].cmap,
-            )
-            fig.savefig(
-                setup.detector.savedir
-                + f"data_before_gridding_S{scan_nb}_{nz}_{ny}_{nx}"
-                + binning_comment
-                + ".png"
-            )
-            plt.close(fig)
-            del tmp_data
-            gc.collect()
+    if analysis.interpolation_needed:
+        data_shape = analysis.data.shape
+        analysis.show_masked_data(
+            title="Data before gridding\n",
+            filename=setup.detector.savedir + f"data_before_gridding_S{scan_nb}"
+            f"_{data_shape[0]}_{data_shape[1]}_{data_shape[2]}"
+            + binning_comment
+            + ".png",
+        )
+        analysis.interpolate_data()
 
-            if prm["interpolation_method"] == "xrayutilities":
-                qconv, offsets = setup.init_qconversion()
-                setup.detector.offsets = offsets
-                hxrd = xu.experiment.HXRD(
-                    prm["sample_inplane"],
-                    prm["sample_outofplane"],
-                    en=setup.energy,
-                    qconv=qconv,
-                )
-                # the first 2 arguments in HXRD are the inplane reference direction
-                # along the beam and surface normal of the sample
+    analysis.calculate_q_bragg()
 
-                # Update the direct beam vertical position,
-                # take into account the roi and binning
-                cch1 = (prm["cch1"] - setup.detector.roi[0]) / (
-                    setup.detector.preprocessing_binning[1] * setup.detector.binning[1]
-                )
-                # Update the direct beam horizontal position,
-                # take into account the roi and binning
-                cch2 = (prm["cch2"] - setup.detector.roi[2]) / (
-                    setup.detector.preprocessing_binning[2] * setup.detector.binning[2]
-                )
-                # number of pixels after taking into account the roi and binning
-                nch1 = (setup.detector.roi[1] - setup.detector.roi[0]) // (
-                    setup.detector.preprocessing_binning[1] * setup.detector.binning[1]
-                ) + (setup.detector.roi[1] - setup.detector.roi[0]) % (
-                    setup.detector.preprocessing_binning[1] * setup.detector.binning[1]
-                )
-                nch2 = (setup.detector.roi[3] - setup.detector.roi[2]) // (
-                    setup.detector.preprocessing_binning[2] * setup.detector.binning[2]
-                ) + (setup.detector.roi[3] - setup.detector.roi[2]) % (
-                    setup.detector.preprocessing_binning[2] * setup.detector.binning[2]
-                )
-                # detector init_area method, pixel sizes are the binned ones
-                hxrd.Ang2Q.init_area(
-                    setup.detector_ver_xrutil,
-                    setup.detector_hor_xrutil,
-                    cch1=cch1,
-                    cch2=cch2,
-                    Nch1=nch1,
-                    Nch2=nch2,
-                    pwidth1=setup.detector.pixelsize_y,
-                    pwidth2=setup.detector.pixelsize_x,
-                    distance=setup.distance,
-                    detrot=prm["detrot"],
-                    tiltazimuth=prm["tiltazimuth"],
-                    tilt=prm["tilt_detector"],
-                )
-                # the first two arguments in init_area are
-                # the direction of the detector
-
-                data, mask, q_values, frames_logical = bu.grid_bcdi_xrayutil(
-                    data=data,
-                    mask=mask,
-                    scan_number=scan_nb,
-                    setup=setup,
-                    frames_logical=frames_logical,
-                    hxrd=hxrd,
-                    debugging=prm["debug"],
-                    cmap=prm["colormap"].cmap,
-                    logger=logger,
-                )
-                # find the Bragg peak position from the interpolated data
-                interpolated_metadata = bu.find_bragg(
-                    array=data,
-                    binning=None,
-                    roi=None,
-                    peak_method=prm["centering_method"]["reciprocal_space"],
-                    tilt_values=None,
-                    logger=logger,
-                    plot_fit=False,
-                )
-                q_bragg = np.array(
-                    [
-                        q_values[0][interpolated_metadata["bragg_peak"][0]],
-                        q_values[1][interpolated_metadata["bragg_peak"][1]],
-                        q_values[2][interpolated_metadata["bragg_peak"][2]],
-                    ]
-                )
-                qnorm = np.linalg.norm(q_bragg)
-            else:  # 'linearization'
-                # for q values, the frame used is
-                # (qx downstream, qy outboard, qz vertical up)
-                # for reference_axis, the frame is z downstream, y vertical up,
-                # x outboard but the order must be x,y,z
-                data, mask, q_values, transfer_matrix = bu.grid_bcdi_labframe(
-                    data=data,
-                    mask=mask,
-                    detector=setup.detector,
-                    setup=setup,
-                    align_q=prm["align_q"],
-                    reference_axis=AXIS_TO_ARRAY[prm["ref_axis_q"]],
-                    debugging=prm["debug"],
-                    fill_value=(0, prm["fill_value_mask"]),
-                    cmap=prm["colormap"].cmap,
-                    logger=logger,
-                )
-                prm["transformation_matrix"] = transfer_matrix
-
-                qnorm = np.linalg.norm(setup.q_laboratory)  # (1/A)
-                q_bragg = setup.q_laboratory
-
-            nz, ny, nx = data.shape
-            logger.info(
-                "Data size after interpolation into an orthonormal frame:"
-                f"{nz}, {ny}, {nx}"
-            )
-
-            ###############################################################
-            # plot normalization by incident monitor for the gridded data #
-            ###############################################################
-            if prm["normalize_flux"]:
-                plt.ion()
-                tmp_data = np.copy(
-                    data
-                )  # do not modify the raw data before the interpolation
-                tmp_data[tmp_data < 5] = 0  # threshold the background
-                tmp_data[mask == 1] = 0
-                fig = gu.combined_plots(
-                    tuple_array=(monitor, tmp_data),
-                    tuple_sum_frames=(False, True),
-                    tuple_sum_axis=(0, 1),
-                    tuple_width_v=None,
-                    tuple_width_h=None,
-                    tuple_colorbar=(False, False),
-                    tuple_vmin=(np.nan, 0),
-                    tuple_vmax=(np.nan, np.nan),
-                    tuple_title=(
-                        "monitor.min() / monitor",
-                        "Gridded normed data (threshold 5)\n",
-                    ),
-                    tuple_scale=("linear", "log"),
-                    xlabel=("Frame number", "Q$_y$"),
-                    ylabel=("Counts (a.u.)", "Q$_x$"),
-                    position=(323, 122),
-                    is_orthogonal=not prm["use_rawdata"],
-                    reciprocal_space=True,
-                    cmap=prm["colormap"].cmap,
-                )
-
-                fig.savefig(
-                    setup.detector.savedir
-                    + f"monitor_gridded_S{scan_nb}_{nz}_{ny}_{nx}"
-                    + binning_comment
-                    + ".png"
-                )
-                if prm["flag_interact"]:
-                    fig.canvas.mpl_disconnect(fig.canvas.manager.key_press_handler_id)
-                    cid = plt.connect("close_event", gu.close_event)
-                    fig.waitforbuttonpress()
-                    plt.disconnect(cid)
-                plt.close(fig)
-                plt.ioff()
-                del tmp_data
-                gc.collect()
-    else:  # reload_orthogonal
-        if q_values:  # find the Bragg peak position from the interpolated data
-            interpolated_metadata = bu.find_bragg(
-                array=data,
-                binning=None,
-                roi=None,
-                peak_method=prm["centering_method"]["reciprocal_space"],
-                tilt_values=None,
-                logger=logger,
-                plot_fit=False,
-            )
-            q_bragg = np.array(
-                [
-                    q_values[0][interpolated_metadata["bragg_peak"][0]],
-                    q_values[1][interpolated_metadata["bragg_peak"][1]],
-                    q_values[2][interpolated_metadata["bragg_peak"][2]],
-                ]
-            )
-            qnorm = np.linalg.norm(q_bragg)
-        else:
-            q_bragg = None
-            qnorm = None
-
-    if qnorm is not None:
-        planar_distance = 2 * np.pi / qnorm
+    if analysis.q_bragg is not None:
         # expressed in the laboratory frame z downstream, y vertical, x outboard
-        logger.info(f"Wavevector transfer of Bragg peak: {q_bragg}, Qnorm={qnorm:.4f}")
-        logger.info(f"Interplanar distance: {planar_distance:.6f} angstroms")
-    else:
-        planar_distance = None
+        logger.info(
+            f"Wavevector transfer of Bragg peak: {analysis.q_bragg}, "
+            f"Qnorm={analysis.q_norm:.4f}"
+        )
+        logger.info(f"Interplanar distance: {analysis.planar_distance:.6f} angstroms")
 
     ########################
     # crop/pad/center data #
     ########################
-    data, mask, pad_width, q_values, frames_logical = bu.center_fft(
-        data=data,
-        mask=mask,
-        detector=setup.detector,
-        frames_logical=frames_logical,
-        centering=prm["centering_method"],
-        fft_option=prm["center_fft"],
-        pad_size=prm["pad_size"],
-        fix_bragg=prm["bragg_peak"],
-        q_values=q_values,
-        logger=logger,
-    )
+    analysis.apply_mask_to_data()
+    analysis.center_fft()
 
-    starting_frame = [
-        pad_width[0],
-        pad_width[2],
-        pad_width[4],
-    ]  # no need to check padded frames
-    logger.info(f"Pad width: {pad_width}")
-    nz, ny, nx = data.shape
-    logger.info(f"Data size after cropping / padding: {data.shape}")
-
-    ##########################################
-    # optional masking of zero photon events #
-    ##########################################
+    #########################################################
+    # optional masking of points when there is no intensity #
+    # along the whole rocking curve (probably dead pixels)  #
+    #########################################################
     if prm["mask_zero_event"]:
-        # mask points when there is no intensity along the whole rocking curve
-        # probably dead pixels
-        temp_mask = np.zeros((ny, nx))
-        temp_mask[np.sum(data, axis=0) == 0] = 1
-        mask[np.repeat(temp_mask[np.newaxis, :, :], repeats=nz, axis=0) == 1] = 1
-        del temp_mask
+        analysis.mask_zero_events()
 
-    ###########################################
-    # save data and mask before alien removal #
-    ###########################################
-    fig, _, _ = gu.multislices_plot(
-        data,
-        sum_frames=True,
-        scale="log",
-        plot_colorbar=True,
-        vmin=0,
+    #####################################
+    # save figures before alien removal #
+    #####################################
+    nz, ny, nx = analysis.data.shape
+    analysis.show_masked_data(
         title="Data before aliens removal\n",
-        is_orthogonal=not prm["use_rawdata"],
-        reciprocal_space=True,
-        cmap=prm["colormap"].cmap,
+        filename=setup.detector.savedir
+        + f"data_before_masking_sum_S{scan_nb}_{nz}_{ny}_{nx}_"
+        f"{setup.detector.binning[0]}_"
+        f"{setup.detector.binning[1]}_{setup.detector.binning[2]}.png",
     )
-    if prm["debug"]:
-        fig.savefig(
-            setup.detector.savedir
-            + f"data_before_masking_sum_S{scan_nb}_{nz}_{ny}_{nx}_"
-            f"{setup.detector.binning[0]}_"
-            f"{setup.detector.binning[1]}_{setup.detector.binning[2]}.png"
-        )
-    if prm["flag_interact"]:
-        fig.canvas.mpl_disconnect(fig.canvas.manager.key_press_handler_id)
-        cid = plt.connect("close_event", gu.close_event)
-        fig.waitforbuttonpress()
-        plt.disconnect(cid)
-    plt.close(fig)
 
-    piz, piy, pix = np.unravel_index(data.argmax(), data.shape)
-    fig = gu.combined_plots(
-        (data[piz, :, :], data[:, piy, :], data[:, :, pix]),
-        tuple_sum_frames=False,
-        tuple_sum_axis=0,
-        tuple_width_v=None,
-        tuple_width_h=None,
-        tuple_colorbar=True,
-        tuple_vmin=0,
-        tuple_vmax=np.nan,
-        tuple_scale="log",
-        tuple_title=("data at max in xy", "data at max in xz", "data at max in yz"),
-        is_orthogonal=not prm["use_rawdata"],
-        reciprocal_space=False,
-        cmap=prm["colormap"].cmap,
+    analysis.show_masked_data_at_max(
+        title="data at max\n",
+        filename=setup.detector.savedir
+        + f"data_before_masking_S{scan_nb}_{nz}_{ny}_{nx}_"
+        f"{setup.detector.binning[0]}"
+        f"_{setup.detector.binning[1]}_{setup.detector.binning[2]}.png",
     )
-    if prm["debug"]:
-        fig.savefig(
-            setup.detector.savedir + f"data_before_masking_S{scan_nb}_{nz}_{ny}_{nx}_"
-            f"{setup.detector.binning[0]}"
-            f"_{setup.detector.binning[1]}_{setup.detector.binning[2]}.png"
-        )
-    if prm["flag_interact"]:
-        fig.canvas.mpl_disconnect(fig.canvas.manager.key_press_handler_id)
-        cid = plt.connect("close_event", gu.close_event)
-        fig.waitforbuttonpress()
-        plt.disconnect(cid)
-    plt.close(fig)
 
-    fig, _, _ = gu.multislices_plot(
-        mask,
-        sum_frames=True,
-        scale="linear",
-        plot_colorbar=True,
-        vmin=0,
-        vmax=(nz, ny, nx),
+    analysis.show_mask(
         title="Mask before aliens removal\n",
-        is_orthogonal=not prm["use_rawdata"],
-        reciprocal_space=True,
-        cmap=prm["colormap"].cmap,
+        filename=setup.detector.savedir
+        + f"mask_before_masking_S{scan_nb}_{nz}_{ny}_{nx}_"
+        f"{setup.detector.binning[0]}"
+        f"_{setup.detector.binning[1]}_{setup.detector.binning[2]}.png",
+        vmax=(nz, ny, nx),
     )
-    if prm["debug"]:
-        fig.savefig(
-            setup.detector.savedir + f"mask_before_masking_S{scan_nb}_{nz}_{ny}_{nx}_"
-            f"{setup.detector.binning[0]}"
-            f"_{setup.detector.binning[1]}_{setup.detector.binning[2]}.png"
+
+    if analysis.is_orthogonal and analysis.data_loader.q_values is not None:
+        analysis.save_to_vti(
+            filename=os.path.join(
+                setup.detector.savedir,
+                f"S{scan_nb}_ortho_int" + comment + ".vti",
+            )
         )
-
-    if prm["flag_interact"]:
-        fig.canvas.mpl_disconnect(fig.canvas.manager.key_press_handler_id)
-        cid = plt.connect("close_event", gu.close_event)
-        fig.waitforbuttonpress()
-        plt.disconnect(cid)
-    plt.close(fig)
-
-    ###############################################
-    # save the orthogonalized diffraction pattern #
-    ###############################################
-    if not prm["use_rawdata"] and len(q_values) != 0:
-        qx = q_values[0]
-        qz = q_values[1]
-        qy = q_values[2]
-
-        if prm["save_to_vti"]:
-            # save diffraction pattern to vti
-            (
-                nqx,
-                nqz,
-                nqy,
-            ) = (
-                data.shape
-            )  # in nexus z downstream, y vertical / in q z vertical, x downstream
-            logger.info(
-                f"(dqx, dqy, dqz) = ({qx[1] - qx[0]:2f}, {qy[1] - qy[0]:2f}, "
-                f"{qz[1] - qz[0]:2f})"
-            )
-            # in nexus z downstream, y vertical / in q z vertical, x downstream
-            qx0 = qx.min()
-            dqx = (qx.max() - qx0) / nqx
-            qy0 = qy.min()
-            dqy = (qy.max() - qy0) / nqy
-            qz0 = qz.min()
-            dqz = (qz.max() - qz0) / nqz
-
-            gu.save_to_vti(
-                filename=os.path.join(
-                    setup.detector.savedir,
-                    f"S{scan_nb}_ortho_int" + comment + ".vti",
-                ),
-                voxel_size=(dqx, dqz, dqy),
-                tuple_array=data,
-                tuple_fieldnames="int",
-                origin=(qx0, qz0, qy0),
-                logger=logger,
-            )
 
     ########################################################
     # load an optional mask from the config and combine it #
     ########################################################
     mask_file = prm.get("mask")
     if isinstance(mask_file, str):
-        config_mask, _ = util.load_file(mask_file)
-        valid.valid_ndarray(config_mask, shape=data.shape)
-        config_mask[np.nonzero(config_mask)] = 1
-        mask = np.multiply(mask, config_mask.astype(mask.dtype))
+        analysis.update_mask(mask_file)
 
     if prm["flag_interact"]:
-        plt.ioff()
-        #############################################
-        # remove aliens
-        #############################################
-        nz, ny, nx = np.shape(data)
-        width = 5
-        max_colorbar = 5
-        flag_mask = False
-        flag_aliens = True
+        interactive_mask = analysis.get_interactive_mask()
+        ##################
+        # aliens removal #
+        ##################
+        interactive_mask.interactive_masking_aliens()
 
-        fig_mask, ((ax0, ax1), (ax2, ax3)) = plt.subplots(
-            nrows=2, ncols=2, figsize=(12, 6)
-        )
-        fig_mask.canvas.mpl_disconnect(fig_mask.canvas.manager.key_press_handler_id)
-        original_data = np.copy(data)
-        original_mask = np.copy(mask)
-        frame_index = starting_frame
-        ax0.imshow(
-            data[frame_index[0], :, :],
-            vmin=0,
-            vmax=max_colorbar,
-            cmap=prm["colormap"].cmap,
-        )
-        ax1.imshow(
-            data[:, frame_index[1], :],
-            vmin=0,
-            vmax=max_colorbar,
-            cmap=prm["colormap"].cmap,
-        )
-        ax2.imshow(
-            data[:, :, frame_index[2]],
-            vmin=0,
-            vmax=max_colorbar,
-            cmap=prm["colormap"].cmap,
-        )
-        ax3.set_visible(False)
-        ax0.axis("scaled")
-        ax1.axis("scaled")
-        ax2.axis("scaled")
-        if not prm["use_rawdata"]:
-            ax0.invert_yaxis()  # detector Y is vertical down
-        ax0.set_title(f"XY - Frame {frame_index[0] + 1} / {nz}")
-        ax1.set_title(f"XZ - Frame {frame_index[1] + 1} / {ny}")
-        ax2.set_title(f"YZ - Frame {frame_index[2] + 1} / {nx}")
-        fig_mask.text(
-            0.60,
-            0.30,
-            "m mask ; b unmask ; u next frame ; d previous frame",
-            size=12,
-        )
-        fig_mask.text(
-            0.60,
-            0.25,
-            "up larger ; down smaller ; right darker ; left brighter",
-            size=12,
-        )
-        fig_mask.text(0.60, 0.20, "p plot full image ; q quit", size=12)
-        plt.tight_layout()
-        plt.connect("key_press_event", press_key)
-        fig_mask.set_facecolor(prm["background_plot"])
-        plt.show()
-        del fig_mask, original_data, original_mask
-        gc.collect()
-
-        mask[np.nonzero(mask)] = 1
-
-        fig, _, _ = gu.multislices_plot(
-            data,
-            sum_frames=True,
-            scale="log",
-            plot_colorbar=True,
-            vmin=0,
+        analysis.show_masked_data(
             title="Data after aliens removal\n",
-            is_orthogonal=not prm["use_rawdata"],
-            reciprocal_space=True,
-            cmap=prm["colormap"].cmap,
+            filename=setup.detector.savedir
+            + f"data_after_aliens_removal_S{scan_nb}_{nz}_{ny}_{nx}_"
+            f"{setup.detector.binning[0]}"
+            f"_{setup.detector.binning[1]}_{setup.detector.binning[2]}.png",
         )
 
-        fig.canvas.mpl_disconnect(fig.canvas.manager.key_press_handler_id)
-        cid = plt.connect("close_event", gu.close_event)
-        fig.waitforbuttonpress()
-        plt.disconnect(cid)
-        plt.close(fig)
-
-        fig, _, _ = gu.multislices_plot(
-            mask,
-            sum_frames=True,
-            scale="linear",
-            plot_colorbar=True,
-            vmin=0,
-            vmax=(nz, ny, nx),
+        analysis.show_mask(
             title="Mask after aliens removal\n",
-            is_orthogonal=not prm["use_rawdata"],
-            reciprocal_space=True,
-            cmap=prm["colormap"].cmap,
+            filename=setup.detector.savedir
+            + f"mask_after_aliens_removal_S{scan_nb}_{nz}_{ny}_{nx}_"
+            f"{setup.detector.binning[0]}"
+            f"_{setup.detector.binning[1]}_{setup.detector.binning[2]}.png",
+            vmax=(nz, ny, nx),
         )
 
-        fig.canvas.mpl_disconnect(fig.canvas.manager.key_press_handler_id)
-        cid = plt.connect("close_event", gu.close_event)
-        fig.waitforbuttonpress()
-        plt.disconnect(cid)
-        plt.close(fig)
+        interactive_mask.refine_mask()  # (remove remaining hotpixels, ...)
 
-        ###############
-        # define mask #
-        ###############
-        width = 0
-        max_colorbar = 5
-        flag_aliens = False
-        flag_mask = True
-        flag_pause = False  # press x to pause for pan/zoom
-        previous_axis = None
-        xy: List[List[int]] = []  # list of points for mask
-
-        fig_mask, ((ax0, ax1), (ax2, ax3)) = plt.subplots(
-            nrows=2, ncols=2, figsize=(12, 6)
-        )
-        fig_mask.canvas.mpl_disconnect(fig_mask.canvas.manager.key_press_handler_id)
-        original_data = np.copy(data)
-        updated_mask = np.zeros((nz, ny, nx))
-        data[mask == 1] = 0  # will appear as grey in the log plot (nan)
-        ax0.imshow(
-            np.log10(abs(data).sum(axis=0)),
-            vmin=0,
-            vmax=max_colorbar,
-            cmap=prm["colormap"].cmap,
-        )
-        ax1.imshow(
-            np.log10(abs(data).sum(axis=1)),
-            vmin=0,
-            vmax=max_colorbar,
-            cmap=prm["colormap"].cmap,
-        )
-        ax2.imshow(
-            np.log10(abs(data).sum(axis=2)),
-            vmin=0,
-            vmax=max_colorbar,
-            cmap=prm["colormap"].cmap,
-        )
-        ax3.set_visible(False)
-        ax0.axis("scaled")
-        ax1.axis("scaled")
-        ax2.axis("scaled")
-        if not prm["use_rawdata"]:
-            ax0.invert_yaxis()  # detector Y is vertical down
-        ax0.set_title("XY")
-        ax1.set_title("XZ")
-        ax2.set_title("YZ")
-        fig_mask.text(
-            0.60, 0.45, "click to select the vertices of a polygon mask", size=12
-        )
-        fig_mask.text(
-            0.60, 0.40, "x to pause/resume polygon masking for pan/zoom", size=12
-        )
-        fig_mask.text(0.60, 0.35, "p plot mask ; r reset current points", size=12)
-        fig_mask.text(
-            0.60,
-            0.30,
-            "m square mask ; b unmask ; right darker ; left brighter",
-            size=12,
-        )
-        fig_mask.text(
-            0.60, 0.25, "up larger masking box ; down smaller masking box", size=12
-        )
-        fig_mask.text(0.60, 0.20, "a restart ; q quit", size=12)
-        info_text = fig_mask.text(0.60, 0.05, "masking enabled", size=16)
-        plt.tight_layout()
-        plt.connect("key_press_event", press_key)
-        plt.connect("button_press_event", on_click)
-        fig_mask.set_facecolor(prm["background_plot"])
-        plt.show()
-
-        mask[np.nonzero(updated_mask)] = 1
-        data = original_data
-
-        del fig_mask, flag_pause, flag_mask, original_data, updated_mask
-        gc.collect()
-
-    mask[np.nonzero(mask)] = 1
-    data[mask == 1] = 0
+    analysis.set_binary_mask()
+    analysis.apply_mask_to_data()
 
     #############################################
     # save the interactive mask for later reuse #
     #############################################
-    np.savez_compressed(
-        setup.detector.savedir + f"S{scan_nb}_interactive_mask",
-        hotpixels=mask.astype(int),
+    analysis.save_hotpixels(
+        filename=setup.detector.savedir + f"S{scan_nb}_interactive_mask"
     )
 
     ###############################################
     # mask or median filter isolated empty pixels #
     ###############################################
-    if prm["median_filter"] in {"mask_isolated", "interp_isolated"}:
-        logger.info("Filtering isolated pixels")
-        nb_pix = 0
-        for idx in range(
-            pad_width[0], nz - pad_width[1]
-        ):  # filter only frames whith data (not padded)
-            data[idx, :, :], processed_pix, mask[idx, :, :] = util.mean_filter(
-                data=data[idx, :, :],
-                nb_neighbours=prm["median_filter_order"],
-                mask=mask[idx, :, :],
-                interpolate=prm["median_filter"],
-                min_count=3,
-                debugging=prm["debug"],
-                cmap=prm["colormap"].cmap,
-            )
-            nb_pix += processed_pix
-        logger.info(f"Total number of filtered pixels: {nb_pix}")
-    elif prm["median_filter"] == "median":  # apply median filter
-        logger.info("Applying median filtering")
-        for idx in range(pad_width[0], nz - pad_width[1]):
-            # filter only frames whith data (not padded)
-            data[idx, :, :] = scipy.signal.medfilt2d(data[idx, :, :], [3, 3])
+    if analysis.is_filtering_needed:
+        analysis.filter_data()
     else:
         logger.info("Skipping median filtering")
 
-    ##########################
-    # apply photon threshold #
-    ##########################
-    if prm["photon_threshold"] != 0:
-        mask[data < prm["photon_threshold"]] = 1
-        data[data < prm["photon_threshold"]] = 0
-        logger.info(f"Applying photon threshold < {prm['photon_threshold']}")
-
-    ################################################
-    # check for nans and infs in the data and mask #
-    ################################################
-    nz, ny, nx = data.shape
-    logger.info(f"Data size after masking: {data.shape}")
-    data, mask = util.remove_nan(data=data, mask=mask)
-    data[mask == 1] = 0
+    analysis.apply_photon_threshold()
+    analysis.remove_nan()
 
     ####################
     # debugging plots  #
     ####################
-    plt.ion()
-    if prm["debug"]:
-        z0, y0, x0 = center_of_mass(data)
-        fig, _, _ = gu.multislices_plot(
-            data,
-            sum_frames=False,
-            scale="log",
-            plot_colorbar=True,
-            vmin=0,
-            title="Masked data",
-            slice_position=[int(z0), int(y0), int(x0)],
-            is_orthogonal=not prm["use_rawdata"],
-            reciprocal_space=True,
-            cmap=prm["colormap"].cmap,
-        )
-        fig.savefig(
-            setup.detector.savedir
-            + f"middle_frame_S{scan_nb}_{nz}_{ny}_{nx}_{setup.detector.binning[0]}_"
-            f"{setup.detector.binning[1]}_{setup.detector.binning[2]}"
-            + comment
-            + ".png"
-        )
-        if not prm["flag_interact"]:
-            plt.close(fig)
-
-        fig, _, _ = gu.multislices_plot(
-            data,
-            sum_frames=True,
-            scale="log",
-            plot_colorbar=True,
-            vmin=0,
-            title="Masked data",
-            is_orthogonal=not prm["use_rawdata"],
-            reciprocal_space=True,
-            cmap=prm["colormap"].cmap,
-        )
-        fig.savefig(
-            setup.detector.savedir
-            + f"sum_S{scan_nb}_{nz}_{ny}_{nx}_{setup.detector.binning[0]}_"
-            f"{setup.detector.binning[1]}_{setup.detector.binning[2]}"
-            + comment
-            + ".png"
-        )
-        if not prm["flag_interact"]:
-            plt.close(fig)
-
-        fig, _, _ = gu.multislices_plot(
-            mask,
-            sum_frames=True,
-            scale="linear",
-            plot_colorbar=True,
-            vmin=0,
-            vmax=(nz, ny, nx),
-            title="Mask",
-            is_orthogonal=not prm["use_rawdata"],
-            reciprocal_space=True,
-            cmap=prm["colormap"].cmap,
-        )
-        fig.savefig(
-            setup.detector.savedir + f"mask_S{scan_nb}_{nz}_{ny}_{nx}_"
-            f"{setup.detector.binning[0]}_{setup.detector.binning[1]}_"
-            f"{setup.detector.binning[2]}" + comment + ".png"
-        )
-        if not prm["flag_interact"]:
-            plt.close(fig)
+    analysis.show_masked_data_at_com(
+        title="Masked data\n",
+        filename=setup.detector.savedir
+        + f"middle_frame_S{scan_nb}_{nz}_{ny}_{nx}_{setup.detector.binning[0]}_"
+        f"{setup.detector.binning[1]}_{setup.detector.binning[2]}" + comment + ".png",
+    )
+    analysis.show_masked_data(
+        title="Masked data\n",
+        filename=setup.detector.savedir
+        + f"sum_S{scan_nb}_{nz}_{ny}_{nx}_{setup.detector.binning[0]}_"
+        f"{setup.detector.binning[1]}_{setup.detector.binning[2]}" + comment + ".png",
+    )
+    analysis.show_mask(
+        title="Mask\n",
+        filename=setup.detector.savedir + f"mask_S{scan_nb}_{nz}_{ny}_{nx}_"
+        f"{setup.detector.binning[0]}_{setup.detector.binning[1]}_"
+        f"{setup.detector.binning[2]}" + comment + ".png",
+        vmax=(nz, ny, nx),
+    )
 
     ##################################################
     # bin the stacking axis if needed, the detector  #
     # plane was already binned when loading the data #
     ##################################################
-    if (
-        setup.detector.binning[0] != 1 and not prm["reload_orthogonal"]
-    ):  # data was already binned for reload_orthogonal
-        data = util.bin_data(
-            data,
-            (setup.detector.binning[0], 1, 1),
-            debugging=False,
-            cmap=prm["colormap"].cmap,
-            logger=logger,
-        )
-        mask = util.bin_data(
-            mask,
-            (setup.detector.binning[0], 1, 1),
-            debugging=False,
-            cmap=prm["colormap"].cmap,
-            logger=logger,
-        )
-        mask[np.nonzero(mask)] = 1
-        setup.detector.current_binning = list(
-            map(
-                mul,
-                setup.detector.current_binning,
-                (setup.detector.binning[0], 1, 1),
-            )
-        )
-        if not prm["use_rawdata"] and len(q_values) != 0:
-            numz = len(qx)
-            qx = qx[
-                : numz - (numz % setup.detector.binning[0]) : setup.detector.binning[0]
-            ]  # along Z
-            del numz
-    logger.info(f"Data size after binning the stacking dimension: {data.shape}")
-    expected_binning = list(
-        map(
-            mul,
-            setup.detector.preprocessing_binning,
-            setup.detector.binning,
-        )
-    )
-    if any(
-        val1 != val2
-        for val1, val2 in zip(setup.detector.current_binning, expected_binning)
-    ):
-        raise ValueError(
-            f"Mismatch in binning, current_binning = {setup.detector.current_binning}, "
-            f"expected binning = {expected_binning}"
-        )
+    if analysis.is_binning_rocking_axis_needed:
+        analysis.bin_rocking_axis()
+    analysis.check_binning()
 
     ##################################################################
     # final check of the shape to comply with FFT shape requirements #
     ##################################################################
-    final_shape = util.smaller_primes(data.shape, maxprime=7, required_dividers=(2,))
-    com = tuple(map(lambda x: int(np.rint(x)), center_of_mass(data)))
-    crop_center = pu.find_crop_center(
-        array_shape=data.shape, crop_shape=final_shape, pivot=com
-    )
-    data = util.crop_pad(
-        data,
-        output_shape=final_shape,
-        crop_center=crop_center,
-        cmap=prm["colormap"].cmap,
-        logger=logger,
-    )
-    mask = util.crop_pad(
-        mask,
-        output_shape=final_shape,
-        crop_center=crop_center,
-        cmap=prm["colormap"].cmap,
-        logger=logger,
-    )
-    logger.info(f"Data size after considering FFT shape requirements: {data.shape}")
-    nz, ny, nx = data.shape
-    comment = f"{comment}_{nz}_{ny}_{nx}" + binning_comment
+    analysis.crop_to_fft_compliant_shape()
+
+    nz, ny, nx = analysis.data.shape
+    comment.concatenate(f"{nz}_{ny}_{nx}" + binning_comment)
 
     ############################
     # save final data and mask #
     ############################
     logger.info(f"Saving directory: {setup.detector.savedir}")
     if prm["save_as_int"]:
-        data = data.astype(int)
-    logger.info(f"Data type before saving: {data.dtype}")
-    mask[np.nonzero(mask)] = 1
-    mask = mask.astype(int)
-    logger.info(f"Mask type before saving: {mask.dtype}")
-    if not prm["use_rawdata"] and len(q_values) != 0:
-        if prm["save_to_npz"]:
-            np.savez_compressed(
-                setup.detector.savedir + f"QxQzQy_S{scan_nb}" + comment,
-                qx=qx,
-                qz=qz,
-                qy=qy,
-            )
-        if prm["save_to_mat"]:
-            savemat(setup.detector.savedir + f"S{scan_nb}_qx.mat", {"qx": qx})
-            savemat(setup.detector.savedir + f"S{scan_nb}_qz.mat", {"qz": qz})
-            savemat(setup.detector.savedir + f"S{scan_nb}_qy.mat", {"qy": qy})
-        max_z = data.sum(axis=0).max()
-        fig, _, _ = gu.contour_slices(
-            data,
-            (qx, qz, qy),
-            sum_frames=True,
-            title="Final data",
-            plot_colorbar=True,
-            scale="log",
-            is_orthogonal=True,
-            levels=np.linspace(0, np.ceil(np.log10(max_z)), 150, endpoint=False),
-            reciprocal_space=True,
-            cmap=prm["colormap"].cmap,
+        analysis.cast_data_to_int()
+    logger.info(f"Data type before saving: {analysis.data.dtype}")
+    logger.info(f"Mask type before saving: {analysis.mask.dtype}")
+
+    if analysis.is_orthogonal and analysis.data_loader.q_values is not None:
+        analysis.save_q_values(
+            filename=setup.detector.savedir + f"QxQzQy_S{scan_nb}" + comment
         )
-        fig.savefig(
-            setup.detector.savedir
+        analysis.contour_data(
+            title="Final data\n",
+            filename=setup.detector.savedir
             + f"final_reciprocal_space_S{scan_nb}"
             + comment
-            + ".png"
-        )
-        plt.close(fig)
-
-    if prm["save_to_npz"]:
-        np.savez_compressed(
-            setup.detector.savedir + f"S{scan_nb}_pynx" + comment, data=data
-        )
-        np.savez_compressed(
-            setup.detector.savedir + f"S{scan_nb}_maskpynx" + comment, mask=mask
+            + ".png",
         )
 
-    if prm["save_to_mat"]:
-        # save to .mat, the new order is x y z (outboard, vertical up, downstream)
-        savemat(
-            setup.detector.savedir + f"S{scan_nb}_data.mat",
-            {"data": np.moveaxis(data.astype(np.float32), [0, 1, 2], [-1, -2, -3])},
-        )
-        savemat(
-            setup.detector.savedir + f"S{scan_nb}_mask.mat",
-            {"data": np.moveaxis(mask.astype(np.int8), [0, 1, 2], [-1, -2, -3])},
-        )
-
-    # save results in hdf5 file
-    with h5py.File(
-        f"{setup.detector.savedir}S{scan_nb}_preprocessing{comment}.h5", "w"
-    ) as hf:
-        out = hf.create_group("output")
-        par = hf.create_group("params")
-        out.create_dataset("data", data=data)
-        out.create_dataset("mask", data=mask)
-
-        if metadata is not None:
-            out.create_dataset("tilt_values", data=metadata["tilt_values"])
-            out.create_dataset("rocking_curve", data=metadata["rocking_curve"])
-            out.create_dataset("interp_tilt", data=metadata["interp_tilt_values"])
-            out.create_dataset("interp_curve", data=metadata["interp_rocking_curve"])
-            out.create_dataset("COM_rocking_curve", data=metadata["tilt_value_at_peak"])
-            out.create_dataset(
-                "detector_data_COM", data=metadata["detector_data_at_peak"]
-            )
-            out.create_dataset("interp_fwhm", data=metadata["interp_fwhm"])
-        try:
-            out.create_dataset("bragg_peak", data=prm["bragg_peak"])
-        except TypeError:
-            logger.info("Bragg peak position not computed.")
-        out.create_dataset("q_bragg", data=q_bragg)
-        out.create_dataset("qnorm", data=qnorm)
-        out.create_dataset("planar_distance", data=planar_distance)
-        if prm["rocking_angle"] != "energy":
-            out.create_dataset("bragg_inplane", data=prm["inplane_angle"])
-            out.create_dataset("bragg_outofplane", data=prm["outofplane_angle"])
-
-        par.create_dataset("detector", data=str(setup.detector.params))
-        par.create_dataset("setup", data=str(setup.params))
-        par.create_dataset("parameters", data=str(prm))
+    analysis.save_data(filename=setup.detector.savedir + f"S{scan_nb}_pynx" + comment)
+    analysis.save_mask(
+        filename=setup.detector.savedir + f"S{scan_nb}_maskpynx" + comment
+    )
+    analysis.save_results_as_h5(
+        filename=f"{setup.detector.savedir}S{scan_nb}_preprocessing{comment}.h5"
+    )
 
     ############################
     # plot final data and mask #
     ############################
-    data[np.nonzero(mask)] = 0
-    fig, _, _ = gu.multislices_plot(
-        data,
-        sum_frames=True,
-        scale="log",
-        plot_colorbar=True,
-        vmin=0,
-        title="Final data",
-        is_orthogonal=not prm["use_rawdata"],
-        reciprocal_space=True,
-        cmap=prm["colormap"].cmap,
+    analysis.apply_mask_to_data()
+    analysis.show_masked_data(
+        title="Final data\n",
+        filename=setup.detector.savedir + f"finalsum_S{scan_nb}" + comment + ".png",
     )
-    fig.savefig(setup.detector.savedir + f"finalsum_S{scan_nb}" + comment + ".png")
-    if not prm["flag_interact"]:
-        plt.close(fig)
-
-    fig, _, _ = gu.multislices_plot(
-        mask,
-        sum_frames=True,
-        scale="linear",
-        plot_colorbar=True,
-        vmin=0,
+    analysis.show_mask(
+        title="Final mask\n",
+        filename=setup.detector.savedir + f"finalmask_S{scan_nb}" + comment + ".png",
         vmax=(nz, ny, nx),
-        title="Final mask",
-        is_orthogonal=not prm["use_rawdata"],
-        reciprocal_space=True,
-        cmap=prm["colormap"].cmap,
     )
-    fig.savefig(setup.detector.savedir + f"finalmask_S{scan_nb}" + comment + ".png")
-    if not prm["flag_interact"]:
-        plt.close(fig)
-
-    del data, mask
-    gc.collect()
 
     if len(prm["scans"]) > 1:
         plt.close("all")

--- a/bcdi/preprocessing/process_scan.py
+++ b/bcdi/preprocessing/process_scan.py
@@ -281,7 +281,7 @@ def process_scan(
         analysis.update_mask(mask_file)
 
     if prm["flag_interact"]:
-        interactive_mask = analysis.get_interactive_mask()
+        interactive_mask = analysis.get_interactive_masker()
         ##################
         # aliens removal #
         ##################
@@ -305,6 +305,8 @@ def process_scan(
         )
 
         interactive_mask.refine_mask()  # (remove remaining hotpixels, ...)
+        analysis.mask = np.copy(interactive_mask.mask)
+        del interactive_mask
 
     analysis.set_binary_mask()
     analysis.apply_mask_to_data()
@@ -334,19 +336,23 @@ def process_scan(
         title="Masked data\n",
         filename=setup.detector.savedir
         + f"middle_frame_S{scan_nb}_{nz}_{ny}_{nx}_{setup.detector.binning[0]}_"
-        f"{setup.detector.binning[1]}_{setup.detector.binning[2]}" + comment + ".png",
+        f"{setup.detector.binning[1]}_{setup.detector.binning[2]}"
+        + comment.text
+        + ".png",
     )
     analysis.show_masked_data(
         title="Masked data\n",
         filename=setup.detector.savedir
         + f"sum_S{scan_nb}_{nz}_{ny}_{nx}_{setup.detector.binning[0]}_"
-        f"{setup.detector.binning[1]}_{setup.detector.binning[2]}" + comment + ".png",
+        f"{setup.detector.binning[1]}_{setup.detector.binning[2]}"
+        + comment.text
+        + ".png",
     )
     analysis.show_mask(
         title="Mask\n",
         filename=setup.detector.savedir + f"mask_S{scan_nb}_{nz}_{ny}_{nx}_"
         f"{setup.detector.binning[0]}_{setup.detector.binning[1]}_"
-        f"{setup.detector.binning[2]}" + comment + ".png",
+        f"{setup.detector.binning[2]}" + comment.text + ".png",
         vmax=(nz, ny, nx),
     )
 
@@ -377,19 +383,21 @@ def process_scan(
 
     if analysis.is_orthogonal and analysis.data_loader.q_values is not None:
         analysis.save_q_values(
-            filename=setup.detector.savedir + f"QxQzQy_S{scan_nb}" + comment
+            filename=setup.detector.savedir + f"QxQzQy_S{scan_nb}" + comment.text
         )
         analysis.contour_data(
             title="Final data\n",
             filename=setup.detector.savedir
             + f"final_reciprocal_space_S{scan_nb}"
-            + comment
+            + comment.text
             + ".png",
         )
 
-    analysis.save_data(filename=setup.detector.savedir + f"S{scan_nb}_pynx" + comment)
+    analysis.save_data(
+        filename=setup.detector.savedir + f"S{scan_nb}_pynx" + comment.text
+    )
     analysis.save_mask(
-        filename=setup.detector.savedir + f"S{scan_nb}_maskpynx" + comment
+        filename=setup.detector.savedir + f"S{scan_nb}_maskpynx" + comment.text
     )
     analysis.save_results_as_h5(
         filename=f"{setup.detector.savedir}S{scan_nb}_preprocessing{comment}.h5"
@@ -401,11 +409,17 @@ def process_scan(
     analysis.apply_mask_to_data()
     analysis.show_masked_data(
         title="Final data\n",
-        filename=setup.detector.savedir + f"finalsum_S{scan_nb}" + comment + ".png",
+        filename=setup.detector.savedir
+        + f"finalsum_S{scan_nb}"
+        + comment.text
+        + ".png",
     )
     analysis.show_mask(
         title="Final mask\n",
-        filename=setup.detector.savedir + f"finalmask_S{scan_nb}" + comment + ".png",
+        filename=setup.detector.savedir
+        + f"finalmask_S{scan_nb}"
+        + comment.text
+        + ".png",
         vmax=(nz, ny, nx),
     )
 

--- a/bcdi/preprocessing/process_scan.py
+++ b/bcdi/preprocessing/process_scan.py
@@ -27,8 +27,8 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
-from bcdi.preprocessing.analysis import create_analysis
 from bcdi.experiment.setup import Setup
+from bcdi.preprocessing.analysis import create_analysis
 from bcdi.utils.snippets_logging import FILE_FORMATTER
 
 logger = logging.getLogger(__name__)

--- a/bcdi/preprocessing/process_scan.py
+++ b/bcdi/preprocessing/process_scan.py
@@ -48,7 +48,6 @@ def process_scan(
     :param scan_idx: index of the scan to be processed in prm["scans"]
     :param prm: the parsed parameters
     """
-
     ####################################################
     # Initialize parameters for the callback functions #
     ####################################################

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -1653,13 +1653,19 @@ def line(x_array, a, b):
     return a * x_array + b
 
 
-def pad_from_roi(arrays, roi, binning, pad_value=0, **kwargs):
+def pad_from_roi(
+    arrays: Union[np.ndarray, Tuple[np.ndarray, ...]],
+    roi: List[int],
+    binning: Tuple[int, int],
+    pad_value: Union[float, Tuple[float, ...]] = 0.0,
+    **kwargs,
+) -> Union[np.ndarray, Tuple[np.ndarray, ...]]:
     """
     Pad a 3D stack of frames provided a region of interest.
 
     The stacking is assumed to be on the first axis.
 
-    :param arrays: a 3D array of a sequence of 3D arrays of the same shape
+    :param arrays: a 3D array or a sequence of 3D arrays of the same shape
     :param roi: the desired region of interest of the unbinned frame. For an array in
      arrays, the shape is (nz, ny, nx), and roi corresponds to [y0, y1, x0, x1]
     :param binning: tuple of two integers (binning along Y, binning along X)
@@ -1670,7 +1676,7 @@ def pad_from_roi(arrays, roi, binning, pad_value=0, **kwargs):
     :return: an array (if a single array was provided) or a tuple of arrays interpolated
      on an orthogonal grid (same length as the number of input arrays)
     """
-    logger = kwargs.get("logger", module_logger)
+    logger: Logger = kwargs.get("logger", module_logger)
     ####################
     # check parameters #
     ####################
@@ -1690,7 +1696,7 @@ def pad_from_roi(arrays, roi, binning, pad_value=0, **kwargs):
         length=2,
         name="binning",
     )
-    if isinstance(pad_value, Real):
+    if isinstance(pad_value, float):
         pad_value = (pad_value,) * nb_arrays
     valid.valid_container(
         pad_value,
@@ -1738,8 +1744,8 @@ def pad_from_roi(arrays, roi, binning, pad_value=0, **kwargs):
             output_arrays.append(array)
 
         if nb_arrays == 1:
-            output_arrays = output_arrays[0]  # return the array instead of the tuple
-        return output_arrays
+            return np.asarray(output_arrays[0])  # return the array instead of the tuple
+        return tuple(output_arrays)
     return arrays
 
 

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -573,6 +573,64 @@ def dos2unix(input_file: str, savedir: str) -> None:
             output.write(row + str.encode("\n"))
 
 
+def find_crop_center(array_shape, crop_shape, pivot):
+    """
+    Find the position of the center of the cropping window.
+
+    It finds the closest voxel to pivot which allows to crop an array of array_shape to
+    crop_shape.
+
+    :param array_shape: initial shape of the array
+    :type array_shape: tuple
+    :param crop_shape: final shape of the array
+    :type crop_shape: tuple
+    :param pivot: position on which the final region of interest dhould be centered
+     (center of mass of the Bragg peak)
+    :type pivot: tuple
+    :return: the voxel position closest to pivot which allows cropping to the defined
+     shape.
+    """
+    valid.valid_container(
+        array_shape,
+        container_types=(tuple, list, np.ndarray),
+        min_length=1,
+        item_types=int,
+        name="array_shape",
+    )
+    ndim = len(array_shape)
+    valid.valid_container(
+        crop_shape,
+        container_types=(tuple, list, np.ndarray),
+        length=ndim,
+        item_types=int,
+        name="crop_shape",
+    )
+    valid.valid_container(
+        pivot,
+        container_types=(tuple, list, np.ndarray),
+        length=ndim,
+        item_types=int,
+        name="pivot",
+    )
+    crop_center = np.empty(ndim)
+    for idx, _ in enumerate(range(ndim)):
+        if max(0, pivot[idx] - crop_shape[idx] // 2) == 0:
+            # not enough range on this side of the com
+            crop_center[idx] = crop_shape[idx] // 2
+        else:
+            if (
+                min(array_shape[idx], pivot[idx] + crop_shape[idx] // 2)
+                == array_shape[idx]
+            ):
+                # not enough range on this side of the com
+                crop_center[idx] = array_shape[idx] - crop_shape[idx] // 2
+            else:
+                crop_center[idx] = pivot[idx]
+
+    crop_center = list(map(int, crop_center))
+    return crop_center
+
+
 def find_file(filename: Optional[str], default_folder: str, **kwargs) -> str:
     """
     Locate a file.

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -82,7 +82,7 @@ def apply_logical_array(
     # number of measured frames during the experiment
     # frames_logical[idx]=-1 means that a frame was added (padding) at index idx
     original_frames = frames_logical[frames_logical != -1]
-    nb_original = int(original_frames.sum())
+    nb_original = len(original_frames)
 
     output = []
     for array in arrays:

--- a/bcdi/utils/validation.py
+++ b/bcdi/utils/validation.py
@@ -9,6 +9,7 @@
 
 from numbers import Number, Real
 from typing import List, Optional, Tuple, Union
+
 import numpy as np
 
 

--- a/bcdi/utils/validation.py
+++ b/bcdi/utils/validation.py
@@ -8,7 +8,7 @@
 """Functions related to the validation of input parameters."""
 
 from numbers import Number, Real
-
+from typing import List, Optional, Tuple, Union
 import numpy as np
 
 
@@ -433,8 +433,13 @@ def valid_1d_array(
 
 
 def valid_ndarray(
-    arrays, ndim=None, shape=None, fix_ndim=True, fix_shape=True, name=None
-):
+    arrays: Union[np.ndarray, Tuple[np.ndarray, ...]],
+    ndim: Optional[Union[int, Tuple[int, ...]]] = None,
+    shape: Optional[Tuple[int, ...]] = None,
+    fix_ndim: bool = True,
+    fix_shape: bool = True,
+    name: Optional[str] = None,
+) -> bool:
     """
     Check that arrays have the same shape and the correct number of dimensions.
 
@@ -447,7 +452,7 @@ def valid_ndarray(
     :return: True if checks pass, raise some error otherwise
     """
     # check the validity of the requirements
-    if isinstance(ndim, Number):
+    if isinstance(ndim, int):
         ndim = (ndim,)
     valid_container(
         ndim,

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,6 +1,9 @@
 Future:
 -------
 
+* Create classes Analysis, PreprocessingLoader and InteractiveMasker for preprocessing.
+  Refactor `preprocessing.process_scan` to use these classes.
+
 * Add support for ESRF BM02 beamline (th rocking curve).
 
 * Create classes Analysis, PhaseManipulator and InterpolatedCrystal for postprocessing.

--- a/tests/preprocessing/test_analysis.py
+++ b/tests/preprocessing/test_analysis.py
@@ -5,19 +5,13 @@
 #   (c) 07/2019-05/2021 : DESY PHOTON SCIENCE
 #       authors:
 #         Jerome Carnis, carnis_jerome@yahoo.fr
-import os.path
-import tempfile
+
 import unittest
-from copy import deepcopy
-from logging import Logger
 from pathlib import Path
-from unittest.mock import patch
 
 import matplotlib
-import numpy as np
 
 import bcdi.preprocessing.analysis as analysis
-from bcdi.experiment.setup import Setup
 from bcdi.preprocessing.preprocessing_runner import initialize_parameters_bcdi
 from bcdi.utils.parser import ConfigParser
 from tests.config import run_tests
@@ -32,3 +26,40 @@ try:
     skip_tests = False
 except ValueError:
     skip_tests = True
+
+
+class TestDefineAnalysisType(unittest.TestCase):
+    def test_reload_orthogonal_true(self) -> None:
+        self.assertTrue(
+            analysis.define_analysis_type(
+                reload_orthogonal=True, use_rawdata=True, interpolation_method=""
+            ),
+            "interpolated",
+        )
+        self.assertTrue(
+            analysis.define_analysis_type(
+                reload_orthogonal=True, use_rawdata=False, interpolation_method=""
+            ),
+            "interpolated",
+        )
+
+    def test_reload_orthogonal_false_use_rawdata(self) -> None:
+        self.assertTrue(
+            analysis.define_analysis_type(
+                reload_orthogonal=False, use_rawdata=True, interpolation_method=""
+            ),
+            "detector_frame",
+        )
+
+    def test_reload_orthogonal_false_interpolate_rawdata(self) -> None:
+        method = "this_method"
+        self.assertTrue(
+            analysis.define_analysis_type(
+                reload_orthogonal=False, use_rawdata=False, interpolation_method=method
+            ),
+            method,
+        )
+
+
+if __name__ == "__main__":
+    run_tests(TestDefineAnalysisType)

--- a/tests/preprocessing/test_analysis.py
+++ b/tests/preprocessing/test_analysis.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+# BCDI: tools for pre(post)-processing Bragg coherent X-ray diffraction imaging data
+#   (c) 07/2017-06/2019 : CNRS UMR 7344 IM2NP
+#   (c) 07/2019-05/2021 : DESY PHOTON SCIENCE
+#       authors:
+#         Jerome Carnis, carnis_jerome@yahoo.fr
+import os.path
+import tempfile
+import unittest
+from copy import deepcopy
+from logging import Logger
+from pathlib import Path
+from unittest.mock import patch
+
+import matplotlib
+import numpy as np
+
+import bcdi.preprocessing.analysis as analysis
+from bcdi.experiment.setup import Setup
+from bcdi.preprocessing.preprocessing_runner import initialize_parameters_bcdi
+from bcdi.utils.parser import ConfigParser
+from tests.config import run_tests
+
+here = Path(__file__).parent
+THIS_DIR = str(here)
+CONFIG = str(here.parents[1] / "bcdi/examples/S11_config_preprocessing.yml")
+try:
+    parameters = initialize_parameters_bcdi(ConfigParser(CONFIG).load_arguments())
+    parameters.update({"backend": "agg"})
+    matplotlib.use(parameters["backend"])
+    skip_tests = False
+except ValueError:
+    skip_tests = True


### PR DESCRIPTION
## Description

Create classes Analysis, PreprocessingLoader and InteractiveMasker for preprocessing. Each preprocessing case (loading/reloading, interpolation or not) is using a child class. Refactor `preprocessing.process_scan` to use these classes, so that it is much easier to follow analysis steps.

Fixes #301 

## Type of change

- [X] Refactor (non-breaking change which adds functionality)

## How has this been tested?

- [X] I have made corresponding changes to the documentation
- [X] I have added (some) corresponding unit tests -> need to remove temporal coupling in Setup
- [X] I have run ``doit`` and all tasks have passed
