### PR TITLE
Implement a method to interpolate into the laboratory frame

### DIFF
--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,6 +1,9 @@
 Future:
 -------
 
+* Split `setup.ortho_directspace` into methods to get the transformation matrix in the
+  laboratory frame or crystal frame. Implement `setup.ortho_directspace_labframe`.
+
 * Create a new script `postprocessing/bcdi_orthogonalization.py`, which only
   interpolates the output of phase retrieval (no processing on the phase)
 


### PR DESCRIPTION
Previously, the interpolation of the reconstructed crystal was done directly into the crystal frame. There are some use-cases where one would like to interpolate into the laboratory frame. This required previously two interpolations (detector_frame -> crystal frame -> back to laboratory frame).

Split `setup.ortho_directspace` into methods to get the transformation matrix in the laboratory frame or crystal frame. Implement `setup.ortho_directspace_labframe` if one wants to interpolate into the laboratory frame.

Fixes #317 

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] I have made corresponding changes to the documentation
- [X] I have run ``doit`` and all tasks have passed
