### PR TITLE
fix postprocessing for energy scans

### DIFF
--- a/bcdi/experiment/beamline_factory.py
+++ b/bcdi/experiment/beamline_factory.py
@@ -275,6 +275,36 @@ class Beamline(ABC):
         """
 
     @abstractmethod
+    def inplane_coeff(self):
+        """
+        Coefficient related to the detector inplane orientation.
+
+        Define a coefficient +/- 1 depending on the detector inplane rotation direction
+        (1 for clockwise, -1 for anti-clockwise) and the detector inplane orientation
+        (1 for inboard, -1 for outboard).
+
+        For a SAXS Beamline it does not matter, the fixed detector inplane angle is 0.
+
+        :return: +1
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def outofplane_coeff(self):
+        """
+        Coefficient related to the detector inplane orientation.
+
+        Define a coefficient +/- 1 depending on the detector inplane rotation direction
+        (1 for clockwise, -1 for anti-clockwise) and the detector inplane orientation
+        (1 for inboard, -1 for outboard).
+
+        For a SAXS Beamline it does not matter, the fixed detector inplane angle is 0.
+
+        :return: +1
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def process_positions(
         self,
         setup: "Setup",
@@ -314,7 +344,7 @@ class Beamline(ABC):
         Crop or pad array depending on how compare two numbers.
 
         Cropping or padding depends on the number of current frames compared to the
-        number of motor steps. For padding it assumes that array is linear in the
+        number of motor steps. For pading it assumes that array is linear in the
         angular_step.
 
         :param array: a 1D numpy array of motor values
@@ -680,3 +710,31 @@ class BeamlineSaxs(Beamline):
                 title="calculated polar radius for the 2D grid",
             )
         return interp_angle, interp_radius
+
+    def inplane_coeff(self):
+        """
+        Coefficient related to the detector inplane orientation.
+
+        Define a coefficient +/- 1 depending on the detector inplane rotation direction
+        (1 for clockwise, -1 for anti-clockwise) and the detector inplane orientation
+        (1 for inboard, -1 for outboard).
+
+        For a SAXS Beamline it does not matter, the fixed detector inplane angle is 0.
+
+        :return: +1
+        """
+        return 1
+
+    def outofplane_coeff(self):
+        """
+        Coefficient related to the detector inplane orientation.
+
+        Define a coefficient +/- 1 depending on the detector inplane rotation direction
+        (1 for clockwise, -1 for anti-clockwise) and the detector inplane orientation
+        (1 for inboard, -1 for outboard).
+
+        For a SAXS Beamline it does not matter, the fixed detector inplane angle is 0.
+
+        :return: +1
+        """
+        return 1

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -35,7 +35,7 @@ module_logger = logging.getLogger(__name__)
 
 
 def get_mean_tilt(
-    angles: Optional[Union[float, int, np.ndarray, list[Union[float, int]]]]
+    angles: Optional[Union[float, int, np.ndarray, List[Union[float, int]]]]
 ) -> Optional[float]:
     """
     Calculate the mean tilt depending on the array of incident angles.

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -17,7 +17,6 @@ import datetime
 import logging
 import multiprocessing as mp
 import time
-from collections.abc import Sequence
 from numbers import Integral, Real
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -25,6 +24,7 @@ import numpy as np
 from scipy.interpolate import RegularGridInterpolator, griddata
 
 from bcdi.experiment.beamline import create_beamline
+from bcdi.experiment.beamline_factory import BeamlineGoniometer, BeamlineSaxs
 from bcdi.experiment.detector import Detector, create_detector
 from bcdi.graph import graph_utils as gu
 from bcdi.utils import utilities as util
@@ -1622,6 +1622,11 @@ class Setup:
          - a tuple of motor offsets used later for q calculation
 
         """
+        if not isinstance(self.beamline, BeamlineGoniometer):
+            raise TypeError(
+                "init_qconversion supports only for beamlines with goniometer, "
+                f"got {type(self.beamline)}"
+            )
         return self.beamline.init_qconversion(
             conversion_table=self.labframe_to_xrayutil,
             beam_direction=self.beam_direction_xrutils,
@@ -2838,6 +2843,11 @@ class Setup:
          - the q offset (3D vector) if direct_space is False.
 
         """
+        if not isinstance(self.beamline, BeamlineGoniometer):
+            raise TypeError(
+                "transformation_bcdi supports only for beamlines with goniometer, "
+                f"got {type(self.beamline)}"
+            )
         if verbose:
             self.logger.info(
                 f"out-of plane detector angle={self.outofplane_angle:.3f} deg, "
@@ -2911,6 +2921,11 @@ class Setup:
            region of interest and binning.
 
         """
+        if not isinstance(self.beamline, BeamlineSaxs):
+            raise TypeError(
+                "transformation_cdi supports only for SAXS beamlines, "
+                f"got {type(self.beamline)}"
+            )
         #########################
         # check some parameters #
         #########################

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -660,8 +660,8 @@ class Setup:
         return self._tilt_angle
 
     @tilt_angle.setter
-    def tilt_angle(self, value):
-        if not isinstance(value, Real) and value is not None:
+    def tilt_angle(self, value: Union[float, int]) -> None:
+        if not isinstance(value, (float, int)) and value is not None:
             raise TypeError("tilt_angle should be a number in degrees")
         self._tilt_angle = value
 
@@ -781,11 +781,18 @@ class Setup:
             raise ValueError("the detector in-plane angle is not defined")
 
         self.tilt_angles = tilt_angle
-        if tilt_angle is not None:
-            tilt_angle = np.mean(
-                np.asarray(tilt_angle)[1:] - np.asarray(tilt_angle)[0:-1]
-            )
-        self.tilt_angle = self.tilt_angle or tilt_angle
+        if tilt_angle is None or isinstance(tilt_angle, (float, int)):
+            mean_tilt = tilt_angle
+        elif isinstance(tilt_angle, np.ndarray):
+            if tilt_angle.ndim == 0:
+                mean_tilt = float(tilt_angle)
+            else:
+                mean_tilt = np.mean(
+                    np.asarray(tilt_angle)[1:] - np.asarray(tilt_angle)[0:-1]
+                )
+        else:
+            raise TypeError(f"tilt_angle should be a ndarray, got {type(tilt_angle)}")
+        self.tilt_angle = self.tilt_angle or mean_tilt
         if self.tilt_angle is None:
             raise ValueError("the tilt angle is not defined")
         if not isinstance(self.tilt_angle, Real):

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -781,22 +781,26 @@ class Setup:
             raise ValueError("the detector in-plane angle is not defined")
 
         self.tilt_angles = tilt_angle
-        if tilt_angle is None or isinstance(tilt_angle, (float, int)):
-            mean_tilt = tilt_angle
-        elif isinstance(tilt_angle, np.ndarray):
-            if tilt_angle.size == 1:
-                mean_tilt = float(tilt_angle)
-            else:
-                mean_tilt = np.mean(
-                    np.asarray(tilt_angle)[1:] - np.asarray(tilt_angle)[0:-1]
-                )
-        else:
-            raise TypeError(f"tilt_angle should be a ndarray, got {type(tilt_angle)}")
-        self.tilt_angle = self.tilt_angle or mean_tilt
+        self.tilt_angle = self.tilt_angle or self._get_mean_tilt(tilt_angle)
         if self.tilt_angle is None:
             raise ValueError("the tilt angle is not defined")
         if not isinstance(self.tilt_angle, Real):
             raise TypeError("the tilt angle should be a number")
+
+    @staticmethod
+    def _get_mean_tilt(
+        angles: Optional[Union[float, int, np.ndarray]]
+    ) -> Optional[float]:
+        """Calculate the mean tilt depending on the array of incident angles."""
+        if angles is None:
+            return angles
+        if isinstance(angles, (float, int)) or (
+            isinstance(angles, np.ndarray) and angles.size == 1
+        ):
+            return float(angles)
+        if isinstance(angles, np.ndarray) and angles.size > 1:
+            return float(np.mean(angles[1:] - angles[0:-1]))
+        raise TypeError(f"tilt_angle should be a ndarray, got {type(angles)}")
 
     def check_setup_cdi(
         self,

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -635,14 +635,16 @@ class Setup:
         }
 
     @property
-    def q_laboratory(self) -> np.ndarray:
+    def q_laboratory(self) -> Optional[np.ndarray]:
         """
         Calculate the diffusion vector in the laboratory frame.
 
         Frame convention: (z downstream, y vertical up, x outboard). The unit is 1/A.
 
-        :return: npdarray of three vectors components.
+        :return: ndarray of three vectors components.
         """
+        if self.exit_wavevector.ndim > 1:  # energy scan
+            return None
         q_laboratory = (self.exit_wavevector - self.incident_wavevector) * 1e-10
         if np.isclose(np.linalg.norm(q_laboratory), 0, atol=1e-15):
             raise ValueError("q_laboratory is null")

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -784,7 +784,7 @@ class Setup:
         if tilt_angle is None or isinstance(tilt_angle, (float, int)):
             mean_tilt = tilt_angle
         elif isinstance(tilt_angle, np.ndarray):
-            if tilt_angle.ndim == 0:
+            if tilt_angle.size == 1:
                 mean_tilt = float(tilt_angle)
             else:
                 mean_tilt = np.mean(

--- a/bcdi/postprocessing/process_scan.py
+++ b/bcdi/postprocessing/process_scan.py
@@ -186,17 +186,6 @@ def process_scan(
 
         analysis.update_detector_angles(bragg_peak_position=prm["bragg_peak"])
 
-    #########################################################
-    # calculate q of the Bragg peak in the laboratory frame #
-    #########################################################
-    q_lab = analysis.get_normalized_q_bragg_laboratory_frame
-    logger.info(
-        "Normalized diffusion vector in the laboratory frame (z*, y*, x*): "
-        f"{[f'{val:.4f}' for _, val in enumerate(q_lab)]} (1/A)"
-    )
-    logger.info(f"Wavevector transfer: {analysis.get_norm_q_bragg:.4f} 1/A")
-    logger.info(f"Atomic planar distance: {analysis.get_interplanar_distance:.4f} nm")
-
     #######################
     #  orthogonalize data #
     #######################
@@ -271,11 +260,7 @@ def process_scan(
         # rotate also q_lab to have it along ref_axis_q,
         # as a cross-checkm, vectors needs to be in xyz order
         comment.concatenate("crystalframe")
-        interpolated_crystal.rotate_vector_to_saving_frame(
-            vector=analysis.get_normalized_q_bragg_laboratory_frame[::-1],
-            axis_to_align=AXIS_TO_ARRAY[prm["ref_axis_q"]],
-            reference_axis=analysis.get_normalized_q_bragg_laboratory_frame[::-1],
-        )
+        interpolated_crystal.set_q_bragg_to_saving_frame(analysis)
 
     ###############################################
     # rotates the crystal e.g. for easier slicing #
@@ -296,7 +281,6 @@ def process_scan(
             reference_axis=prm["axis_to_align"],
         )
 
-    interpolated_crystal.rescale_q()
     q_final = interpolated_crystal.q_bragg_in_saving_frame
     logger.info(
         f"q_final = ({q_final[0]:.4f} 1/A,"

--- a/bcdi/postprocessing/process_scan.py
+++ b/bcdi/postprocessing/process_scan.py
@@ -242,6 +242,8 @@ def process_scan(
     # laboratory frame (for debugging purpose)     #
     ################################################
     if prm["save_frame"] in ["laboratory", "lab_flat_sample"]:
+        if analysis.get_normalized_q_bragg_laboratory_frame is None:
+            raise ValueError("analysis.get_normalized_q_bragg_laboratory_frame is None")
         comment.concatenate("labframe")
         logger.info("Rotating back the crystal in laboratory frame")
         interpolated_crystal.rotate_crystal(

--- a/bcdi/utils/parameters.py
+++ b/bcdi/utils/parameters.py
@@ -213,7 +213,7 @@ class CDIPreprocessingChecker(ConfigChecker):
     """Configure preprocessing-dependent parameters for the 'CDI' case."""
 
     def _configure_params(self) -> None:
-        """Hard-code processing-dependent parameter configuration."""
+        """Hard-coded processing-dependent parameter configuration."""
         self._checked_params["roi_detector"] = self._create_roi()
         if self._checked_params["photon_filter"] == "loading":
             self._checked_params["loading_threshold"] = self._checked_params[
@@ -284,7 +284,7 @@ class PreprocessingChecker(ConfigChecker):
     """Configure preprocessing-dependent parameters."""
 
     def _configure_params(self) -> None:
-        """Hard-code processing-dependent parameter configuration."""
+        """Hard-coded processing-dependent parameter configuration."""
         if self._nb_scans is not None and self._nb_scans > 1:
             if self._checked_params["center_fft"] not in [
                 "crop_asymmetric_ZYX",
@@ -388,8 +388,20 @@ class PreprocessingChecker(ConfigChecker):
 class PostprocessingChecker(ConfigChecker):
     """Configure postprocessing-dependent parameters."""
 
+    def check_config(self) -> Dict[str, Any]:
+        """Check if the provided config is consistent."""
+        super().check_config()
+        if (
+            self._checked_params["rocking_angle"] == "energy"
+            and self._checked_params["data_frame"] == "detector"
+        ):
+            raise NotImplementedError(
+                "Energy scans must be interpolated during preprocessing."
+            )
+        return self._checked_params
+
     def _configure_params(self) -> None:
-        """Hard-code processing-dependent parameter configuration."""
+        """Hard-coded processing-dependent parameter configuration."""
         if self._nb_scans is not None and self._nb_scans > 1:
             self._checked_params["backend"] = "Agg"
             if self._checked_params["multiprocessing"] and any(

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -2367,8 +2367,11 @@ def rotate_crystal(
 
 
 def rotate_vector(
-    vectors, axis_to_align=None, reference_axis=None, rotation_matrix=None
-):
+    vectors: Union[np.ndarray, Tuple[np.ndarray, ...]],
+    axis_to_align: Optional[np.ndarray] = None,
+    reference_axis: Optional[np.ndarray] = None,
+    rotation_matrix: Optional[np.ndarray] = None,
+) -> Union[np.ndarray, Tuple[np.ndarray, ...]]:
     """
     Rotate vectors.
 

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,3 +1,9 @@
+Future:
+-------
+
+* Postprocessing: raise NotImplementedError for energy scans not interpolated during
+  preprocessing.
+
 Version 0.2.9:
 --------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -62,7 +62,7 @@ release = __version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/tests/experiment/test_setup.py
+++ b/tests/experiment/test_setup.py
@@ -10,7 +10,8 @@ import unittest
 
 import numpy as np
 
-from bcdi.experiment.setup import get_mean_tilt, Setup
+from bcdi.experiment.setup import Setup, get_mean_tilt
+from bcdi.graph.colormap import ColormapFactory  # needed for test_rocking_angle_str
 from tests.config import load_config, run_tests
 
 parameters, skip_tests = load_config("preprocessing")

--- a/tests/experiment/test_setup.py
+++ b/tests/experiment/test_setup.py
@@ -117,10 +117,17 @@ class TestCheckSetup(unittest.TestCase):
         self.setup.check_setup(**self.params)
         self.assertAlmostEqual(self.setup.tilt_angle, self.params["tilt_angle"])
 
-    def test_check_setup_tilt_angle_not_in_config_tilt_angle_single_valued_array(self):
+    def test_check_setup_tilt_angle_not_in_config_tilt_angle_0d_array(self):
         self.setup.tilt_angle = None
         self.params["tilt_angle"] = np.array(1.23)
         self.setup.check_setup(**self.params)
+        self.assertAlmostEqual(self.setup.tilt_angle, float(self.params["tilt_angle"]))
+
+    def test_check_setup_tilt_angle_not_in_config_tilt_angle_1d_array(self):
+        self.setup.tilt_angle = None
+        self.params["tilt_angle"] = np.array([1.23])
+        self.setup.check_setup(**self.params)
+        self.assertAlmostEqual(self.setup.tilt_angle, float(self.params["tilt_angle"]))
 
     def test_check_setup_outofplane_angle_predefined(self):
         self.setup.outofplane_angle = 2

--- a/tests/experiment/test_setup.py
+++ b/tests/experiment/test_setup.py
@@ -111,6 +111,17 @@ class TestCheckSetup(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.setup.check_setup(**self.params)
 
+    def test_check_setup_tilt_angle_not_in_config_energy_scan(self):
+        self.setup.tilt_angle = None
+        self.params["tilt_angle"] = 1.23
+        self.setup.check_setup(**self.params)
+        self.assertAlmostEqual(self.setup.tilt_angle, self.params["tilt_angle"])
+
+    def test_check_setup_tilt_angle_not_in_config_tilt_angle_single_valued_array(self):
+        self.setup.tilt_angle = None
+        self.params["tilt_angle"] = np.array(1.23)
+        self.setup.check_setup(**self.params)
+
     def test_check_setup_outofplane_angle_predefined(self):
         self.setup.outofplane_angle = 2
         self.setup.check_setup(**self.params)

--- a/tests/experiment/test_setup.py
+++ b/tests/experiment/test_setup.py
@@ -10,8 +10,7 @@ import unittest
 
 import numpy as np
 
-from bcdi.experiment.setup import Setup
-from bcdi.graph.colormap import ColormapFactory
+from bcdi.experiment.setup import get_mean_tilt, Setup
 from tests.config import load_config, run_tests
 
 parameters, skip_tests = load_config("preprocessing")
@@ -177,6 +176,57 @@ class TestCheckSetup(unittest.TestCase):
         self.params["grazing_angle"] = None
         self.setup.check_setup(**self.params)
         self.assertEqual(self.setup.grazing_angle, None)
+
+
+class TestGetMeanTilt(unittest.TestCase):
+    """
+    Tests related to _get_mean_tilt(
+        angles: Optional[Union[float, int, np.ndarray]]
+    ) -> Optional[float]:
+    """
+
+    def test_float(self):
+        expected = 1.23
+        out = get_mean_tilt(expected)
+        self.assertAlmostEqual(out, expected)
+
+    def test_int(self):
+        expected = 1
+        out = get_mean_tilt(expected)
+        self.assertEqual(out, expected)
+
+    def test_none(self):
+        out = get_mean_tilt(None)
+        self.assertIsNone(out)
+
+    def test_0d_array_of_size_1(self):
+        expected = 1.23
+        out = get_mean_tilt(np.array(expected))
+        self.assertAlmostEqual(out, expected)
+
+    def test_1d_array_of_size_1(self):
+        expected = 1.23
+        out = get_mean_tilt(np.array([expected]))
+        self.assertAlmostEqual(out, expected)
+
+    def test_list_of_length_1(self):
+        expected = 1.23
+        out = get_mean_tilt([expected])
+        self.assertAlmostEqual(out, expected)
+
+    def test_list_of_length_larger_than_1(self):
+        expected = 1
+        out = get_mean_tilt([1, 2, 3])
+        self.assertAlmostEqual(out, expected)
+
+    def test_1d_array_of_size_larger_than_1(self):
+        expected = 1
+        out = get_mean_tilt(np.array([1, 2, 3]))
+        self.assertAlmostEqual(out, expected)
+
+    def test_wrong_type(self):
+        with self.assertRaises(TypeError):
+            get_mean_tilt((1, 2, 3))
 
 
 class TestCorrectDirectBeam(unittest.TestCase):

--- a/tests/postprocessing/test_analysis.py
+++ b/tests/postprocessing/test_analysis.py
@@ -12,7 +12,7 @@ import unittest
 from copy import deepcopy
 from logging import Logger
 from pathlib import Path
-from unittest.mock import patch, PropertyMock
+from unittest.mock import PropertyMock, patch
 
 import numpy as np
 

--- a/tests/postprocessing/test_analysis.py
+++ b/tests/postprocessing/test_analysis.py
@@ -12,7 +12,7 @@ import unittest
 from copy import deepcopy
 from logging import Logger
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, PropertyMock
 
 import numpy as np
 
@@ -344,7 +344,6 @@ class TestDetectorFrameLinearization(unittest.TestCase):
 
     def test_interpolate_into_crystal_frame(self):
         self.analysis.interpolate_into_crystal_frame()
-        print(self.analysis.parameters["transformation_matrix"])
         self.assertTrue(
             np.allclose(
                 self.analysis.parameters["transformation_matrix"],
@@ -357,6 +356,24 @@ class TestDetectorFrameLinearization(unittest.TestCase):
                 ),
             )
         )
+
+    def test_get_q_bragg_crystal_frame_q_lab_defined(self):
+        expected_q_norm = 2.7755521652279227
+        expected_q_bragg_crystal = np.array([0, expected_q_norm, 0])
+        self.assertTrue(
+            np.allclose(
+                self.analysis.get_q_bragg_crystal_frame(),
+                expected_q_bragg_crystal,
+            )
+        )
+
+    def test_get_q_bragg_crystal_frame_q_lab_is_none(self):
+        with patch(
+            "bcdi.postprocessing.analysis.Analysis.get_q_bragg_laboratory_frame",
+            new_callable=PropertyMock,
+        ) as mock_get_q_lab:
+            mock_get_q_lab.return_value = None
+            self.assertIsNone(self.analysis.get_q_bragg_crystal_frame())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix the type conversion of the input parameter `tilt_angle` in `setup.check_setup`. When it was a float or a 0D array, the calculation of the mean would fail. 

Implement the calculation of q_bragg from the q-values saved after the interpolation by xrayutilities in preprocessing.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have added corresponding unit tests
- [X] I have run ``doit`` and all tasks have passed
