### PR TITLE
Remove temporal coupling in Setup initialization

### DIFF
--- a/bcdi/experiment/beamline.py
+++ b/bcdi/experiment/beamline.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
 import numpy as np
 
-from bcdi.experiment.beamline_factory import BeamlineGoniometer, BeamlineSaxs
+from bcdi.experiment.beamline_factory import Beamline, BeamlineGoniometer, BeamlineSaxs
 from bcdi.utils import utilities as util
 from bcdi.utils import validation as valid
 
@@ -31,32 +31,39 @@ if TYPE_CHECKING:
 module_logger = logging.getLogger(__name__)
 
 
-def create_beamline(name, **kwargs):
+def create_beamline(name, sample_offsets=None, **kwargs) -> Beamline:
     """
     Create the instance of the beamline.
 
     :param name: str, name of the beamline
-    :param kwargs: optional beamline-dependent parameters
+    :param sample_offsets: list or tuple of angles in degrees, corresponding to
+     the offsets of each of the sample circles (the offset for the most outer circle
+     should be at index 0). The number of circles is beamline dependent. Convention:
+     the sample offsets will be subtracted to measurement the motor values.
+    :param kwargs:
+     - optional beamline-dependent parameters
+     - 'logger': an optional logger
+
     :return: the corresponding beamline instance
     """
     if name in {"ID01", "ID01BLISS"}:
-        return BeamlineID01(name=name, **kwargs)
+        return BeamlineID01(name=name, sample_offsets=sample_offsets, **kwargs)
     if name == "BM02":
-        return BeamlineBM02(name=name, **kwargs)
+        return BeamlineBM02(name=name, sample_offsets=sample_offsets, **kwargs)
     if name == "ID27":
-        return BeamlineID27(name=name, **kwargs)
+        return BeamlineID27(name=name, sample_offsets=sample_offsets, **kwargs)
     if name in {"SIXS_2018", "SIXS_2019"}:
-        return BeamlineSIXS(name=name, **kwargs)
+        return BeamlineSIXS(name=name, sample_offsets=sample_offsets, **kwargs)
     if name == "34ID":
-        return Beamline34ID(name=name, **kwargs)
+        return Beamline34ID(name=name, sample_offsets=sample_offsets, **kwargs)
     if name == "P10":
-        return BeamlineP10(name=name, **kwargs)
+        return BeamlineP10(name=name, sample_offsets=sample_offsets, **kwargs)
     if name == "P10_SAXS":
-        return BeamlineP10SAXS(name=name, **kwargs)
+        return BeamlineP10SAXS(name=name, sample_offsets=sample_offsets, **kwargs)
     if name == "CRISTAL":
-        return BeamlineCRISTAL(name=name, **kwargs)
+        return BeamlineCRISTAL(name=name, sample_offsets=sample_offsets, **kwargs)
     if name == "NANOMAX":
-        return BeamlineNANOMAX(name=name, **kwargs)
+        return BeamlineNANOMAX(name=name, sample_offsets=sample_offsets, **kwargs)
     raise ValueError(f"Beamline {name} not supported")
 
 

--- a/bcdi/experiment/beamline_factory.py
+++ b/bcdi/experiment/beamline_factory.py
@@ -74,6 +74,10 @@ class Beamline(ABC):
     Base class for defining a beamline.
 
     :param name: name of the beamline
+    :param sample_offsets: list or tuple of angles in degrees, corresponding to
+     the offsets of each of the sample circles (the offset for the most outer circle
+     should be at index 0). The number of circles is beamline dependent. Convention:
+     the sample offsets will be subtracted to measurement the motor values.
     :param kwargs:
 
      - optional beamline-dependent parameters
@@ -88,17 +92,16 @@ class Beamline(ABC):
     # "x-" detector horizontal axis inboard, as it should be in the CXI convention
     # "y-" detector vertical axis down, as it should be in the CXI convention
 
-    def __init__(self, name, **kwargs):
+    def __init__(self, name, sample_offsets=None, **kwargs):
         self.logger = kwargs.get("logger", module_logger)
         self.name = name
         self.diffractometer = DiffractometerFactory().create_diffractometer(
-            name=name, **kwargs
+            name=name, sample_offsets=sample_offsets, **kwargs
         )
-        loader_kwargs = {"logger": self.logger} if kwargs.get("logger") else {}
         self.loader = create_loader(
             name=name,
             sample_offsets=self.diffractometer.sample_offsets,
-            **loader_kwargs,
+            **kwargs,
         )
         self.sample_angles: Optional[Tuple[Union[float, List, np.ndarray]]] = None
 

--- a/bcdi/experiment/detector.py
+++ b/bcdi/experiment/detector.py
@@ -126,14 +126,13 @@ class Detector(ABC):
      integrated intensity
     :param binning: binning factor of the 3D dataset
      (stacking dimension, detector vertical axis, detector horizontal axis)
-    :param kwargs:
-
-     - 'preprocessing_binning': tuple of the three binning factors used in a previous
+    :param preprocessing_binning: tuple of the three binning factors used in a previous
        preprocessing step
-     - 'offsets': tuple or list, sample and detector offsets corresponding to the
+    :param offsets: tuple or list, sample and detector offsets corresponding to the
        parameter delta in xrayutilities hxrd.Ang2Q.area method
-     - 'linearity_func': function to apply to each pixel of the detector in order to
+    :param linearity_func: function to apply to each pixel of the detector in order to
        compensate the deviation of the detector linearity for large intensities.
+    :param kwargs:
      - 'logger': an optional logger
 
     """
@@ -144,24 +143,26 @@ class Detector(ABC):
         rootdir=None,
         datadir=None,
         savedir=None,
-        template_file=None,
         template_imagefile=None,
         specfile=None,
         sample_name=None,
         roi=None,
         sum_roi=None,
         binning=(1, 1, 1),
+        preprocessing_binning=(1, 1, 1),
+        offsets=None,
+        linearity_func=None,
         **kwargs,
     ):
         # the detector name should be initialized first,
-        # other properties are depending on it
+        # other properties depend on it
         self._name = name
 
         # load the kwargs
         self.logger = kwargs.get("logger", module_logger)
-        self.preprocessing_binning = kwargs.get("preprocessing_binning") or (1, 1, 1)
-        self.offsets = kwargs.get("offsets")  # delegate the test to xrayutilities
-        self.linearity_func = kwargs.get("linearity_func")
+        self.preprocessing_binning = preprocessing_binning
+        self.offsets = offsets  # delegate the test to xrayutilities
+        self.linearity_func = linearity_func
 
         # load other positional arguments
         self.binning = binning
@@ -172,7 +173,6 @@ class Detector(ABC):
         self.datadir = datadir
         self.savedir = savedir
         self.sample_name = sample_name
-        self.template_file = template_file
         self.template_imagefile = template_imagefile
         self.specfile = specfile
 
@@ -342,7 +342,6 @@ class Detector(ABC):
             "scandir": self.scandir,
             "savedir": self.savedir,
             "sample_name": self.sample_name,
-            "template_file": self.template_file,
             "template_imagefile": self.template_imagefile,
             "specfile": self.specfile,
         }
@@ -494,22 +493,6 @@ class Detector(ABC):
         if value[1] <= value[0] or value[3] <= value[2]:
             raise ValueError("roi coordinates should be increasing in x and y")
         self._sum_roi = value
-
-    @property
-    def template_file(self):
-        """Template that can be used to generate template_imagefile."""
-        return self._template_file
-
-    @template_file.setter
-    def template_file(self, value):
-        valid.valid_container(
-            value,
-            container_types=str,
-            min_length=0,
-            allow_none=True,
-            name="Detector.template_file",
-        )
-        self._template_file = value
 
     @property
     def template_imagefile(self):

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -1261,11 +1261,7 @@ class LoaderID01(Loader):
 
         detector_distance = (
             self.retrieve_distance(
-                util.find_file(
-                    filename=setup.detector.specfile,
-                    default_folder=setup.detector.rootdir,
-                    logger=self.logger,
-                )
+                filename=setup.detector.specfile, default_folder=setup.detector.rootdir
             )
             or setup.distance
         )
@@ -1325,16 +1321,26 @@ class LoaderID01(Loader):
         )
         return monitor
 
-    def retrieve_distance(self, filename: str) -> Optional[float]:
+    def retrieve_distance(self, filename: str, default_folder: str) -> Optional[float]:
         """
         Load the spec file and retrieve the detector distance if it has been calibrated.
 
-        :param filename: full path to the spec or log file
+        :param filename: name of the spec file
+        :param default_folder: folder where the spec file is expected
         :return: the detector distance in meters or None
         """
         distance = None
         found_distance = 0
-        with open(filename, "r") as file:
+        if not filename.endswith(".spec"):
+            raise ValueError(f"Expecting a spec file, got {filename}")
+        with open(
+            util.find_file(
+                filename=filename,
+                default_folder=default_folder,
+                logger=self.logger,
+            ),
+            "r",
+        ) as file:
             lines = file.readlines()
             for line in lines:
                 if line.startswith("#UDETCALIB"):

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -1083,7 +1083,8 @@ class LoaderID01(Loader):
         file = kwargs.get("file")  # this kwarg is provided by @safeload
         if file is None:
             raise ValueError("file should be the opened file, not None")
-
+        if setup.logfile is None:
+            raise ValueError("logfile undefined")
         scan_number = setup.logfile.scan_number
         if not isinstance(scan_number, int):
             raise TypeError(
@@ -1183,7 +1184,8 @@ class LoaderID01(Loader):
         file = kwargs.get("file")  # this kwarg is provided by @safeload
         if file is None:
             raise ValueError("file should be the opened file, not None")
-
+        if setup.logfile is None:
+            raise ValueError("logfile undefined")
         scan_number = setup.logfile.scan_number
         if not isinstance(scan_number, int):
             raise TypeError(
@@ -1257,7 +1259,16 @@ class LoaderID01(Loader):
             nu = setup.custom_motors["nu"]
             energy = setup.energy
 
-        detector_distance = self.retrieve_distance(setup=setup) or setup.distance
+        detector_distance = (
+            self.retrieve_distance(
+                util.find_file(
+                    filename=setup.detector.specfile,
+                    default_folder=setup.detector.rootdir,
+                    logger=self.logger,
+                )
+            )
+            or setup.distance
+        )
         return mu, eta, phi, nu, delta, energy, detector_distance
 
     @safeload
@@ -1272,7 +1283,8 @@ class LoaderID01(Loader):
         file = kwargs.get("file")  # this kwarg is provided by @safeload_static
         if file is None:
             raise ValueError("file should be the opened file, not None")
-
+        if setup.logfile is None:
+            raise ValueError("logfile undefined")
         scan_number = setup.logfile.scan_number
         if not isinstance(scan_number, int):
             raise TypeError(
@@ -1297,6 +1309,8 @@ class LoaderID01(Loader):
         :param setup: an instance of the class Setup
         :return: the default monitor values
         """
+        if setup.logfile is None:
+            raise ValueError("logfile undefined")
         scan_number = setup.logfile.scan_number
         if not isinstance(scan_number, int):
             raise TypeError(
@@ -1311,22 +1325,16 @@ class LoaderID01(Loader):
         )
         return monitor
 
-    def retrieve_distance(self, setup: "Setup") -> Optional[float]:
+    def retrieve_distance(self, filename: str) -> Optional[float]:
         """
         Load the spec file and retrieve the detector distance if it has been calibrated.
 
-        :param setup: an instance of the class Setup
+        :param filename: full path to the spec or log file
         :return: the detector distance in meters or None
         """
-        path = util.find_file(
-            filename=setup.detector.specfile,
-            default_folder=setup.detector.rootdir,
-            logger=self.logger,
-        )
-
         distance = None
         found_distance = 0
-        with open(path, "r") as file:
+        with open(filename, "r") as file:
             lines = file.readlines()
             for line in lines:
                 if line.startswith("#UDETCALIB"):
@@ -1458,7 +1466,8 @@ class LoaderBM02(Loader):
         file = kwargs.get("file")  # this kwarg is provided by @safeload
         if file is None:
             raise ValueError("file should be the opened file, not None")
-
+        if setup.logfile is None:
+            raise ValueError("logfile undefined")
         scan_number = setup.logfile.scan_number
         if not isinstance(scan_number, int):
             raise TypeError(
@@ -1549,7 +1558,8 @@ class LoaderBM02(Loader):
         file = kwargs.get("file")  # this kwarg is provided by @safeload
         if file is None:
             raise ValueError("file should be the opened file, not None")
-
+        if setup.logfile is None:
+            raise ValueError("logfile undefined")
         scan_number = setup.logfile.scan_number
         if not isinstance(scan_number, int):
             raise TypeError(
@@ -1642,7 +1652,8 @@ class LoaderBM02(Loader):
         file = kwargs.get("file")  # this kwarg is provided by @safeload_static
         if file is None:
             raise ValueError("file should be the opened file, not None")
-
+        if setup.logfile is None:
+            raise ValueError("logfile undefined")
         scan_number = setup.logfile.scan_number
         if not isinstance(scan_number, int):
             raise TypeError(
@@ -1667,6 +1678,8 @@ class LoaderBM02(Loader):
         :param setup: an instance of the class Setup
         :return: the default monitor values
         """
+        if setup.logfile is None:
+            raise ValueError("logfile undefined")
         scan_number = setup.logfile.scan_number
         if not isinstance(scan_number, int):
             raise TypeError(
@@ -1779,7 +1792,8 @@ class LoaderID01BLISS(Loader):
         file = kwargs.get("file")  # this kwarg is provided by @safeload
         if file is None:
             raise ValueError("file should be the opened file, not None")
-
+        if setup.logfile is None:
+            raise ValueError("logfile undefined")
         scan_number = setup.logfile.scan_number
         if scan_number is None:
             raise ValueError("'scan_number' parameter required")
@@ -1853,7 +1867,8 @@ class LoaderID01BLISS(Loader):
         file = kwargs.get("file")  # this kwarg is provided by @safeload
         if file is None:
             raise ValueError("file should be the opened file, not None")
-
+        if setup.logfile is None:
+            raise ValueError("logfile undefined")
         scan_number = setup.logfile.scan_number
         if scan_number is None:
             raise ValueError("'scan_number' parameter required")
@@ -1909,7 +1924,8 @@ class LoaderID01BLISS(Loader):
         file = kwargs.get("file")  # this kwarg is provided by @safeload_static
         if file is None:
             raise ValueError("file should be the opened file, not None")
-
+        if setup.logfile is None:
+            raise ValueError("logfile undefined")
         scan_number = setup.logfile.scan_number
         if scan_number is None:
             raise ValueError("'scan_number' parameter required")
@@ -1934,6 +1950,8 @@ class LoaderID01BLISS(Loader):
         :param setup: an instance of the class Setup
         :return: the default monitor values
         """
+        if setup.logfile is None:
+            raise ValueError("logfile undefined")
         scan_number = setup.logfile.scan_number
         if scan_number is None:
             raise ValueError("'scan_number' parameter required")
@@ -2044,7 +2062,8 @@ class LoaderID27(Loader):
         file = kwargs.get("file")  # this kwarg is provided by @safeload
         if file is None:
             raise ValueError("file should be the opened file, not None")
-
+        if setup.logfile is None:
+            raise ValueError("logfile undefined")
         scan_number = setup.logfile.scan_number
         if scan_number is None:
             raise ValueError("'scan_number' parameter required")
@@ -2100,7 +2119,8 @@ class LoaderID27(Loader):
         file = kwargs.get("file")  # this kwarg is provided by @safeload
         if file is None:
             raise ValueError("file should be the opened file, not None")
-
+        if setup.logfile is None:
+            raise ValueError("logfile undefined")
         scan_number = setup.logfile.scan_number
         if scan_number is None:
             raise ValueError("'scan_number' parameter required")
@@ -2142,7 +2162,8 @@ class LoaderID27(Loader):
         file = kwargs.get("file")  # this kwarg is provided by @safeload_static
         if file is None:
             raise ValueError("file should be the opened file, not None")
-
+        if setup.logfile is None:
+            raise ValueError("logfile undefined")
         scan_number = setup.logfile.scan_number
         if scan_number is None:
             raise ValueError("'scan_number' parameter required")
@@ -2163,6 +2184,8 @@ class LoaderID27(Loader):
         :param setup: an instance of the class Setup
         :return: the default monitor values
         """
+        if setup.logfile is None:
+            raise ValueError("logfile undefined")
         scan_number = setup.logfile.scan_number
         monitor_name: Optional[str] = None
         if scan_number is None:
@@ -2332,7 +2355,7 @@ class LoaderSIXS(Loader):
         elif setup.detector.name == "MerlinSixS":
             tmp_data = file.merlin[:]
         else:  # Maxipix
-            if setup.beamline == "SIXS_2018":
+            if setup.beamline == "SIXS_2018":  # type: ignore
                 tmp_data = file.mfilm[:]
             else:
                 try:
@@ -2441,9 +2464,7 @@ class LoaderSIXS(Loader):
         :param setup: an instance of the class Setup
         :return: the default monitor values
         """
-        if setup.beamline is None:
-            raise ValueError("'beamline' parameter required")
-        if setup.beamline == "SIXS_2018":
+        if setup.beamline == "SIXS_2018":  # type: ignore
             monitor: np.ndarray = self.read_device(setup=setup, device_name="imon1")
         else:  # "SIXS_2019"
             monitor = self.read_device(setup=setup, device_name="imon0")
@@ -2565,7 +2586,8 @@ class Loader34ID(Loader):
         file = kwargs.get("file")  # this kwarg is provided by @safeload
         if file is None:
             raise ValueError("file should be the opened file, not None")
-
+        if setup.logfile is None:
+            raise ValueError("logfile undefined")
         scan_number = setup.logfile.scan_number
         if scan_number is None:
             raise ValueError("'scan_number' parameter required")
@@ -2665,7 +2687,8 @@ class Loader34ID(Loader):
         file = kwargs.get("file")  # this kwarg is provided by @safeload
         if file is None:
             raise ValueError("file should be the opened file, not None")
-
+        if setup.logfile is None:
+            raise ValueError("logfile undefined")
         scan_number = setup.logfile.scan_number
 
         if not setup.custom_scan:
@@ -2741,7 +2764,8 @@ class Loader34ID(Loader):
         file = kwargs.get("file")  # this kwarg is provided by @safeload_static
         if file is None:
             raise ValueError("file should be the opened file, not None")
-
+        if setup.logfile is None:
+            raise ValueError("logfile undefined")
         scan_number = setup.logfile.scan_number
         if scan_number is None:
             raise ValueError("'scan_number' parameter required")
@@ -3554,6 +3578,8 @@ class LoaderCRISTAL(Loader):
         :return: (mgomega, mgphi, gamma, delta, energy) values
         """
         if not setup.custom_scan:
+            if setup.logfile is None:
+                raise ValueError("logfile undefined")
             with setup.logfile as file:
                 group_key = list(file.keys())[0]
 

--- a/bcdi/graph/colormap.py
+++ b/bcdi/graph/colormap.py
@@ -16,6 +16,7 @@ import colorcet as cc
 from matplotlib.colors import Colormap, LinearSegmentedColormap, ListedColormap
 
 from bcdi.graph.turbo_colormap import turbo_colormap_data
+from bcdi.utils import utilities as util
 from bcdi.utils.validation import is_float
 
 data_table = (
@@ -77,3 +78,7 @@ class ColormapFactory:
         else:
             raise NotImplementedError(f"colormap {self.colormap} not implemented")
         self.cmap.set_bad(color=self.bad_color)
+
+    def __repr__(self):
+        """Representation string of the ColormapFactory instance."""
+        return util.create_repr(self, ColormapFactory)

--- a/bcdi/postprocessing/postprocessing_runner.py
+++ b/bcdi/postprocessing/postprocessing_runner.py
@@ -90,6 +90,7 @@ def initialize_parameters(parameters: Dict[str, Any]) -> Dict[str, Any]:
             "sample_offsets": None,
             "sample_outofplane": [0, 0, 1],
             "save": True,
+            "save_dirname": "result",
             "save_rawdata": False,
             "save_support": False,
             "skip_unwrap": False,

--- a/bcdi/postprocessing/postprocessing_utils.py
+++ b/bcdi/postprocessing/postprocessing_utils.py
@@ -19,7 +19,7 @@ import numpy.ma as ma
 import scipy
 from numpy.fft import fftn, fftshift, ifftn, ifftshift
 from scipy.interpolate import RegularGridInterpolator
-from scipy.ndimage.measurements import center_of_mass
+from scipy.ndimage import center_of_mass
 from scipy.signal import convolve
 from scipy.stats import multivariate_normal, norm
 from skimage.restoration import unwrap_phase

--- a/bcdi/postprocessing/process_scan.py
+++ b/bcdi/postprocessing/process_scan.py
@@ -73,51 +73,10 @@ def process_scan(
     # define the experimental setup #
     #################################
     setup = Setup(
-        beamline_name=prm["beamline"],
-        energy=prm["energy"],
-        outofplane_angle=prm["outofplane_angle"],
-        inplane_angle=prm["inplane_angle"],
-        tilt_angle=prm["tilt_angle"],
-        rocking_angle=prm["rocking_angle"],
-        distance=prm["detector_distance"],
-        sample_offsets=prm["sample_offsets"],
-        actuators=prm["actuators"],
-        custom_scan=prm["custom_scan"],
-        custom_motors=prm["custom_motors"],
-        dirbeam_detector_angles=prm["dirbeam_detector_angles"],
-        direct_beam=prm["direct_beam"],
-        is_series=prm["is_series"],
-        detector_name=prm["detector"],
-        template_imagefile=prm["template_imagefile"][scan_idx],
-        roi=prm["roi_detector"],
-        binning=prm["phasing_binning"],
-        preprocessing_binning=prm["preprocessing_binning"],
-        custom_pixelsize=prm["custom_pixelsize"],
+        parameters=prm,
+        scan_index=scan_idx,
         logger=logger,
     )
-
-    ########################################
-    # Initialize the paths and the logfile #
-    ########################################
-    setup.init_paths(
-        sample_name=prm["sample_name"][scan_idx],
-        scan_number=scan_nb,
-        root_folder=prm["root_folder"],
-        data_dir=prm["data_dir"][scan_idx],
-        save_dir=prm["save_dir"][scan_idx],
-        specfile_name=prm["specfile_name"][scan_idx],
-        template_imagefile=prm["template_imagefile"][scan_idx],
-    )
-
-    setup.create_logfile(
-        scan_number=scan_nb,
-        root_folder=prm["root_folder"],
-        filename=setup.detector.specfile,
-    )
-
-    # load the goniometer positions needed in the calculation
-    # of the transformation matrix
-    setup.read_logfile(scan_number=scan_nb)
 
     logger.info(f"##############\nSetup instance\n##############\n{setup.params}")
     logger.info(

--- a/bcdi/preprocessing/analysis.py
+++ b/bcdi/preprocessing/analysis.py
@@ -24,7 +24,7 @@ from matplotlib.backend_bases import KeyEvent, MouseEvent
 from matplotlib.figure import Figure
 from matplotlib.text import Text
 from scipy.io import savemat
-from scipy.ndimage.measurements import center_of_mass
+from scipy.ndimage import center_of_mass
 
 import bcdi.graph.graph_utils as gu
 import bcdi.preprocessing.bcdi_utils as bu

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -22,7 +22,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import xrayutilities as xu
 from scipy.interpolate import interp1d
-from scipy.ndimage.measurements import center_of_mass
+from scipy.ndimage import center_of_mass
 
 from bcdi.experiment import loader
 from bcdi.graph import graph_utils as gu

--- a/bcdi/preprocessing/process_scan.py
+++ b/bcdi/preprocessing/process_scan.py
@@ -93,61 +93,11 @@ def process_scan(
     # define the experimental setup #
     #################################
     setup = Setup(
-        beamline_name=prm["beamline"],
-        energy=prm["energy"],
-        rocking_angle=prm["rocking_angle"],
-        distance=prm["detector_distance"],
-        beam_direction=prm["beam_direction"],
-        sample_inplane=prm["sample_inplane"],
-        sample_outofplane=prm["sample_outofplane"],
-        offset_inplane=prm["offset_inplane"],
-        custom_scan=prm["custom_scan"],
-        custom_images=prm["custom_images"],
-        sample_offsets=prm["sample_offsets"],
-        custom_monitor=prm["custom_monitor"],
-        custom_motors=prm["custom_motors"],
-        actuators=prm["actuators"],
-        is_series=prm["is_series"],
-        outofplane_angle=prm["outofplane_angle"],
-        inplane_angle=prm["inplane_angle"],
-        dirbeam_detector_angles=prm["dirbeam_detector_angles"],
-        direct_beam=prm["direct_beam"],
-        detector_name=prm["detector"],
-        template_imagefile=prm["template_imagefile"][scan_idx],
-        roi=prm["roi_detector"],
-        binning=prm["phasing_binning"],
-        preprocessing_binning=prm["preprocessing_binning"],
-        linearity_func=prm["linearity_func"],
+        parameters=prm,
+        scan_index=scan_idx,
         logger=logger,
     )
 
-    ########################################
-    # Initialize the paths and the logfile #
-    ########################################
-    setup.init_paths(
-        sample_name=prm["sample_name"][scan_idx],
-        scan_number=scan_nb,
-        data_dir=prm["data_dir"][scan_idx],
-        root_folder=prm["root_folder"],
-        save_dir=prm["save_dir"][scan_idx],
-        save_dirname=prm["save_dirname"],
-        specfile_name=prm["specfile_name"][scan_idx],
-        template_imagefile=prm["template_imagefile"][scan_idx],
-    )
-
-    setup.create_logfile(
-        scan_number=scan_nb,
-        root_folder=prm["root_folder"],
-        filename=setup.detector.specfile,
-    )
-
-    # load the goniometer positions needed for the calculation of the corrected
-    # detector angles
-    setup.read_logfile(scan_number=scan_nb)
-
-    ###################
-    # print instances #
-    ###################
     logger.info(f"##############\nSetup instance\n##############\n{setup.params}")
     logger.info(
         "#################\nDetector instance\n#################\n"

--- a/bcdi/preprocessing/process_scan_cdi.py
+++ b/bcdi/preprocessing/process_scan_cdi.py
@@ -244,52 +244,11 @@ def process_scan_cdi(
     # define the experimental setup #
     #################################
     setup = Setup(
-        beamline_name=prm["beamline"],
-        energy=prm["energy"],
-        rocking_angle="inplane",
-        distance=prm["detector_distance"],
-        custom_scan=prm["custom_scan"],
-        custom_images=prm["custom_images"],
-        custom_monitor=prm["custom_monitor"],
-        custom_motors=prm["custom_motors"],
-        actuators=prm["actuators"],
-        is_series=prm["is_series"],
-        detector_name=prm["detector"],
-        template_imagefile=prm["template_imagefile"][scan_idx],
-        direct_beam=prm["direct_beam"],
-        dirbeam_detector_position=prm["dirbeam_detector_position"],
-        roi=prm["roi_detector"],
-        binning=prm["phasing_binning"],
-        preprocessing_binning=prm["preprocessing_binning"],
-        linearity_func=prm["linearity_func"],
+        parameters=prm,
+        scan_index=scan_idx,
         logger=logger,
     )
 
-    # initialize the paths
-    setup.init_paths(
-        sample_name=prm["sample_name"][scan_idx],
-        scan_number=scan_nb,
-        data_dir=prm["data_dir"][scan_idx],
-        root_folder=prm["root_folder"],
-        save_dir=prm["save_dir"][scan_idx],
-        save_dirname=prm["save_dirname"],
-        specfile_name=prm["specfile_name"][scan_idx],
-        template_imagefile=prm["template_imagefile"][scan_idx],
-    )
-
-    setup.create_logfile(
-        scan_number=scan_nb,
-        root_folder=prm["root_folder"],
-        filename=setup.detector.specfile,
-    )
-
-    # load the goniometer positions needed for the calculation of the corrected
-    # detector angles
-    setup.read_logfile(scan_number=scan_nb)
-
-    ###################
-    # print instances #
-    ###################
     logger.info(f"##############\nSetup instance\n##############\n{setup.params}")
     logger.info(
         "#################\nDetector instance\n#################\n"

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,6 +1,9 @@
 Future:
 -------
 
+* Remove temporal couping in the initialization of the Setup instance. Set the paths,
+  create the logfile and read it directly in `setup.__init__`.
+
 * Create classes Analysis, PreprocessingLoader and InteractiveMasker for preprocessing.
   Refactor `preprocessing.process_scan` to use these classes.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -62,6 +62,32 @@ virtual environment named ``myenv``):
 
 .. include:: EXAMPLE_POSTPROCESSING.rst
 
+Running unit tests
+==================
+
+Some of the preprocessing unit tests require to have the example dataset on your local
+machine. To run them, download the dataset ID182 from the following website:
+https://www.cxidb.org/id-182.html
+
+Extract the files, you should get the following::
+
+    CXIDB-182/
+        Readme ID 182.txt
+        CH4760/
+            l5.spec
+            S11/
+            ...
+        HS4670/
+            ...
+
+
+Unittests use the scan ``S11`` from the experiment ``CH4760``.
+The spec file for this scan is ``l5.spec``. You will need to update the paths
+``root_folder`` , ``save_dir`` and ``data_dir`` in the configuration file
+``bcdi/examples/S11_config_preprocessing.yml``.
+
+If the dataset is not available, corresponding unit tests are skipped.
+
 Changelog
 =========
 

--- a/tests/config.py
+++ b/tests/config.py
@@ -26,11 +26,12 @@ def has_backend(backend: str) -> bool:
     return True
 
 
-def get_config(worklow) -> Tuple[str, Callable]:
-    if worklow == "preprocessing":
+def get_config(workflow) -> Tuple[str, Callable]:
+    if workflow == "preprocessing":
         return "bcdi/examples/S11_config_preprocessing.yml", initialize_parameters_bcdi
-    if worklow == "postprocessing":
+    if workflow == "postprocessing":
         return "bcdi/examples/S11_config_postprocessing.yml", initialize_parameters
+    raise NotImplementedError(f"workflow {workflow} not implemented")
 
 
 def load_config(workflow: str) -> Tuple[Dict[str, Any], bool]:

--- a/tests/config.py
+++ b/tests/config.py
@@ -7,8 +7,14 @@
 #         Jerome Carnis, carnis_jerome@yahoo.fr
 
 import unittest
+from pathlib import Path
+from typing import Any, Callable, Dict, Tuple
 
 import matplotlib
+
+from bcdi.postprocessing.postprocessing_runner import initialize_parameters
+from bcdi.preprocessing.preprocessing_runner import initialize_parameters_bcdi
+from bcdi.utils.parser import ConfigParser
 
 
 def has_backend(backend: str) -> bool:
@@ -18,6 +24,33 @@ def has_backend(backend: str) -> bool:
     except ImportError:
         return False
     return True
+
+
+def get_config(worklow) -> Tuple[str, Callable]:
+    if worklow == "preprocessing":
+        return "bcdi/examples/S11_config_preprocessing.yml", initialize_parameters_bcdi
+    if worklow == "postprocessing":
+        return "bcdi/examples/S11_config_postprocessing.yml", initialize_parameters
+
+
+def load_config(workflow: str) -> Tuple[Dict[str, Any], bool]:
+    allowed_workflows = {"preprocessing", "postprocessing"}
+    if workflow not in allowed_workflows:
+        raise ValueError(
+            f"Unknown worklow '{workflow}', allowed is " f"{allowed_workflows}."
+        )
+
+    filename, function = get_config(workflow)
+    here = Path(__file__).parent
+
+    config = str(here.parents[0] / filename)
+    try:
+        parameters = function(ConfigParser(config).load_arguments())
+        parameters.update({"backend": "agg"})
+        matplotlib.use(parameters["backend"])
+        return parameters, False
+    except ValueError:
+        return {}, True
 
 
 def run_tests(test_class):

--- a/tests/experiment/test_detector.py
+++ b/tests/experiment/test_detector.py
@@ -201,8 +201,8 @@ class TestDetector(fake_filesystem_unittest.TestCase):
             Maxipix(name="Maxipix", preprocessing_binning=[2, 2, None])
 
     def test_preprocessing_binning_none_default(self):
-        det = Maxipix(name="Maxipix", preprocessing_binning=None)
-        self.assertEqual(det.preprocessing_binning, (1, 1, 1))
+        with self.assertRaises(ValueError):
+            Maxipix(name="Maxipix", preprocessing_binning=None)
 
     def test_preprocessing_binning_correct(self):
         det = Maxipix(name="Maxipix", preprocessing_binning=(2, 2, 1))
@@ -322,18 +322,6 @@ class TestDetector(fake_filesystem_unittest.TestCase):
         det = Maxipix(name="Maxipix", sum_roi=(), roi=(2, 252, 1, 35))
         self.assertEqual(det.sum_roi, det.roi)
         self.assertEqual(det.sum_roi, (2, 252, 1, 35))
-
-    def test_template_file_wrong_type(self):
-        with self.assertRaises(TypeError):
-            Maxipix(name="Maxipix", template_file=777)
-
-    def test_template_file_None(self):
-        det = Maxipix(name="Maxipix", template_file=None)
-        self.assertEqual(det.template_file, None)
-
-    def test_template_file_correct(self):
-        det = Maxipix(name="Maxipix", template_file="S")
-        self.assertEqual(det.template_file, "S")
 
     def test_template_imagefile_wrong_type(self):
         with self.assertRaises(TypeError):

--- a/tests/experiment/test_loader.py
+++ b/tests/experiment/test_loader.py
@@ -288,18 +288,24 @@ class TestRetrieveDistance(fake_filesystem_unittest.TestCase):
                 "det_distance_CC=1.434,det_distance_COM=1.193,"
                 "timestamp=2021-02-28T13:01:16.615422"
             )
-        filename = self.valid_path + "defined.spec"
-
-        distance = self.beamline.loader.retrieve_distance(filename)
+        distance = self.beamline.loader.retrieve_distance(
+            filename="defined.spec", default_folder=self.valid_path
+        )
         self.assertTrue(np.isclose(distance, 1.193))
 
     def test_distance_undefined(self):
         with open(self.valid_path + "undefined.spec", "w") as f:
             f.write("test\n#this,is,bad")
-        filename = self.valid_path + "undefined.spec"
-
-        distance = self.beamline.loader.retrieve_distance(filename)
+        distance = self.beamline.loader.retrieve_distance(
+            filename="undefined.spec", default_folder=self.valid_path
+        )
         self.assertTrue(distance is None)
+
+    def test_distance_not_a_spec_file(self):
+        with self.assertRaises(ValueError):
+            self.beamline.loader.retrieve_distance(
+                filename="undefined.txt", default_folder=self.valid_path
+            )
 
 
 class TestRepr(unittest.TestCase):

--- a/tests/experiment/test_setup.py
+++ b/tests/experiment/test_setup.py
@@ -286,6 +286,10 @@ class TestRepr(unittest.TestCase):
     """Tests related to __repr__."""
 
     def setUp(self) -> None:
+        if skip_tests:
+            self.skipTest(
+                reason="This test can only run locally with the example dataset"
+            )
         self.setup = Setup(parameters=parameters)
 
     def test_return_type(self):

--- a/tests/preprocessing/test_analysis.py
+++ b/tests/preprocessing/test_analysis.py
@@ -7,25 +7,11 @@
 #         Jerome Carnis, carnis_jerome@yahoo.fr
 
 import unittest
-from pathlib import Path
-
-import matplotlib
 
 import bcdi.preprocessing.analysis as analysis
-from bcdi.preprocessing.preprocessing_runner import initialize_parameters_bcdi
-from bcdi.utils.parser import ConfigParser
-from tests.config import run_tests
+from tests.config import load_config, run_tests
 
-here = Path(__file__).parent
-THIS_DIR = str(here)
-CONFIG = str(here.parents[1] / "bcdi/examples/S11_config_preprocessing.yml")
-try:
-    parameters = initialize_parameters_bcdi(ConfigParser(CONFIG).load_arguments())
-    parameters.update({"backend": "agg"})
-    matplotlib.use(parameters["backend"])
-    skip_tests = False
-except ValueError:
-    skip_tests = True
+parameters, skip_tests = load_config("preprocessing")
 
 
 class TestDefineAnalysisType(unittest.TestCase):


### PR DESCRIPTION
## Description

Remove temporal coupling in the initialization of the Setup instance. Set the paths, create the logfile and read it directly in `setup.__init__`. Fixes #313 

## Type of change

Please delete options that are not relevant.

- [X] Refactor
- [X] Documentation update

## Checklist:

- [X] I have made corresponding changes to the documentation
- [X] I have added corresponding unit tests
- [X] I have run ``doit`` and all tasks have passed
