### PR TITLE
Allow 'frames pattern' to list only the indices of the frames to exclude

### DIFF
--- a/bcdi/examples/S11_config_preprocessing.yml
+++ b/bcdi/examples/S11_config_preprocessing.yml
@@ -130,9 +130,11 @@ photon_filter: "loading"  # 'loading' or 'postprocessing',
 # it is applied at the end of the script before saving
 bin_during_loading: False  # True to bin during loading, faster
 frames_pattern: None
-# list of int, of length data.shape[0]. If frames_pattern is 0 at index,
-# the frame at data[index] will be skipped, if 1 the frame will be added to the stack.
-# Use this if you need to remove some frames and you know it in advance.
+# Use this if you need to remove some frames, and you know it in advance. You can
+# provide a binary list of length the number of images in the dataset. If frames_pattern
+# is 0 at index, the frame at data[index] will be skipped, if 1 the frame will be added
+# to the stack. Or you can directly specify the indices of the frames to be skipped,
+# e.g. [0, 127] to skip frames at indices 0 and 127.
 background_file: None  # non-empty file path or None
 hotpixels_file: None  # non-empty file path or None
 flatfield_file: None  # non-empty file path or None

--- a/bcdi/experiment/beamline_factory.py
+++ b/bcdi/experiment/beamline_factory.py
@@ -60,6 +60,7 @@ import xrayutilities as xu
 from bcdi.experiment.diffractometer import DiffractometerFactory
 from bcdi.experiment.loader import create_loader
 from bcdi.graph import graph_utils as gu
+import bcdi.utils.format as fmt
 from bcdi.utils import utilities as util
 from bcdi.utils import validation as valid
 
@@ -380,7 +381,7 @@ class Beamline(ABC):
 
     def __repr__(self):
         """Representation string of the Beamline instance."""
-        return util.create_repr(self, Beamline)
+        return fmt.create_repr(self, Beamline)
 
     @property
     def sample_angles(self):

--- a/bcdi/experiment/beamline_factory.py
+++ b/bcdi/experiment/beamline_factory.py
@@ -57,10 +57,10 @@ from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 import numpy as np
 import xrayutilities as xu
 
+import bcdi.utils.format as fmt
 from bcdi.experiment.diffractometer import DiffractometerFactory
 from bcdi.experiment.loader import create_loader
 from bcdi.graph import graph_utils as gu
-import bcdi.utils.format as fmt
 from bcdi.utils import utilities as util
 from bcdi.utils import validation as valid
 
@@ -599,7 +599,7 @@ class BeamlineGoniometer(Beamline):
 
     def __repr__(self):
         """Representation string of the Beamline instance."""
-        return util.create_repr(self, BeamlineGoniometer)
+        return fmt.create_repr(self, BeamlineGoniometer)
 
     @abstractmethod
     def transformation_matrix(

--- a/bcdi/experiment/detector.py
+++ b/bcdi/experiment/detector.py
@@ -67,7 +67,7 @@ from numbers import Integral, Real
 
 import numpy as np
 
-from bcdi.utils import utilities as util
+import bcdi.utils.format as fmt
 from bcdi.utils import validation as valid
 
 module_logger = logging.getLogger(__name__)
@@ -528,7 +528,7 @@ class Detector(ABC):
 
     def __repr__(self):
         """Representation string of the Detector instance."""
-        return util.create_repr(self, Detector)
+        return fmt.create_repr(self, Detector)
 
     @staticmethod
     def _background_subtraction(data, background):

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -59,7 +59,7 @@ import numpy as np
 
 from bcdi.constants import BEAMLINES_BCDI, BEAMLINES_SAXS
 from bcdi.experiment.rotation_matrix import RotationMatrix
-from bcdi.utils import utilities as util
+import bcdi.utils.format as fmt
 from bcdi.utils import validation as valid
 
 module_logger = logging.getLogger(__name__)
@@ -400,7 +400,7 @@ class Diffractometer(ABC):
 
     def __repr__(self) -> str:
         """Representation string of the Diffractometer instance."""
-        return util.create_repr(self, Diffractometer)
+        return fmt.create_repr(self, Diffractometer)
 
     def rotation_matrix(self, stage_name: str, angles: List[Real]) -> np.ndarray:
         """

--- a/bcdi/experiment/diffractometer.py
+++ b/bcdi/experiment/diffractometer.py
@@ -57,9 +57,9 @@ from typing import List, Optional, Tuple, Union
 
 import numpy as np
 
+import bcdi.utils.format as fmt
 from bcdi.constants import BEAMLINES_BCDI, BEAMLINES_SAXS
 from bcdi.experiment.rotation_matrix import RotationMatrix
-import bcdi.utils.format as fmt
 from bcdi.utils import validation as valid
 
 module_logger = logging.getLogger(__name__)

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -501,9 +501,9 @@ def select_frames(data: np.ndarray, frames_logical: np.ndarray) -> np.ndarray:
         frames_logical,
         length=data.shape[0],
         allow_none=False,
-        allowed_types=int,
+        allowed_types=Integral,
         allowed_values=(0, 1),
-        name="frames_pattern",
+        name="frames_logical",
     )
     return np.asarray(data[frames_logical != 0])
 

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -65,6 +65,7 @@ import numpy as np
 from silx.io.specfile import SpecFile
 
 from bcdi.graph import graph_utils as gu
+import bcdi.utils.format as fmt
 from bcdi.utils import utilities as util
 from bcdi.utils import validation as valid
 from bcdi.utils.io_helper import ContextFile, safeload
@@ -946,7 +947,7 @@ class Loader(ABC):
 
     def __repr__(self):
         """Representation string of the Loader instance."""
-        return util.create_repr(self, Loader)
+        return fmt.create_repr(self, Loader)
 
 
 class LoaderID01(Loader):

--- a/bcdi/experiment/loader.py
+++ b/bcdi/experiment/loader.py
@@ -162,18 +162,13 @@ def check_empty_frames(data, mask=None, monitor=None, frames_logical=None, **kwa
     if is_intensity.sum() != data.shape[0]:
         logger.info("Empty frame detected, cropping the data")
 
-    # update frames_logical
-    if len(frames_logical) != len(is_intensity):
-        raise ValueError(
-            f"len(frames_logical)={len(frames_logical)} "
-            f"but len(is_intensity)={len(is_intensity)}"
-        )
-    frames_logical = np.multiply(frames_logical, is_intensity)
-
-    # remove empty frames from the data and update the mask and the monitor
-    data = data[np.nonzero(frames_logical)]
-    mask = mask[np.nonzero(frames_logical)]
-    monitor = monitor[np.nonzero(frames_logical)]
+    # remove empty frames from the data, update the mask, monitor and frames_logical
+    data = data[np.nonzero(is_intensity)]
+    mask = mask[np.nonzero(is_intensity)]
+    monitor = monitor[np.nonzero(is_intensity)]
+    frames_logical = util.update_frames_logical(
+        frames_logical=frames_logical, logical_subset=is_intensity
+    )
     return data, mask, monitor, frames_logical
 
 
@@ -290,11 +285,19 @@ def check_pixels(data, mask, debugging=False, **kwargs):
     return data, mask
 
 
-def load_filtered_data(detector):
+def load_filtered_data(
+    detector, frames_pattern: Optional[List[int]]
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """
     Load a filtered dataset and the corresponding mask.
 
+    In that case
+
     :param detector: an instance of the class Detector
+    :param frames_pattern: user-provided list which can be:
+     - a binary list of length nb_images
+     - a list of the indices of frames to be skipped
+
     :return: the data and the mask array
     """
     root = tk.Tk()
@@ -316,9 +319,25 @@ def load_filtered_data(detector):
     with np.load(file_path) as npzfile:
         mask = npzfile[list(npzfile.files)[0]]
 
-    monitor = np.ones(data.shape[0])
-    frames_logical = np.ones(data.shape[0])
+    valid.valid_container(
+        frames_pattern,
+        container_types=list,
+        item_types=int,
+        min_included=0,
+        max_included=1,
+        allow_none=True,
+        name="frames_pattern",
+    )
+    nb_images = data.shape[0]
 
+    if frames_pattern is not None and len(frames_pattern) != nb_images:
+        # it means that frames_pattern is a list of indices of skipped frames
+        nb_images += len(frames_pattern)
+
+    frames_logical = util.generate_frames_logical(
+        nb_images=nb_images, frames_pattern=frames_pattern
+    )
+    monitor = np.ones(len(frames_logical))
     return data, mask, monitor, frames_logical
 
 
@@ -729,9 +748,10 @@ class Loader(ABC):
 
         :param scan_number: the scan number to load
         :param setup: an instance of the class Setup
-        :param frames_pattern: 1D array of int, of length data.shape[0]. If
-         frames_pattern is 0 at index, the frame at data[index] will be skipped,
-         if 1 the frame will added to the stack.
+        :param frames_pattern: user-provided list which can be:
+         - a binary list of length nb_images
+         - a list of the indices of frames to be skipped
+
         :param flatfield: the 2D flatfield array
         :param hotpixels: the 2D hotpixels array. 1 for a hotpixel, 0 for normal pixels.
         :param background: the 2D background array to subtract to the data
@@ -769,9 +789,8 @@ class Loader(ABC):
 
         if setup.filtered_data:
             data, mask3d, monitor, frames_logical = load_filtered_data(
-                detector=setup.detector
+                detector=setup.detector, frames_pattern=frames_pattern
             )
-            frames_logical = np.ones(data.shape[0], dtype=int)
         else:
             data, mask2d, monitor, loading_roi = self.load_data(
                 setup=setup,

--- a/bcdi/experiment/rotation_matrix.py
+++ b/bcdi/experiment/rotation_matrix.py
@@ -13,7 +13,7 @@ from numbers import Real
 
 import numpy as np
 
-from bcdi.utils import utilities as util
+import bcdi.utils.format as fmt
 from bcdi.utils import validation as valid
 
 module_logger = logging.getLogger(__name__)
@@ -121,4 +121,4 @@ class RotationMatrix:
 
     def __repr__(self):
         """Representation string of the RotationMatrix instance."""
-        return util.create_repr(self, RotationMatrix)
+        return fmt.create_repr(self, RotationMatrix)

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -23,11 +23,11 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import numpy as np
 from scipy.interpolate import RegularGridInterpolator, griddata
 
+import bcdi.utils.format as fmt
 from bcdi.experiment.beamline import create_beamline
 from bcdi.experiment.beamline_factory import BeamlineGoniometer, BeamlineSaxs
 from bcdi.experiment.detector import Detector, create_detector
 from bcdi.graph import graph_utils as gu
-import bcdi.utils.format as fmt
 from bcdi.utils import utilities as util
 from bcdi.utils import validation as valid
 from bcdi.utils.io_helper import ContextFile

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -794,9 +794,11 @@ class Setup:
             )
             print("outofplane_angle")
         if isinstance(self.tilt_angles, np.ndarray):
-            self.tilt_angles = util.apply_logical_array(
-                arrays=self.tilt_angles,
-                frames_logical=self.frames_logical,
+            self.tilt_angles = np.asarray(
+                util.apply_logical_array(
+                    arrays=self.tilt_angles,
+                    frames_logical=self.frames_logical,
+                )
             )
 
     def check_setup(

--- a/bcdi/experiment/setup.py
+++ b/bcdi/experiment/setup.py
@@ -27,6 +27,7 @@ from bcdi.experiment.beamline import create_beamline
 from bcdi.experiment.beamline_factory import BeamlineGoniometer, BeamlineSaxs
 from bcdi.experiment.detector import Detector, create_detector
 from bcdi.graph import graph_utils as gu
+import bcdi.utils.format as fmt
 from bcdi.utils import utilities as util
 from bcdi.utils import validation as valid
 from bcdi.utils.io_helper import ContextFile
@@ -697,7 +698,7 @@ class Setup:
 
     def __repr__(self):
         """Representation string of the Setup instance."""
-        return util.create_repr(self, Setup)
+        return fmt.create_repr(self, Setup)
 
     def calc_qvalues_xrutils(self, hxrd, nb_frames, **kwargs):
         """

--- a/bcdi/graph/colormap.py
+++ b/bcdi/graph/colormap.py
@@ -15,8 +15,8 @@ from typing import Optional
 import colorcet as cc
 from matplotlib.colors import Colormap, LinearSegmentedColormap, ListedColormap
 
-from bcdi.graph.turbo_colormap import turbo_colormap_data
 import bcdi.utils.format as fmt
+from bcdi.graph.turbo_colormap import turbo_colormap_data
 from bcdi.utils.validation import is_float
 
 data_table = (

--- a/bcdi/graph/colormap.py
+++ b/bcdi/graph/colormap.py
@@ -16,7 +16,7 @@ import colorcet as cc
 from matplotlib.colors import Colormap, LinearSegmentedColormap, ListedColormap
 
 from bcdi.graph.turbo_colormap import turbo_colormap_data
-from bcdi.utils import utilities as util
+import bcdi.utils.format as fmt
 from bcdi.utils.validation import is_float
 
 data_table = (
@@ -81,4 +81,4 @@ class ColormapFactory:
 
     def __repr__(self):
         """Representation string of the ColormapFactory instance."""
-        return util.create_repr(self, ColormapFactory)
+        return fmt.create_repr(self, ColormapFactory)

--- a/bcdi/postprocessing/facet_analysis.py
+++ b/bcdi/postprocessing/facet_analysis.py
@@ -22,7 +22,7 @@ import vtk
 from ipywidgets import Layout, interactive
 from pandas import DataFrame
 
-import bcdi.utils.format as fmt
+import bcdi.utils.format as ft
 from bcdi.utils import validation as valid
 
 
@@ -1473,7 +1473,7 @@ class Facets:
 
     def __repr__(self):
         """Unambiguous representation of the class."""
-        return fmt.create_repr(obj=self, cls=Facets)
+        return ft.create_repr(obj=self, cls=Facets)
 
     def __str__(self):
         """Readable representation of the class."""

--- a/bcdi/postprocessing/facet_analysis.py
+++ b/bcdi/postprocessing/facet_analysis.py
@@ -22,7 +22,7 @@ import vtk
 from ipywidgets import Layout, interactive
 from pandas import DataFrame
 
-from bcdi.utils import utilities as util
+import bcdi.utils.format as fmt
 from bcdi.utils import validation as valid
 
 
@@ -1473,7 +1473,7 @@ class Facets:
 
     def __repr__(self):
         """Unambiguous representation of the class."""
-        return util.create_repr(obj=self, cls=Facets)
+        return fmt.create_repr(obj=self, cls=Facets)
 
     def __str__(self):
         """Readable representation of the class."""

--- a/bcdi/preprocessing/analysis.py
+++ b/bcdi/preprocessing/analysis.py
@@ -489,7 +489,6 @@ class Analysis(ABC):
                 tilt_values=None,
                 logger=self.logger,
                 plot_fit=False,
-                frames_pattern=self.parameters["frames_pattern"],
             )
             self.q_bragg = np.array(
                 [
@@ -664,7 +663,6 @@ class Analysis(ABC):
             peak_method=self.parameters["centering_method"]["reciprocal_space"],
             tilt_values=self.setup.tilt_angles,
             savedir=self.setup.detector.savedir,
-            frames_pattern=self.parameters.get("frames_pattern"),
             user_defined_peak=self.parameters["bragg_peak"],
             logger=self.logger,
             plot_fit=True,

--- a/bcdi/preprocessing/analysis.py
+++ b/bcdi/preprocessing/analysis.py
@@ -1175,7 +1175,7 @@ class FirstDataLoading(PreprocessingLoader):
         return bu.load_bcdi_data(
             scan_number=self.scan_nb,
             setup=self.setup,
-            frames_pattern=self.parameters["frames_pattern"],
+            frames_pattern=self.parameters.get("frames_pattern"),
             bin_during_loading=self.parameters["bin_during_loading"],
             flatfield=util.load_flatfield(self.parameters["flatfield_file"]),
             hotpixels=util.load_hotpixels(self.parameters["hotpixels_file"]),

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -982,7 +982,7 @@ def load_bcdi_data(
         name="photon_threshold",
     )
 
-    rawdata, rawmask, monitor, setup.frames_logical = setup.loader.load_check_dataset(
+    rawdata, rawmask, monitor, frames_logical = setup.loader.load_check_dataset(
         scan_number=scan_number,
         setup=setup,
         frames_pattern=kwargs.get("frames_pattern"),
@@ -993,7 +993,7 @@ def load_bcdi_data(
         normalize=normalize,
         debugging=debugging,
     )
-
+    setup.frames_logical = frames_logical
     #####################################################
     # apply an optional photon threshold before binning #
     #####################################################
@@ -1043,7 +1043,7 @@ def load_bcdi_data(
         pad_value=(0, 1),
     )
 
-    return rawdata, rawmask, setup.frames_logical, monitor
+    return np.asarray(rawdata), np.asarray(rawmask), frames_logical, np.asarray(monitor)
 
 
 def reload_bcdi_data(

--- a/bcdi/preprocessing/bcdi_utils.py
+++ b/bcdi/preprocessing/bcdi_utils.py
@@ -75,7 +75,9 @@ class PeakFinder:
         )
         self.binning = [1, 1, 1] if binning is None else binning
         self.peak_method = peak_method
-        self.frames_pattern: Optional[List[int]] = kwargs.get("frames_pattern")
+        self.frames_pattern = util.generate_frames_logical(
+            nb_images=self.array.shape[0], frames_pattern=kwargs.get("frames_pattern")
+        )
         self.logger: logging.Logger = kwargs.get("logger", module_logger)
 
         self._peaks = self.find_peak(kwargs.get("user_defined_peak"))
@@ -356,8 +358,7 @@ class PeakFinder:
         x_axis = (
             tilt_values if tilt_values is not None else np.arange(len(rocking_curve))
         )
-        if self.frames_pattern is not None:
-            x_axis = x_axis[self.frames_pattern == 1]
+        x_axis = x_axis[self.frames_pattern == 1]
         if len(x_axis) != len(rocking_curve):
             self.logger.warning(
                 "tilt_values and rocking curve don't have the same length (hint: did "
@@ -531,8 +532,12 @@ def find_bragg(
     :param kwargs:
      - "logger": an optional logger
      - "user_defined_peak": [z, y, x] Bragg peak position defined by the user
-     - 'frames_pattern' = list of int, of length the size of the original dataset along
-       the rocking curve dimension. 0 if a frame was skipped, 1 otherwise
+     - 'frames_pattern': None or list of int.
+       Use this if you need to remove some frames, and you know it in advance. You can
+       provide a binary list of length the number of images in the dataset. If
+       frames_pattern is 0 at index, the frame at data[index] will be skipped, if 1 the
+       frame will be added to the stack. Or you can directly specify the indices of the
+       frames to be skipped, e.g. [0, 127] to skip frames at indices 0 and 127.
 
     :return: the metadata with the results of the peak search and the fit.
     """
@@ -541,13 +546,12 @@ def find_bragg(
         allowed_kwargs={"frames_pattern", "logger", "user_defined_peak"},
     )
     logger: logging.Logger = kwargs.get("logger", module_logger)
-    frames_pattern: Optional[List[int]] = kwargs.get("frames_pattern")
     peakfinder = PeakFinder(
         array=array,
         region_of_interest=roi,
         binning=binning,
         peak_method=peak_method,
-        frames_pattern=frames_pattern,
+        frames_pattern=kwargs.get("frames_pattern"),
         user_defined_peak=kwargs.get("user_defined_peak"),
         logger=logger,
     )
@@ -961,9 +965,12 @@ def load_bcdi_data(
     :param kwargs:
 
      - 'photon_threshold': float, photon threshold to apply before binning
-     - 'frames_pattern': 1D array of int, of length data.shape[0]. If
-       frames_pattern is 0 at index, the frame at data[index] will be skipped,
-       if 1 the frame will added to the stack.
+     - 'frames_pattern': None or list of int.
+       Use this if you need to remove some frames, and you know it in advance. You can
+       provide a binary list of length the number of images in the dataset. If
+       frames_pattern is 0 at index, the frame at data[index] will be skipped, if 1 the
+       frame will be added to the stack. Or you can directly specify the indices of the
+       frames to be skipped, e.g. [0, 127] to skip frames at indices 0 and 127.
      - 'logger': an optional logger
 
     :return:
@@ -988,15 +995,11 @@ def load_bcdi_data(
         min_included=0,
         name="photon_threshold",
     )
-    frames_pattern = kwargs.get("frames_pattern")
-    valid.valid_1d_array(
-        frames_pattern, allow_none=True, allowed_values={0, 1}, name="frames_pattern"
-    )
 
     rawdata, rawmask, monitor, frames_logical = setup.loader.load_check_dataset(
         scan_number=scan_number,
         setup=setup,
-        frames_pattern=frames_pattern,
+        frames_pattern=kwargs.get("frames_pattern"),
         bin_during_loading=bin_during_loading,
         flatfield=flatfield,
         hotpixels=hotpixels,
@@ -1078,8 +1081,12 @@ def reload_bcdi_data(
     :param debugging:  set to True to see plots
     :parama kwargs:
 
-     - 'frames_pattern' = list of int, of length the size of the original dataset along
-       the rocking curve dimension. 0 if a frame was skipped, 1 otherwise
+     - 'frames_pattern': None or list of int.
+       Use this if you need to remove some frames, and you know it in advance. You can
+       provide a binary list of length the number of images in the dataset. If
+       frames_pattern is 0 at index, the frame at data[index] will be skipped, if 1 the
+       frame will be added to the stack. Or you can directly specify the indices of the
+       frames to be skipped, e.g. [0, 127] to skip frames at indices 0 and 127.
      - 'photon_threshold' = float, photon threshold to apply before binning
      - 'logger': an optional logger
 
@@ -1089,7 +1096,6 @@ def reload_bcdi_data(
 
     """
     logger = kwargs.get("logger", module_logger)
-    frames_pattern = kwargs.get("frames_pattern")
     valid.valid_ndarray(arrays=(data, mask), ndim=3)
     # check and load kwargs
     valid.valid_kwargs(
@@ -1105,8 +1111,8 @@ def reload_bcdi_data(
     )
 
     nbz, nby, nbx = data.shape
-    frames_logical = (
-        frames_pattern if frames_pattern is not None else np.ones(nbz, dtype=int)
+    frames_logical = util.generate_frames_logical(
+        nb_images=nbz, frames_pattern=kwargs.get("frames_pattern")
     )
 
     logger.info(f"{(data < 0).sum()} negative data points masked")

--- a/bcdi/utils/format.py
+++ b/bcdi/utils/format.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+
+# BCDI: tools for pre(post)-processing Bragg coherent X-ray diffraction imaging data
+#   (c) 07/2017-06/2019 : CNRS UMR 7344 IM2NP
+#   (c) 07/2019-05/2021 : DESY PHOTON SCIENCE
+#       authors:
+#         Jerome Carnis, carnis_jerome@yahoo.fr
+"""Functions related to formatting for string representation."""
+
+import logging
+from inspect import signature
+from typing import Any, List, Optional, Tuple
+
+import json
+import numpy as np
+
+module_logger = logging.getLogger(__name__)
+
+
+class CustomEncoder(json.JSONEncoder):
+    """Class to handle the serialization of np.ndarrays, sets."""
+
+    def default(self, obj):
+        """Override the JSONEncoder.default method to support more types."""
+        if isinstance(obj, np.ndarray):
+            return ndarray_to_list(obj)
+            # Let the base class default method raise the TypeError
+        if isinstance(obj, set):
+            return list(obj)
+        if isinstance(obj, (np.int32, np.int64)):
+            return int(obj)
+        return json.JSONEncoder.default(self, obj)
+
+
+def create_repr(obj: Any, cls: type) -> str:
+    """
+    Generate the string representation of the object.
+
+    It uses the parameters given to __init__, except self, args and kwargs.
+
+    :param obj: the object for which the string representation should be generated
+    :param cls: the cls from which __init__ parameters should be extracted (e.g., base
+     class in case of inheritance)
+    :return: the string representation
+    """
+    if not isinstance(cls, type):
+        raise TypeError(f"'cls' should be a class, for {type(cls)}")
+    output = obj.__class__.__name__ + "("
+    for _, param in enumerate(
+        signature(cls.__init__).parameters.keys()  # type: ignore
+    ):
+        if param not in ["self", "args", "kwargs"]:
+            out, quote_mark = format_value(getattr(obj, param))
+            output += f"{param}=" + format_repr(out, quote_mark)
+
+    output += ")"
+    return str(output)
+
+
+def format_value(value: Any) -> Tuple[Any, bool]:
+    """Format the value for a proper representation."""
+    quote_mark = True
+    if isinstance(value, np.ndarray):
+        out = ndarray_to_list(value)
+        quote_mark = True
+    elif callable(value):
+        out = value.__module__ + "." + value.__name__
+        # it's a string, but we don't want to put it in quote mark in order to
+        # be able to call it directly
+        quote_mark = False
+    elif isinstance(value, dict):
+        out = {}  # type: ignore
+        for key, val in value.items():
+            if not isinstance(key, str):
+                raise NotImplementedError(f"key {key} should be a string")
+            out[key] = format_value(val)[0]  # type: ignore
+        quote_mark = False
+    else:
+        out = value
+    return out, quote_mark
+
+
+def format_repr(value: Optional[Any], quote_mark: bool = True) -> str:
+    """
+    Format strings for the __repr__ method.
+
+    :param value: string or None
+    :param quote_mark: True to put quote marks around strings
+    :return: a string
+    """
+    if isinstance(value, str) and quote_mark:
+        return f'"{value}", '.replace("\\", "/")
+    return f"{value}, ".replace("\\", "/")
+
+
+def ndarray_to_list(array: np.ndarray) -> List:
+    """
+    Convert a numpy ndarray of any dimension to a nested list.
+
+    :param array: the array to be converted
+    """
+    if not isinstance(array, np.ndarray):
+        raise TypeError("a numpy ndarray is expected")
+    if array.ndim == 1:
+        return list(array)
+    output = []
+    for idx in range(array.shape[0]):
+        output.append(ndarray_to_list(array[idx]))
+    return output

--- a/bcdi/utils/format.py
+++ b/bcdi/utils/format.py
@@ -7,11 +7,11 @@
 #         Jerome Carnis, carnis_jerome@yahoo.fr
 """Functions related to formatting for string representation."""
 
+import json
 import logging
 from inspect import signature
 from typing import Any, List, Optional, Tuple
 
-import json
 import numpy as np
 
 module_logger = logging.getLogger(__name__)

--- a/bcdi/utils/io_helper.py
+++ b/bcdi/utils/io_helper.py
@@ -13,8 +13,8 @@ import os
 from functools import wraps
 from typing import Callable, Optional, Union
 
+import bcdi.utils.format as fmt
 import bcdi.utils.validation as valid
-from bcdi.utils import utilities as util
 
 module_logger = logging.getLogger(__name__)
 
@@ -191,7 +191,7 @@ class ContextFile:
 
     def __repr__(self):
         """Representation string of the ContextFile instance."""
-        return util.create_repr(obj=self, cls=ContextFile)
+        return fmt.create_repr(obj=self, cls=ContextFile)
 
 
 def safeload(func: Callable) -> Callable:

--- a/bcdi/utils/parameters.py
+++ b/bcdi/utils/parameters.py
@@ -743,9 +743,13 @@ def valid_param(key: str, value: Any) -> Tuple[Any, bool]:
         )
     elif key == "frames_pattern":
         if value is not None:
-            value = np.asarray(value)
-            valid.valid_1d_array(
-                value, allow_none=False, allowed_values={0, 1}, name=key
+            valid.valid_container(
+                value,
+                container_types=list,
+                item_types=int,
+                allow_none=False,
+                min_included=0,
+                name=key,
             )
     elif key == "half_width_avg_phase":
         valid.valid_item(value, allowed_types=int, min_included=0, name=key)

--- a/bcdi/utils/parser.py
+++ b/bcdi/utils/parser.py
@@ -18,8 +18,8 @@ from typing import Any, Dict, List, Optional, Type
 
 import yaml
 
+import bcdi.utils.format as fmt
 import bcdi.utils.validation as valid
-from bcdi.utils import utilities as util
 from bcdi.utils.parameters import valid_param
 
 logger = logging.getLogger(__name__)
@@ -280,4 +280,4 @@ class ConfigParser:
 
     def __repr__(self):
         """Representation string of the ConfigParser instance."""
-        return util.create_repr(self, ConfigParser)
+        return fmt.create_repr(self, ConfigParser)

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -940,6 +940,52 @@ def gaussian_window(window_shape, sigma=0.3, mu=0.0, voxel_size=None, debugging=
     return window
 
 
+def generate_frames_logical(
+    nb_images: int, frames_pattern: Optional[List[int]]
+) -> np.ndarray:
+    """
+    Generate a logical array allowing ti discrad frames in the dataset.
+
+    :param nb_images: the number of 2D images in te dataset.
+    :param frames_pattern: user-provided list which can be:
+     - a binary list of length nb_images
+     - a list of the indices of frames to be skipped
+
+    :return: a binary numpy array of length nb_images
+    """
+    valid.valid_item(nb_images, allowed_types=int, min_excluded=0, name="nb_images")
+    if frames_pattern is None:
+        return np.ones(nb_images, dtype=int)
+
+    valid.valid_container(
+        frames_pattern,
+        container_types=list,
+        max_length=nb_images,
+        item_types=int,
+        min_included=0,
+        max_excluded=nb_images,
+        allow_none=False,
+        name="frames_pattern",
+    )
+
+    if len(frames_pattern) == nb_images:
+        if all(val in {0, 1} for val in frames_pattern):
+            return np.array(frames_pattern, dtype=int)
+        raise ValueError(f"A binary list of lenght {nb_images} is expected")
+
+    if len(set(frames_pattern)) != len(frames_pattern):
+        if all(val in {0, 1} for val in frames_pattern):
+            raise ValueError(
+                "frame_patterns is a binary list of length "
+                f"{len(frames_pattern)}, but there are {nb_images} images"
+            )
+        raise ValueError("Duplicated indices in frame_patterns")
+
+    frames_logical = np.ones(nb_images, dtype=int)
+    frames_logical[frames_pattern] = 0
+    return frames_logical
+
+
 def higher_primes(number, maxprime=13, required_dividers=(4,)):
     """
     Find the closest larger number that meets some condition.

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -2567,6 +2567,28 @@ def unpack_array(
     return np.asarray(array)
 
 
+def update_frames_logical(
+    frames_logical: np.ndarray, logical_subset: np.ndarray
+) -> np.ndarray:
+    """
+    Update frames_logical with a logical array of smaller length.
+
+    The number of non-zero elements of frames_logical should be equal to the length of
+    the logical subset.
+    """
+    if len(np.where(frames_logical != 0)[0]) != len(logical_subset):
+        raise ValueError(
+            f"len(frames_logical != 0)={len(np.where(frames_logical != 0)[0])} "
+            f"but len(logical_subset)={len(logical_subset)}"
+        )
+    counter = 0
+    for idx, val in enumerate(frames_logical):
+        if val != 0:
+            frames_logical[idx] = logical_subset[counter]
+            counter += 1
+    return frames_logical
+
+
 def upsample(array: Union[np.ndarray, List], factor: int = 2) -> np.ndarray:
     """
     Upsample an array.

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -35,9 +35,9 @@ module_logger = logging.getLogger(__name__)
 
 
 def apply_logical_array(
-    arrays: Union[np.ndarray, Tuple[np.ndarray, ...]],
+    arrays: Union[Real, np.ndarray, Tuple[Union[Real, np.ndarray], ...]],
     frames_logical: Optional[np.ndarray],
-) -> Union[np.ndarray, Tuple[np.ndarray, ...]]:
+) -> Union[Real, np.ndarray, Tuple[Union[Real, np.ndarray], ...]]:
     """
     Apply a logical array to a sequence of arrays.
 
@@ -50,7 +50,7 @@ def apply_logical_array(
      (added) frame
     :return: an array (if a single array was provided) or a tuple of cropped arrays
     """
-    if isinstance(arrays, np.ndarray):
+    if not isinstance(arrays, (tuple, list)):
         arrays = (arrays,)
     if frames_logical is None:
         return arrays

--- a/bcdi/utils/utilities.py
+++ b/bcdi/utils/utilities.py
@@ -9,13 +9,11 @@
 
 import ctypes
 import gc
-import json
 import logging
 import os
 import shutil
 from collections import OrderedDict
 from functools import reduce
-from inspect import signature
 from logging import Logger
 from numbers import Integral, Real
 from pathlib import Path
@@ -34,21 +32,6 @@ from bcdi.graph import graph_utils as gu
 from bcdi.utils import validation as valid
 
 module_logger = logging.getLogger(__name__)
-
-
-class CustomEncoder(json.JSONEncoder):
-    """Class to handle the serialization of np.ndarrays, sets."""
-
-    def default(self, obj):
-        """Override the JSONEncoder.default method to support more types."""
-        if isinstance(obj, np.ndarray):
-            return ndarray_to_list(obj)
-            # Let the base class default method raise the TypeError
-        if isinstance(obj, set):
-            return list(obj)
-        if isinstance(obj, (np.int32, np.int64)):
-            return int(obj)
-        return json.JSONEncoder.default(self, obj)
 
 
 def apply_logical_array(
@@ -814,67 +797,6 @@ def fit3d_poly4(x_axis, a, b, c, d, e, f, g, h, i, j, k, m, n):
     )
 
 
-def create_repr(obj: Any, cls: type) -> str:
-    """
-    Generate the string representation of the object.
-
-    It uses the parameters given to __init__, except self, args and kwargs.
-
-    :param obj: the object for which the string representation should be generated
-    :param cls: the cls from which __init__ parameters should be extracted (e.g., base
-     class in case of inheritance)
-    :return: the string representation
-    """
-    if not isinstance(cls, type):
-        raise TypeError(f"'cls' should be a class, for {type(cls)}")
-    output = obj.__class__.__name__ + "("
-    for _, param in enumerate(
-        signature(cls.__init__).parameters.keys()  # type: ignore
-    ):
-        if param not in ["self", "args", "kwargs"]:
-            out, quote_mark = format_value(getattr(obj, param))
-            output += f"{param}=" + format_repr(out, quote_mark)
-
-    output += ")"
-    return str(output)
-
-
-def format_value(value: Any) -> Tuple[Any, bool]:
-    """Format the value for a proper representation."""
-    quote_mark = True
-    if isinstance(value, np.ndarray):
-        out = ndarray_to_list(value)
-        quote_mark = True
-    elif callable(value):
-        out = value.__module__ + "." + value.__name__
-        # it's a string, but we don't want to put it in quote mark in order to
-        # be able to call it directly
-        quote_mark = False
-    elif isinstance(value, dict):
-        out = {}  # type: ignore
-        for key, val in value.items():
-            if not isinstance(key, str):
-                raise NotImplementedError(f"key {key} should be a string")
-            out[key] = format_value(val)[0]  # type: ignore
-        quote_mark = False
-    else:
-        out = value
-    return out, quote_mark
-
-
-def format_repr(value: Optional[Any], quote_mark: bool = True) -> str:
-    """
-    Format strings for the __repr__ method.
-
-    :param value: string or None
-    :param quote_mark: True to put quote marks around strings
-    :return: a string
-    """
-    if isinstance(value, str) and quote_mark:
-        return f'"{value}", '.replace("\\", "/")
-    return f"{value}, ".replace("\\", "/")
-
-
 def function_lmfit(params, x_axis, distribution, iterator=0):
     """
     Calculate distribution defined by lmfit Parameters.
@@ -1602,22 +1524,6 @@ def move_log(result: Tuple[Path, Path, Optional[Logger]]):
     filename = result[0].name
     shutil.move(result[0], result[1] / filename)
     logger.info(f"{filename.replace('.log', '')} processed")
-
-
-def ndarray_to_list(array: np.ndarray) -> List:
-    """
-    Convert a numpy ndarray of any dimension to a nested list.
-
-    :param array: the array to be converted
-    """
-    if not isinstance(array, np.ndarray):
-        raise TypeError("a numpy ndarray is expected")
-    if array.ndim == 1:
-        return list(array)
-    output = []
-    for idx in range(array.shape[0]):
-        output.append(ndarray_to_list(array[idx]))
-    return output
 
 
 def objective_lmfit(params, x_axis, data, distribution):

--- a/doc/HISTORY.rst
+++ b/doc/HISTORY.rst
@@ -1,3 +1,9 @@
+Future:
+-------
+
+* Allow the config parameter 'frames_pattern' to be a list containing only the indices
+  of the detector frames to skip.
+
 Version 0.3.0:
 --------------
 

--- a/doc/modules/postprocessing/index.rst
+++ b/doc/modules/postprocessing/index.rst
@@ -22,7 +22,8 @@ API Reference
 analysis
 ^^^^^^^^
 
-This module provides the classes used in postprocessing strain analysis.
+This module provides the classes used in postprocessing strain analysis. It is mainly
+an abstration layer making analysis steps more understandable.
 
 API Reference
 -------------

--- a/doc/modules/preprocessing/index.rst
+++ b/doc/modules/preprocessing/index.rst
@@ -17,6 +17,18 @@ API Reference
 .. automodule:: bcdi.preprocessing.preprocessing_runner
    :members:
 
+analysis
+^^^^^^^^
+
+This module provides the classes used in data preprocessing. It is mainly an abstration
+layer making analysis steps more understandable.
+
+API Reference
+-------------
+
+.. automodule:: bcdi.preprocessing.analysis
+   :members:
+
 bcdi_utils
 ^^^^^^^^^^
 

--- a/doc/modules/utils/index.rst
+++ b/doc/modules/utils/index.rst
@@ -18,7 +18,18 @@ API Reference
 .. automodule:: bcdi.utils.utilities
    :members:
 
-image_registration 
+format
+^^^^^^
+
+Functions and class related to string formatting for JSON dump and repr.
+
+API Reference
+-------------
+
+.. automodule:: bcdi.utils.format
+   :members:
+
+image_registration
 ^^^^^^^^^^^^^^^^^^
 
 Functions related to image registration and the alignment of datasets in direct or

--- a/scripts/postprocessing/bcdi_angular_profile.py
+++ b/scripts/postprocessing/bcdi_angular_profile.py
@@ -22,6 +22,7 @@ from scipy.ndimage.measurements import center_of_mass
 
 import bcdi.graph.graph_utils as gu
 import bcdi.postprocessing.facet_recognition as fu
+import bcdi.utils.format as fmt
 import bcdi.utils.utilities as util
 import bcdi.utils.validation as valid
 
@@ -428,10 +429,10 @@ result["origin"] = origin
 result["roi"] = roi
 
 if debug:
-    print("output dictionary:\n", json.dumps(result, cls=util.CustomEncoder, indent=4))
+    print("output dictionary:\n", json.dumps(result, cls=fmt.CustomEncoder, indent=4))
 
 with open(savedir + "ang_width" + comment + ".json", "w", encoding="utf-8") as file:
-    json.dump(result, file, cls=util.CustomEncoder, ensure_ascii=False, indent=4)
+    json.dump(result, file, cls=fmt.CustomEncoder, ensure_ascii=False, indent=4)
 
 plt.ioff()
 plt.show()

--- a/scripts/postprocessing/bcdi_line_profile.py
+++ b/scripts/postprocessing/bcdi_line_profile.py
@@ -19,6 +19,7 @@ import numpy as np
 from scipy.interpolate import interp1d
 
 import bcdi.graph.graph_utils as gu
+import bcdi.utils.format as fmt
 import bcdi.utils.utilities as util
 import bcdi.utils.validation as valid
 
@@ -464,10 +465,10 @@ gu.savefig(
 # save the result #
 ###################
 if debug:
-    print("output dictionary:\n", json.dumps(result, cls=util.CustomEncoder, indent=4))
+    print("output dictionary:\n", json.dumps(result, cls=fmt.CustomEncoder, indent=4))
 
 with open(savedir + "cut" + comment + ".json", "w", encoding="utf-8") as file:
-    json.dump(result, file, cls=util.CustomEncoder, ensure_ascii=False, indent=4)
+    json.dump(result, file, cls=fmt.CustomEncoder, ensure_ascii=False, indent=4)
 
 plt.ioff()
 plt.show()

--- a/scripts/preprocessing/bcdi_preprocess.py
+++ b/scripts/preprocessing/bcdi_preprocess.py
@@ -213,10 +213,12 @@ Usage:
      the end of the script before saving
     :param bin_during_loading: e.g. False
      True to bin during loading, faster
-    :param frames_pattern:  list of int, of length data.shape[0].
-     If frames_pattern is 0 at index, the frame at data[index] will be skipped, if 1
-     the frame will be added to the stack. Use this if you need to remove some frames
-     and you know it in advance.
+    :param frames_pattern: None or list of int.
+     Use this if you need to remove some frames, and you know it in advance. You can
+     provide a binary list of length the number of images in the dataset. If
+     frames_pattern is 0 at index, the frame at data[index] will be skipped, if 1 the
+     frame will be added to the stack. Or you can directly specify the indices of the
+     frames to be skipped, e.g. [0, 127] to skip frames at indices 0 and 127.
     :param background_file: non-empty file path or None
     :param hotpixels_file: non-empty file path or None
     :param flatfield_file: non-empty file path or None

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+
+# BCDI: tools for pre(post)-processing Bragg coherent X-ray diffraction imaging data
+#   (c) 07/2017-06/2019 : CNRS UMR 7344 IM2NP
+#   (c) 07/2019-05/2021 : DESY PHOTON SCIENCE
+#       authors:
+#         Jerome Carnis, carnis_jerome@yahoo.fr
+
+import os
+import unittest
+
+import numpy as np
+from pyfakefs import fake_filesystem_unittest
+
+import bcdi.utils.format as fmt
+from bcdi.experiment.detector import Detector, create_detector
+from bcdi.experiment.setup import Setup
+from bcdi.utils.io_helper import ContextFile
+from tests.config import load_config, run_tests
+
+parameters, skip_tests = load_config("preprocessing")
+
+
+class TestCreateRepr(unittest.TestCase):
+    """
+    Tests on the function format.create_repr.
+
+    def create_repr(obj: type) -> str
+    """
+
+    def test_repr_setup(self):
+        if skip_tests:
+            self.skipTest(
+                reason="This test can only run locally with the example dataset"
+            )
+        setup = Setup(parameters=parameters)
+        valid = (
+            "Setup(parameters={'scans': (11,), "
+            "'root_folder': 'C:/Users/Jerome/Documents/data/CXIDB-I182/CH4760/', "
+            "'save_dir': ['C:/Users/Jerome/Documents/data/CXIDB-I182/CH4760/test/'], "
+            "'data_dir': ('C:/Users/Jerome/Documents/data/CXIDB-I182/CH4760/S11/',), "
+            "'sample_name': ('S',), 'comment': ''"
+            ""
+        )
+        out = fmt.create_repr(obj=setup, cls=Setup)
+        self.assertTrue(out.startswith(valid))
+
+
+class TestCreateReprFake(fake_filesystem_unittest.TestCase):
+    """
+    Tests on the function format.create_repr.
+
+    def create_repr(obj: type) -> str
+    """
+
+    def setUp(self):
+        self.setUpPyfakefs()
+        self.valid_path = "/gpfs/bcdi/data/"
+        self.filename = "dummy.spec"
+        os.makedirs(self.valid_path)
+        with open(self.valid_path + self.filename, "w") as f:
+            f.write("dummy")
+
+    def test_contextfile(self):
+        ctx = ContextFile(filename=self.valid_path + self.filename, open_func=open)
+        valid = (
+            'ContextFile(filename="/gpfs/bcdi/data/dummy.spec", '
+            'open_func=pyfakefs.fake_filesystem.open, scan_number=None, mode="r", '
+            'encoding="utf-8", longname=None, shortname=None, directory=None, )'
+        )
+        out = fmt.create_repr(obj=ctx, cls=ContextFile)
+        print(out)
+        self.assertEqual(out, valid)
+
+    def test_detector(self):
+        det = create_detector(name="Maxipix")
+        valid = (
+            'Maxipix(name="Maxipix", rootdir=None, datadir=None, savedir=None, '
+            "template_imagefile=None, specfile=None, sample_name=None, "
+            "roi=[0, 516, 0, 516], sum_roi=[0, 516, 0, 516], binning=(1, 1, 1), "
+            "preprocessing_binning=(1, 1, 1), offsets=None, linearity_func=None, )"
+        )
+        out = fmt.create_repr(obj=det, cls=Detector)
+        print(out)
+        self.assertEqual(out, valid)
+
+    def test_not_a_class(self):
+        det = create_detector(name="Maxipix")
+        with self.assertRaises(TypeError):
+            fmt.create_repr(obj=det, cls="Detector")
+
+    def test_empty_init(self):
+        valid = "Empty()"
+
+        class Empty:
+            """This is an empty class"""
+
+        out = fmt.create_repr(obj=Empty(), cls=Empty)
+        self.assertEqual(out, valid)
+
+
+class TestFormatRepr(unittest.TestCase):
+    """
+    Tests on the function format.format_repr.
+
+    def format_repr(value: Optional[Any], quote_mark: bool = True) -> str:
+    """
+
+    def test_str(self):
+        out = fmt.format_repr("test")
+        self.assertEqual(out, '"test", ')
+
+    def test_str_quote_mark_false(self):
+        out = fmt.format_repr("test", quote_mark=False)
+        self.assertEqual(out, "test, ")
+
+    def test_float(self):
+        out = fmt.format_repr(0.4)
+        self.assertEqual(out, "0.4, ")
+
+    def test_none(self):
+        out = fmt.format_repr(None)
+        self.assertEqual(out, "None, ")
+
+    def test_tuple(self):
+        out = fmt.format_repr((1.0, 2.0))
+        self.assertEqual(out, "(1.0, 2.0), ")
+
+
+class TestNdarrayToList(unittest.TestCase):
+    """
+    Tests on the function format.ndarray_to_list.
+
+    def ndarray_to_list(array: np.ndarray) -> List
+    """
+
+    def test_not_an_array(self):
+        with self.assertRaises(TypeError):
+            fmt.ndarray_to_list(array=2.3)
+
+    def test_none(self):
+        with self.assertRaises(TypeError):
+            fmt.ndarray_to_list(array=None)
+
+    def test_1d_array_int(self):
+        valid = [1, 2, 3]
+        out = fmt.ndarray_to_list(array=np.array(valid))
+        self.assertTrue(out == valid)
+
+    def test_1d_array_float(self):
+        valid = [1.12333333333333333333333333, 2.77, 3.5]
+        out = fmt.ndarray_to_list(array=np.array(valid))
+        self.assertTrue(out == valid)
+
+    def test_2d_array_int(self):
+        valid = [[1, 2, 3], [1.2, 3.333333333, 0]]
+        out = fmt.ndarray_to_list(array=np.array(valid))
+        self.assertTrue(out == valid)
+
+
+if __name__ == "__main__":
+    run_tests(TestCreateRepr)
+    run_tests(TestFormatRepr)
+    run_tests(TestNdarrayToList)

--- a/tests/utils/test_parameters.py
+++ b/tests/utils/test_parameters.py
@@ -604,14 +604,23 @@ class TestParameters(unittest.TestCase):
         val, flag = valid_param(key="energy", value=[1, 2, 3])
         self.assertTrue(val == [1, 2, 3] and flag is True)
 
-    def test_frames_pattern(self):
-        correct = np.array([0, 1, 1, 0])
-        val, flag = valid_param(key="frames_pattern", value=[0, 1, 1, 0])
-        self.assertTrue(np.array_equal(val, correct) and flag is True)
+    def test_frames_pattern_binary_list(self):
+        expected = [0, 1, 1, 0]
+        output, flag = valid_param(key="frames_pattern", value=expected)
+        self.assertTrue(
+            all(val1 == val2 for val1, val2 in zip(expected, output)) and flag is True
+        )
 
     def test_frames_pattern_none(self):
         val, flag = valid_param(key="frames_pattern", value=None)
         self.assertTrue(val is None and flag is True)
+
+    def test_frames_pattern_list_of_indices(self):
+        expected = [126, 138]
+        output, flag = valid_param(key="frames_pattern", value=[126, 138])
+        self.assertTrue(
+            all(val1 == val2 for val1, val2 in zip(expected, output)) and flag is True
+        )
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -370,6 +370,80 @@ class TestUpsample(unittest.TestCase):
         self.assertTrue(np.allclose(output, expected))
 
 
+class TestGenerateFramesLogical(unittest.TestCase):
+    """
+    Tests on the function utilities.generate_frames_logical.
+
+    def generate_frames_logical(
+        nb_images: int, frames_pattern: Optional[List[int]]
+    ) -> np.ndarray:
+    """
+
+    def test_nb_image_none(self) -> None:
+        with self.assertRaises(ValueError):
+            util.generate_frames_logical(nb_images=None, frames_pattern=[128])
+
+    def test_nb_image_null(self) -> None:
+        with self.assertRaises(ValueError):
+            util.generate_frames_logical(nb_images=0, frames_pattern=[128])
+
+    def test_frames_pattern_none(self) -> None:
+        nb_images = 12
+        expected = np.ones(nb_images, dtype=int)
+        out = util.generate_frames_logical(nb_images=nb_images, frames_pattern=None)
+        self.assertTrue(np.array_equal(expected, out))
+
+    def test_frames_pattern_binary(self) -> None:
+        nb_images = 6
+        frames_pattern = [1, 0, 0, 1, 1, 1]
+        expected = np.array([1, 0, 0, 1, 1, 1], dtype=int)
+        out = util.generate_frames_logical(
+            nb_images=nb_images, frames_pattern=frames_pattern
+        )
+        self.assertTrue(np.array_equal(expected, out))
+
+    def test_frames_pattern_binary_wrong_length(self) -> None:
+        nb_images = 6
+        frames_pattern = [1, 0, 1, 1, 1]
+        with self.assertRaises(ValueError):
+            util.generate_frames_logical(
+                nb_images=nb_images, frames_pattern=frames_pattern
+            )
+
+    def test_frames_pattern_list_of_indices_too_long(self) -> None:
+        nb_images = 6
+        frames_pattern = [0, 1, 2, 3, 4, 5, 6]
+        with self.assertRaises(ValueError):
+            util.generate_frames_logical(
+                nb_images=nb_images, frames_pattern=frames_pattern
+            )
+
+    def test_frames_pattern_list_of_indices(self) -> None:
+        nb_images = 6
+        frames_pattern = [0, 3]
+        expected = np.array([0, 1, 1, 0, 1, 1], dtype=int)
+        out = util.generate_frames_logical(
+            nb_images=nb_images, frames_pattern=frames_pattern
+        )
+        self.assertTrue(np.array_equal(expected, out))
+
+    def test_frames_pattern_index_too_large(self) -> None:
+        nb_images = 6
+        frames_pattern = [0, 6]
+        with self.assertRaises(ValueError):
+            util.generate_frames_logical(
+                nb_images=nb_images, frames_pattern=frames_pattern
+            )
+
+    def test_frames_pattern_duplicated_indices(self) -> None:
+        nb_images = 6
+        frames_pattern = [0, 2, 2]
+        with self.assertRaises(ValueError):
+            util.generate_frames_logical(
+                nb_images=nb_images, frames_pattern=frames_pattern
+            )
+
+
 if __name__ == "__main__":
     run_tests(TestInRange)
     run_tests(TestFindFile)

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -503,7 +503,7 @@ class TestApplyLogicalArray(unittest.TestCase):
         )
         self.assertIsInstance(out, tuple)
         for idx, val in enumerate(out):
-            self.assertTrue(np.array_equal(expected[idx], out[idx]))
+            self.assertTrue(np.array_equal(expected[idx], val))
 
     def test_input_is_a_number(self):
         expected = 3

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -444,9 +444,92 @@ class TestGenerateFramesLogical(unittest.TestCase):
             )
 
 
+class TestUpdateFramesLogical(unittest.TestCase):
+    """
+    Tests on the function utilities.update_frames_logical.
+
+    def update_frames_logical(
+        frames_logical: np.ndarray, logical_subset: np.ndarray
+    ) -> np.ndarray:
+    """
+
+    def test_inconsitency_with_length_of_logical_subset(self):
+        frames_logical = np.array([0, 1, 1, 1])
+        logical_subset = np.array([1, 1])
+        with self.assertRaises(ValueError):
+            util.update_frames_logical(
+                frames_logical=frames_logical, logical_subset=logical_subset
+            )
+
+    def test_remove_1_frame(self):
+        frames_logical = np.array([0, 1, 1, 1])
+        logical_subset = np.array([1, 1, 0])
+        expected = np.array([0, 1, 1, 0])
+        out = util.update_frames_logical(
+            frames_logical=frames_logical, logical_subset=logical_subset
+        )
+        self.assertTrue(np.array_equal(expected, out))
+
+
+class TestApplyLogicalArray(unittest.TestCase):
+    """
+    Tests on the function utilities.apply_logical_array.
+
+    def apply_logical_array(
+        arrays: Union[np.ndarray, Tuple[np.ndarray, ...]],
+        frames_logical: Optional[np.ndarray],
+    ) -> Union[np.ndarray, Tuple[np.ndarray, ...]]:
+    """
+
+    def setUp(self) -> None:
+        self.frames_logical = np.array([1, 0, 1, 1, 1, 1, 0])
+
+    def test_single_array(self):
+        expected = np.array([0, 2, 3, 4, 5])
+        out = util.apply_logical_array(
+            arrays=np.arange(len(self.frames_logical)),
+            frames_logical=self.frames_logical,
+        )
+        self.assertTrue(np.array_equal(expected, out))
+
+    def test_tuple_of_arrays(self):
+        expected = np.array([0, 2, 3, 4, 5]), np.array([0, -2, -3, -4, -5])
+        out = util.apply_logical_array(
+            arrays=(
+                np.arange(len(self.frames_logical)),
+                -np.arange(len(self.frames_logical)),
+            ),
+            frames_logical=self.frames_logical,
+        )
+        self.assertIsInstance(out, tuple)
+        for idx, val in enumerate(out):
+            self.assertTrue(np.array_equal(expected[idx], out[idx]))
+
+    def test_input_is_a_number(self):
+        expected = 3
+        out = util.apply_logical_array(
+            arrays=expected,
+            frames_logical=self.frames_logical,
+        )
+        self.assertEqual(out, expected)
+
+    def test_mixed_tuple(self):
+        expected = (3, np.array([0, 2, 3, 4, 5]))
+        out = util.apply_logical_array(
+            arrays=(3, np.arange(len(self.frames_logical))),
+            frames_logical=self.frames_logical,
+        )
+        self.assertIsInstance(out, tuple)
+        self.assertEqual(out[0], expected[0])
+        self.assertTrue(np.array_equal(expected[1], out[1]))
+
+
 if __name__ == "__main__":
     run_tests(TestInRange)
     run_tests(TestFindFile)
     run_tests(TestGaussianWindow)
     run_tests(TestUnpackArray)
     run_tests(TestUpsample)
+    run_tests(TestGenerateFramesLogical)
+    run_tests(TestUpdateFramesLogical)
+    run_tests(TestApplyLogicalArray)

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -13,9 +13,6 @@ import numpy as np
 from pyfakefs import fake_filesystem_unittest
 
 import bcdi.utils.utilities as util
-from bcdi.experiment.detector import Detector, create_detector
-from bcdi.experiment.setup import Setup
-from bcdi.utils.io_helper import ContextFile
 from tests.config import load_config, run_tests
 
 parameters, skip_tests = load_config("preprocessing")
@@ -199,112 +196,6 @@ class TestFindFile(fake_filesystem_unittest.TestCase):
             util.find_file(filename="dum.spec", default_folder=self.valid_path)
 
 
-class TestCreateRepr(unittest.TestCase):
-    """
-    Tests on the function utilities.create_repr.
-
-    def create_repr(obj: type) -> str
-    """
-
-    def test_repr_setup(self):
-        if skip_tests:
-            self.skipTest(
-                reason="This test can only run locally with the example dataset"
-            )
-        setup = Setup(parameters=parameters)
-        valid = (
-            "Setup(parameters={'scans': (11,), "
-            "'root_folder': 'C:/Users/Jerome/Documents/data/CXIDB-I182/CH4760/', "
-            "'save_dir': ['C:/Users/Jerome/Documents/data/CXIDB-I182/CH4760/test/'], "
-            "'data_dir': ('C:/Users/Jerome/Documents/data/CXIDB-I182/CH4760/S11/',), "
-            "'sample_name': ('S',), 'comment': ''"
-            ""
-        )
-        out = util.create_repr(obj=setup, cls=Setup)
-        self.assertTrue(out.startswith(valid))
-
-
-class TestCreateReprFake(fake_filesystem_unittest.TestCase):
-    """
-    Tests on the function utilities.create_repr.
-
-    def create_repr(obj: type) -> str
-    """
-
-    def setUp(self):
-        self.setUpPyfakefs()
-        self.valid_path = "/gpfs/bcdi/data/"
-        self.filename = "dummy.spec"
-        os.makedirs(self.valid_path)
-        with open(self.valid_path + self.filename, "w") as f:
-            f.write("dummy")
-
-    def test_contextfile(self):
-        ctx = ContextFile(filename=self.valid_path + self.filename, open_func=open)
-        valid = (
-            'ContextFile(filename="/gpfs/bcdi/data/dummy.spec", '
-            'open_func=pyfakefs.fake_filesystem.open, scan_number=None, mode="r", '
-            'encoding="utf-8", longname=None, shortname=None, directory=None, )'
-        )
-        out = util.create_repr(obj=ctx, cls=ContextFile)
-        print(out)
-        self.assertEqual(out, valid)
-
-    def test_detector(self):
-        det = create_detector(name="Maxipix")
-        valid = (
-            'Maxipix(name="Maxipix", rootdir=None, datadir=None, savedir=None, '
-            "template_imagefile=None, specfile=None, sample_name=None, "
-            "roi=[0, 516, 0, 516], sum_roi=[0, 516, 0, 516], binning=(1, 1, 1), "
-            "preprocessing_binning=(1, 1, 1), offsets=None, linearity_func=None, )"
-        )
-        out = util.create_repr(obj=det, cls=Detector)
-        print(out)
-        self.assertEqual(out, valid)
-
-    def test_not_a_class(self):
-        det = create_detector(name="Maxipix")
-        with self.assertRaises(TypeError):
-            util.create_repr(obj=det, cls="Detector")
-
-    def test_empty_init(self):
-        valid = "Empty()"
-
-        class Empty:
-            """This is an empty class"""
-
-        out = util.create_repr(obj=Empty(), cls=Empty)
-        self.assertEqual(out, valid)
-
-
-class TestFormatRepr(unittest.TestCase):
-    """
-    Tests on the function utilities.format_repr.
-
-    def format_repr(value: Optional[Any], quote_mark: bool = True) -> str:
-    """
-
-    def test_str(self):
-        out = util.format_repr("test")
-        self.assertEqual(out, '"test", ')
-
-    def test_str_quote_mark_false(self):
-        out = util.format_repr("test", quote_mark=False)
-        self.assertEqual(out, "test, ")
-
-    def test_float(self):
-        out = util.format_repr(0.4)
-        self.assertEqual(out, "0.4, ")
-
-    def test_none(self):
-        out = util.format_repr(None)
-        self.assertEqual(out, "None, ")
-
-    def test_tuple(self):
-        out = util.format_repr((1.0, 2.0))
-        self.assertEqual(out, "(1.0, 2.0), ")
-
-
 class TestInRange(unittest.TestCase):
     """Tests on the function utilities.in_range."""
 
@@ -421,37 +312,6 @@ class TestUnpackArray(unittest.TestCase):
         self.assertEqual(val, 5)
 
 
-class TestNdarrayToList(unittest.TestCase):
-    """
-    Tests on the function utilities.ndarray_to_list.
-
-    def ndarray_to_list(array: np.ndarray) -> List
-    """
-
-    def test_not_an_array(self):
-        with self.assertRaises(TypeError):
-            util.ndarray_to_list(array=2.3)
-
-    def test_none(self):
-        with self.assertRaises(TypeError):
-            util.ndarray_to_list(array=None)
-
-    def test_1d_array_int(self):
-        valid = [1, 2, 3]
-        out = util.ndarray_to_list(array=np.array(valid))
-        self.assertTrue(out == valid)
-
-    def test_1d_array_float(self):
-        valid = [1.12333333333333333333333333, 2.77, 3.5]
-        out = util.ndarray_to_list(array=np.array(valid))
-        self.assertTrue(out == valid)
-
-    def test_2d_array_int(self):
-        valid = [[1, 2, 3], [1.2, 3.333333333, 0]]
-        out = util.ndarray_to_list(array=np.array(valid))
-        self.assertTrue(out == valid)
-
-
 class TestUpsample(unittest.TestCase):
     """
     Tests on the function utilities.upsample.
@@ -516,6 +376,3 @@ if __name__ == "__main__":
     run_tests(TestGaussianWindow)
     run_tests(TestUnpackArray)
     run_tests(TestUpsample)
-    run_tests(TestCreateRepr)
-    run_tests(TestFormatRepr)
-    run_tests(TestNdarrayToList)


### PR DESCRIPTION
Allow the config parameter 'frames_pattern' to be a list containing only the indices of the detector frames to skip. Previously a list of the length of the data had to be provided (this is still supported though).

Fixes #330 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] I have made corresponding changes to the documentation
- [X] I have added corresponding unit tests
- [X] I have run ``doit`` and all tasks have passed
