### PR TITLE
[Bug} Take into account the region of interest in `bcdi_utils.find_bragg`

### DIFF
--- a/bcdi/experiment/detector.py
+++ b/bcdi/experiment/detector.py
@@ -259,7 +259,7 @@ class Detector(ABC):
             name="Detector.datadir",
         )
         if value is not None and not os.path.isdir(value):
-            raise ValueError(f"The directory {value} does not exist")
+            raise ValueError(f"The directory '{value}' does not exist")
         self._datadir = value
 
     @property

--- a/bcdi/postprocessing/analysis.py
+++ b/bcdi/postprocessing/analysis.py
@@ -414,6 +414,7 @@ class Analysis(ABC):
             peak_method=self.parameters["centering_method"]["reciprocal_space"],
             tilt_values=self.setup.tilt_angles,
             savedir=self.setup.detector.savedir,
+            user_defined_peak=self.parameters["bragg_peak"],
             logger=self.logger,
             plot_fit=True,
         )
@@ -592,6 +593,7 @@ class OrthogonalFrame(Analysis):
                 peak_method=self.parameters["centering_method"]["reciprocal_space"],
                 tilt_values=None,
                 savedir=self.setup.detector.savedir,
+                user_defined_peak=self.parameters["bragg_peak"],
                 logger=self.logger,
                 plot_fit=False,
             )["bragg_peak"]

--- a/bcdi/preprocessing/analysis.py
+++ b/bcdi/preprocessing/analysis.py
@@ -523,7 +523,7 @@ class Analysis(ABC):
             centering=self.parameters["centering_method"],
             fft_option=self.parameters["center_fft"],
             pad_size=self.parameters["pad_size"],
-            fix_bragg=self.parameters["bragg_peak"],
+            bragg_peak=self.parameters["bragg_peak"],
             q_values=self.data_loader.q_values,
             logger=self.logger,
         )
@@ -665,6 +665,7 @@ class Analysis(ABC):
             tilt_values=self.setup.tilt_angles,
             savedir=self.setup.detector.savedir,
             frames_pattern=self.parameters.get("frames_pattern"),
+            user_defined_peak=self.parameters["bragg_peak"],
             logger=self.logger,
             plot_fit=True,
         )

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -164,7 +164,7 @@ class PeakFinder:
         self._region_of_interest = value
 
     def find_peak(
-        self, user_defined_peak: Optional[List[int]]
+        self, user_defined_peak: Optional[Tuple[int, int, int]] = None
     ) -> Dict[str, Tuple[int, int, int]]:
         """
         Find the position of the Bragg peak using three different metrics.
@@ -198,12 +198,17 @@ class PeakFinder:
             f"MaxCom at (z, y, x): {position_max_com}, "
             f"value = {int(self.array[position_max_com])}"
         )
-
+        if user_defined_peak is not None:
+            return {
+                "max": self.get_indices_full_detector(list(position_max)),
+                "com": self.get_indices_full_detector(list(position_com)),
+                "max_com": self.get_indices_full_detector(list(position_max_com)),
+                "user": user_defined_peak,
+            }
         return {
             "max": self.get_indices_full_detector(list(position_max)),
             "com": self.get_indices_full_detector(list(position_com)),
             "max_com": self.get_indices_full_detector(list(position_max_com)),
-            "user": user_defined_peak,
         }
 
     def get_indices_cropped_binned_detector(self, position: List[int]) -> List[int]:

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -51,6 +51,7 @@ class PeakFinder:
     :param peak_method: peak searching method, among "max", "com", "max_com".
     :param kwargs:
      - 'logger': an optional logger
+     - "user_defined_peak": [z, y, x] Bragg peak position defined by the user
      - 'frames_pattern' = list of int, of length the size of the original dataset along
        the rocking curve dimension. 0 if a frame was skipped, 1 otherwise
 
@@ -77,7 +78,7 @@ class PeakFinder:
         self.frames_pattern: Optional[List[int]] = kwargs.get("frames_pattern")
         self.logger: logging.Logger = kwargs.get("logger", module_logger)
 
-        self._peaks = self.find_peak()
+        self._peaks = self.find_peak(kwargs.get("user_defined_peak"))
         self._rocking_curve: Optional[np.ndarray] = None
         self._detector_data_at_peak: Optional[np.ndarray] = self.array[
             self._roi_center[0], :, :
@@ -162,7 +163,9 @@ class PeakFinder:
         )
         self._region_of_interest = value
 
-    def find_peak(self) -> Dict[str, Tuple[int, int, int]]:
+    def find_peak(
+        self, user_defined_peak: Optional[List[int]]
+    ) -> Dict[str, Tuple[int, int, int]]:
         """
         Find the position of the Bragg peak using three different metrics.
 
@@ -170,6 +173,8 @@ class PeakFinder:
          - "max": maximum of the modulus
          - "com": center of mass of the modulus
          - "max_com": "max" along the first axis, "com" along the other axes
+
+        :param user_defined_peak: [z, y, x] Bragg peak position defined by the user
         """
         index_max = np.unravel_index(abs(self.array).argmax(), self.array.shape)
         position_max = [int(val) for val in index_max]
@@ -198,6 +203,7 @@ class PeakFinder:
             "max": self.get_indices_full_detector(list(position_max)),
             "com": self.get_indices_full_detector(list(position_com)),
             "max_com": self.get_indices_full_detector(list(position_max_com)),
+            "user": user_defined_peak,
         }
 
     def get_indices_cropped_binned_detector(self, position: List[int]) -> List[int]:
@@ -207,8 +213,7 @@ class PeakFinder:
 
     def get_indices_full_detector(self, position: List[int]) -> Tuple[int, int, int]:
         """Calculate the position in the unbinned, full detector frame."""
-        unbinned_position = self._unbin(position)
-        return self._offset(unbinned_position, frame="full_detector")
+        return self._offset(self._unbin(position), frame="full_detector")
 
     def fit_rocking_curve(self, tilt_values: Optional[np.ndarray] = None):
         """
@@ -472,8 +477,7 @@ def center_fft(
     # check and load kwargs
     valid.valid_kwargs(
         kwargs=kwargs,
-        allowed_kwargs={"fix_bragg", "logger", "pad_size", "q_values"},
-        name="kwargs",
+        allowed_kwargs={"bragg_peak", "logger", "pad_size", "q_values"},
     )
 
     centering_fft = CenteringFactory(
@@ -481,7 +485,7 @@ def center_fft(
         binning=detector.binning,
         preprocessing_binning=detector.preprocessing_binning,
         roi=detector.roi,
-        fix_bragg=kwargs.get("fix_bragg"),
+        bragg_peak=kwargs.get("bragg_peak"),
         fft_option=fft_option,
         pad_size=kwargs.get("pad_size"),
         centering_method=centering,
@@ -499,7 +503,7 @@ def center_fft(
 def find_bragg(
     array: np.ndarray,
     binning: Optional[List[int]] = None,
-    region_of_interest: Optional[List[int]] = None,
+    roi: Optional[List[int]] = None,
     peak_method: str = "max_com",
     tilt_values: Optional[np.ndarray] = None,
     savedir: Optional[str] = None,
@@ -513,7 +517,7 @@ def find_bragg(
 
     :param array: the detector data
     :param binning: the binning factor of array relative to the unbinned detector
-    :param region_of_interest: the region of interest applied to build array out of the
+    :param roi: the region of interest applied to build array out of the
      full detector
     :param peak_method: peak searching method, among "max", "com", "max_com".
     :param tilt_values: the angular values of the motor during the rocking curve
@@ -521,19 +525,25 @@ def find_bragg(
     :param plot_fit: if True, will plot results and fit the rocking curve
     :param kwargs:
      - "logger": an optional logger
+     - "user_defined_peak": [z, y, x] Bragg peak position defined by the user
      - 'frames_pattern' = list of int, of length the size of the original dataset along
        the rocking curve dimension. 0 if a frame was skipped, 1 otherwise
 
     :return: the metadata with the results of the peak search and the fit.
     """
+    valid.valid_kwargs(
+        kwargs=kwargs,
+        allowed_kwargs={"frames_pattern", "logger", "user_defined_peak"},
+    )
     logger: logging.Logger = kwargs.get("logger", module_logger)
     frames_pattern: Optional[List[int]] = kwargs.get("frames_pattern")
     peakfinder = PeakFinder(
         array=array,
-        region_of_interest=region_of_interest,
+        region_of_interest=roi,
         binning=binning,
         peak_method=peak_method,
         frames_pattern=frames_pattern,
+        user_defined_peak=kwargs.get("user_defined_peak"),
         logger=logger,
     )
 
@@ -598,7 +608,6 @@ def grid_bcdi_labframe(
     valid.valid_kwargs(
         kwargs=kwargs,
         allowed_kwargs={"cmap", "fill_value", "logger", "reference_axis"},
-        name="kwargs",
     )
     cmap = kwargs.get("cmap", "turbo")
     fill_value = kwargs.get("fill_value", (0, 0))
@@ -966,7 +975,6 @@ def load_bcdi_data(
     valid.valid_kwargs(
         kwargs=kwargs,
         allowed_kwargs={"photon_threshold", "frames_pattern", "logger"},
-        name="kwargs",
     )
     photon_threshold = kwargs.get("photon_threshold", 0)
     valid.valid_item(
@@ -1082,7 +1090,6 @@ def reload_bcdi_data(
     valid.valid_kwargs(
         kwargs=kwargs,
         allowed_kwargs={"frames_pattern", "logger", "photon_threshold"},
-        name="kwargs",
     )
     photon_threshold = kwargs.get("photon_threshold", 0)
     valid.valid_item(

--- a/bcdi/utils/parameters.py
+++ b/bcdi/utils/parameters.py
@@ -921,7 +921,7 @@ def valid_param(key: str, value: Any) -> Tuple[Any, bool]:
     elif key == "root_folder":
         valid.valid_container(value, container_types=str, min_length=1, name=key)
         if not os.path.isdir(value):
-            raise ValueError(f"The directory {value} does not exist")
+            raise ValueError(f"The directory '{value}' does not exist")
     elif key == "sample_inplane":
         valid.valid_container(
             value,

--- a/bcdi/utils/validation.py
+++ b/bcdi/utils/validation.py
@@ -185,7 +185,7 @@ def valid_container(
     return True
 
 
-def valid_kwargs(kwargs, allowed_kwargs, name=None):
+def valid_kwargs(kwargs, allowed_kwargs, name="kwargs"):
     """
     Check if the provided parameters belong to the set of allowed kwargs.
 
@@ -197,9 +197,8 @@ def valid_kwargs(kwargs, allowed_kwargs, name=None):
     # check the validity of the parameters
     if not isinstance(kwargs, dict):
         raise TypeError("kwargs should be a dictionnary")
-    if name is not None and not isinstance(name, str):
+    if not isinstance(name, str):
         raise TypeError("name should be a string")
-    name = name or "obj"
 
     # check if requirements are satisfied
     if isinstance(allowed_kwargs, str):

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,6 +1,10 @@
 Future:
 -------
 
+* `bcdi_utils.find_bragg`: a parameter name in the function signature was change from
+  "roi" to "region_of_interest", therefore the region of interest was not taken into
+  account anymore when calculating the peak position.
+
 * Postprocessing: raise NotImplementedError for energy scans not interpolated during
   preprocessing.
 

--- a/tests/preprocessing/test_bcdi_utils.py
+++ b/tests/preprocessing/test_bcdi_utils.py
@@ -239,6 +239,18 @@ class TestFindBragg(unittest.TestCase):
         metadata = find_bragg(array=self.data, plot_fit=False)
         self.assertTrue(metadata["bragg_peak"] == expected)
 
+    def test_with_binning(self):
+        expected = (3, 50, 46)
+        metadata = find_bragg(array=self.data, binning=[3, 2, 2], plot_fit=False)
+        self.assertTrue(metadata["bragg_peak"] == expected)
+
+    def test_with_binning_and_roi(self):
+        expected = (3, 62, 55)
+        metadata = find_bragg(
+            array=self.data, binning=[3, 2, 2], roi=[12, 44, 9, 41], plot_fit=False
+        )
+        self.assertTrue(metadata["bragg_peak"] == expected)
+
 
 if __name__ == "__main__":
     run_tests(TestPeakFinder)

--- a/tests/preprocessing/test_bcdi_utils.py
+++ b/tests/preprocessing/test_bcdi_utils.py
@@ -42,7 +42,7 @@ class TestPeakFinder(unittest.TestCase):
     def test_no_user_defined_peak(self):
         user_defined_peak = None
         peaks = self.peakfinder.find_peak(user_defined_peak=user_defined_peak)
-        self.assertTrue("user" not in peaks.keys())
+        self.assertTrue("user" not in peaks)
 
     def test_user_defined_peak(self):
         user_defined_peak = (1, 22, 21)
@@ -188,7 +188,7 @@ class TestPeakFinder(unittest.TestCase):
             "tilt_value_at_peak",
         }
         self.peakfinder.fit_rocking_curve()
-        self.assertTrue(key in self.peakfinder.metadata.keys() for key in expected_keys)
+        self.assertTrue(key in self.peakfinder.metadata for key in expected_keys)
 
     def test_plot_peaks_image_saved(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -242,7 +242,7 @@ class TestFindBragg(unittest.TestCase):
 
     def test_check_return_keys(self):
         output = find_bragg(array=self.data)
-        self.assertTrue("detector_data_at_peak" in output.keys())
+        self.assertTrue("detector_data_at_peak" in output)
 
     def test_run_only_peak_finding(self):
         expected = (1, 25, 23)

--- a/tests/preprocessing/test_bcdi_utils.py
+++ b/tests/preprocessing/test_bcdi_utils.py
@@ -39,6 +39,16 @@ class TestPeakFinder(unittest.TestCase):
         peaks = self.peakfinder.find_peak()
         self.assertTrue(peaks["com"] == (1, 25, 23))
 
+    def test_no_user_defined_peak(self):
+        user_defined_peak = None
+        peaks = self.peakfinder.find_peak(user_defined_peak=user_defined_peak)
+        self.assertTrue("user" not in peaks.keys())
+
+    def test_user_defined_peak(self):
+        user_defined_peak = (1, 22, 21)
+        peaks = self.peakfinder.find_peak(user_defined_peak=user_defined_peak)
+        self.assertTrue(peaks["user"] == user_defined_peak)
+
     def test_maxcom(self):
         peaks = self.peakfinder.find_peak()
         self.assertTrue(peaks["max_com"] == (1, 25, 23))

--- a/tests/preprocessing/test_center_fft.py
+++ b/tests/preprocessing/test_center_fft.py
@@ -59,7 +59,7 @@ class TestCenteringFactory(unittest.TestCase):
             binning=(1, 1, 1),
             preprocessing_binning=(1, 1, 1),
             roi=(0, self.data_shape[1], 0, self.data_shape[2]),
-            fix_bragg=None,
+            bragg_peak=None,
             fft_option="crop_sym_ZYX",
             pad_size=None,
             centering_method="max",
@@ -99,8 +99,8 @@ class TestCenteringFactory(unittest.TestCase):
             (4, 2, 4),
         )
 
-    def test_find_center_fix_bragg(self):
-        self.factory.fix_bragg = [3, 3, 3]
+    def test_find_center_bragg_peak(self):
+        self.factory.bragg_peak = [3, 3, 3]
         center = self.factory.find_center(
             data=create_data(self.data_shape), method="max_com"
         )
@@ -109,15 +109,15 @@ class TestCenteringFactory(unittest.TestCase):
             (3, 3, 3),
         )
 
-    def test_find_center_fix_bragg_wrong_length(self):
-        self.factory.fix_bragg = [3, 3]
+    def test_find_center_bragg_peak_wrong_length(self):
+        self.factory.bragg_peak = [3, 3]
         with self.assertRaises(ValueError):
             self.factory.find_center(
                 data=create_data(self.data_shape), method="max_com"
             )
 
-    def test_find_center_fix_bragg_binning(self):
-        self.factory.fix_bragg = [6, 6, 6]
+    def test_find_center_bragg_peak_binning(self):
+        self.factory.bragg_peak = [6, 6, 6]
         self.factory.binning = [1, 2, 1]
         center = self.factory.find_center(
             data=create_data(self.data_shape), method="max_com"
@@ -127,8 +127,8 @@ class TestCenteringFactory(unittest.TestCase):
             (6, 3, 6),
         )
 
-    def test_find_center_fix_bragg_preprocessing_binning(self):
-        self.factory.fix_bragg = [6, 6, 6]
+    def test_find_center_bragg_peak_preprocessing_binning(self):
+        self.factory.bragg_peak = [6, 6, 6]
         self.factory.binning = [1, 2, 1]
         self.factory.preprocessing_binning = [1, 1, 3]
         center = self.factory.find_center(
@@ -139,8 +139,8 @@ class TestCenteringFactory(unittest.TestCase):
             (6, 3, 2),
         )
 
-    def test_find_center_fix_bragg_roi(self):
-        self.factory.fix_bragg = [6, 6, 6]
+    def test_find_center_bragg_peak_roi(self):
+        self.factory.bragg_peak = [6, 6, 6]
         self.factory.roi = (1, self.data_shape[1], 3, self.data_shape[2])
         center = self.factory.find_center(
             data=create_data(self.data_shape), method="max_com"
@@ -241,8 +241,8 @@ class TestCenteringFactory(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.factory.get_centering_instance()
 
-    def test_log_q_values_at_center_fix_bragg(self):
-        self.factory.fix_bragg = (3, 3, 3)
+    def test_log_q_values_at_center_bragg_peak(self):
+        self.factory.bragg_peak = (3, 3, 3)
         expected = (
             "Peak intensity position with detector ROI and binning in the "
             f"detector plane: ({self.factory.center_position})"
@@ -301,7 +301,7 @@ class TestCenterFFT(unittest.TestCase):
             binning=(1, 1, 1),
             preprocessing_binning=(1, 1, 1),
             roi=(0, self.data_shape[1], 0, self.data_shape[2]),
-            fix_bragg=None,
+            bragg_peak=None,
             fft_option="crop_sym_ZYX",
             pad_size=None,
             centering_method="max",
@@ -414,7 +414,7 @@ class TestCenterFFT(unittest.TestCase):
             binning=(1, 1, 1),
             preprocessing_binning=(1, 1, 1),
             roi=(0, self.data_shape[1], 0, self.data_shape[2]),
-            fix_bragg=None,
+            bragg_peak=None,
             fft_option="crop_sym_ZYX",
             pad_size=None,
             centering_method="max",
@@ -440,7 +440,7 @@ class TestCenterFFT(unittest.TestCase):
             binning=(1, 1, 1),
             preprocessing_binning=(1, 1, 1),
             roi=(0, self.data_shape[1], 0, self.data_shape[2]),
-            fix_bragg=None,
+            bragg_peak=None,
             fft_option="crop_sym_ZYX",
             pad_size=None,
             centering_method="max",
@@ -466,7 +466,7 @@ class TestCenterFFT(unittest.TestCase):
             binning=(1, 1, 1),
             preprocessing_binning=(1, 1, 1),
             roi=(0, self.data_shape[1], 0, self.data_shape[2]),
-            fix_bragg=None,
+            bragg_peak=None,
             fft_option="crop_sym_ZYX",
             pad_size=None,
             centering_method="max",


### PR DESCRIPTION
## Description

A parameter name in the signature of `bcdi_utils.find_bragg` was change from "roi" to "region_of_interest", therefore the region of interest was not taken into account anymore when calculating the peak position. Kwargs were allowed without check, so this problem was not creating an error.

 - renamed the parameter to the expected "roi"
 - added a validation check of kwargs
 - added some unit tests

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have made corresponding changes to the documentation
- [X] I have added corresponding unit tests
- [X] I have run ``doit`` and all tasks have passed
